### PR TITLE
Array collections can not be optionally made type safe by supplying an e...

### DIFF
--- a/lib/Doctrine/Common/Collections/ArrayCollection.php
+++ b/lib/Doctrine/Common/Collections/ArrayCollection.php
@@ -55,7 +55,7 @@ class ArrayCollection implements Collection, Selectable
     public function __construct(array $elements = array(), $class = null)
     {
         $this->_class = $class;
-        if($class) {
+        if ($class) {
             $this->_elements = array();
             foreach($elements as $key => $value) {
                 $this->set($key, $value);
@@ -264,7 +264,9 @@ class ArrayCollection implements Collection, Selectable
      */
     public function set($key, $value)
     {
-        $this->checkClass($value);
+        if ($this->_class) {
+            $this->checkClass($value);
+        }
         $this->_elements[$key] = $value;
     }
 
@@ -273,7 +275,9 @@ class ArrayCollection implements Collection, Selectable
      */
     public function add($value)
     {
-        $this->checkClass($value);
+        if ($this->_class) {
+            $this->checkClass($value);    
+        }
         $this->_elements[] = $value;
         return true;
     }
@@ -401,8 +405,9 @@ class ArrayCollection implements Collection, Selectable
         return new static($filtered);
     }
 
-    private function checkClass($value) {
-        if($this->_class !== null && !$value instanceof $this->_class) {
+    private function checkClass($value) 
+    {
+        if ($this->_class && !$value instanceof $this->_class) {
             throw new \Exception("The collection can only accept instances of {$this->_class}. " . 
                                     "Given:" . get_class($value));
         }

--- a/tests/Doctrine/Tests/Common/Collections/CollectionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/CollectionTest.php
@@ -262,7 +262,8 @@ class CollectionTest extends \Doctrine\Tests\DoctrineTestCase
         $this->assertTrue($this->_coll->containsKey('key'));
     }
 
-    public function testClassRestricted() {
+    public function testClassRestricted() 
+    {
         $coll = new \Doctrine\Common\Collections\ArrayCollection(array(), 'Doctrine\Common\Collections\Collection');
         $coll->add($this->_coll);
         $coll['key'] = $this->_coll;
@@ -273,7 +274,8 @@ class CollectionTest extends \Doctrine\Tests\DoctrineTestCase
         }
      }
 
-     public function testClassRestrictedConstructor() {
+    public function testClassRestrictedConstructor() 
+    {
         try {
             $data = array($this->_coll, 5);
             $coll = new \Doctrine\Common\Collections\ArrayCollection($data, 'Doctrine\Common\Collections\Collection');
@@ -282,9 +284,10 @@ class CollectionTest extends \Doctrine\Tests\DoctrineTestCase
             return;
         }
         $this->fail('Expected an exception to be thrown');
-     }
+    }
 
-    private function failCaseOfClassRestricted($collection, $value) {
+    private function failCaseOfClassRestricted($collection, $value) 
+    {
         try {
             $collection->add($value);
         } catch (\Exception $e) {


### PR DESCRIPTION
...xpected type to the constructor

Type hints are great in php. They provide a degree of type safety.
I made a small patch to make collections type safe too. 

Usually, in n-to-many relationships, the collection contains only one type of entity.

To maintain type safety, I usually create 'add' methods

``` php
function addAddress(Address $address) {
  $this->getAddresses()->add($address);
}
```

Instead it would be awesome, if the collection did the type checking for me:

``` php
$coll = new ArrayCollection(array(), 'blah\Address');
$coll->add($address); //good
$coll->add($iceCream); //bad, exception raised

```
