### PR TITLE
Add is* accessor support to ClosureExpressionVisitor#getObjectFieldValue...

### DIFF
--- a/lib/Doctrine/Common/Collections/Expr/ClosureExpressionVisitor.php
+++ b/lib/Doctrine/Common/Collections/Expr/ClosureExpressionVisitor.php
@@ -31,10 +31,9 @@ namespace Doctrine\Common\Collections\Expr;
 class ClosureExpressionVisitor extends ExpressionVisitor
 {
     /**
-     * Accesses the field of a given object. This field has to be public directly
-     * or indirectly (through an accessor get* or a magic method, __get, __call).
-     *
-     * is*() is not supported.
+     * Accesses the field of a given object. This field has to be public
+     * directly or indirectly (through an accessor get*, is*, or a magic
+     * method, __get, __call).
      *
      * @param object $object
      * @param string $field
@@ -43,9 +42,22 @@ class ClosureExpressionVisitor extends ExpressionVisitor
      */
     public static function getObjectFieldValue($object, $field)
     {
-        $accessor = "get" . $field;
+        $accessors = array('get', 'is');
 
-        if (method_exists($object, $accessor) || method_exists($object, '__call')) {
+        foreach ($accessors as $accessor) {
+            $accessor .= $field;
+
+            if ( ! method_exists($object, $accessor)) {
+                continue;
+            }
+
+            return $object->$accessor();
+        }
+
+        // __call should be triggered for get.
+        $accessor = $accessors[0] . $field;
+
+        if (method_exists($object, '__call')) {
             return $object->$accessor();
         }
 

--- a/tests/Doctrine/Tests/Common/Collections/ClosureExpressionVisitorTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/ClosureExpressionVisitorTest.php
@@ -36,6 +36,20 @@ class ClosureExpressionVisitorTest extends \PHPUnit_Framework_TestCase
         $this->builder = new ExpressionBuilder();
     }
 
+    public function testGetObjectFieldValueIsAccessor()
+    {
+        $object = new TestObject(1, 2, true);
+
+        $this->assertTrue($this->visitor->getObjectFieldValue($object, 'baz'));
+    }
+
+    public function testGetObjectFieldValueMagicCallMethod()
+    {
+        $object = new TestObject(1, 2, true, 3);
+
+        $this->assertEquals(3, $this->visitor->getObjectFieldValue($object, 'qux'));
+    }
+
     public function testWalkEqualsComparison()
     {
         $closure = $this->visitor->walkComparison($this->builder->eq("foo", 1));
@@ -178,11 +192,22 @@ class TestObject
 {
     private $foo;
     private $bar;
+    private $baz;
+    private $qux;
 
-    public function __construct($foo = null, $bar = null)
+    public function __construct($foo = null, $bar = null, $baz = null, $qux = null)
     {
         $this->foo = $foo;
         $this->bar = $bar;
+        $this->baz = $baz;
+        $this->qux = $qux;
+    }
+
+    public function __call($name, $arguments)
+    {
+        if ('getqux' === $name) {
+            return $this->qux;
+        }
     }
 
     public function getFoo()
@@ -193,6 +218,11 @@ class TestObject
     public function getBar()
     {
         return $this->bar;
+    }
+
+    public function isBaz()
+    {
+        return $this->baz;
     }
 }
 


### PR DESCRIPTION
I note that the documentation for this method reads "is_() is not supported," but I wasn't sure if this was by design or something to be implemented at a later date. For my company, it would be very helpful to have is_ methods checked because all of our boolean members use them.
