### PR TITLE
Support for 'IsNotNull' in ExpressionBuilder

### DIFF
--- a/lib/Doctrine/Common/Collections/Expr/ClosureExpressionVisitor.php
+++ b/lib/Doctrine/Common/Collections/Expr/ClosureExpressionVisitor.php
@@ -113,7 +113,7 @@ class ClosureExpressionVisitor extends ExpressionVisitor
                 };
 
             case Comparison::NEQ:
-            case Comparison::ISNOT:
+            case Comparison::IS_NOT:
                 return function ($object) use ($field, $value) {
                     return ClosureExpressionVisitor::getObjectFieldValue($object, $field) !== $value;
                 };

--- a/lib/Doctrine/Common/Collections/Expr/Comparison.php
+++ b/lib/Doctrine/Common/Collections/Expr/Comparison.php
@@ -34,7 +34,7 @@ class Comparison implements Expression
     const GT        = '>';
     const GTE       = '>=';
     const IS        = 'IS';
-    const ISNOT     = 'ISNOT';
+    const IS_NOT    = 'IS NOT';
     const IN        = 'IN';
     const NIN       = 'NIN';
     const CONTAINS  = 'CONTAINS';

--- a/lib/Doctrine/Common/Collections/ExpressionBuilder.php
+++ b/lib/Doctrine/Common/Collections/ExpressionBuilder.php
@@ -134,7 +134,7 @@ class ExpressionBuilder
      */
     public function isNotNull($field)
     {
-        return new Comparison($field, Comparison::ISNOT, new Value(null));
+        return new Comparison($field, Comparison::IS_NOT, new Value(null));
     }
 
     /**

--- a/tests/Doctrine/Tests/Common/Collections/ExpressionBuilderTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/ExpressionBuilderTest.php
@@ -115,7 +115,7 @@ class ExpressionBuilderTest extends \PHPUnit_Framework_TestCase
     	$expr = $this->builder->isNotNull("a");
     	
     	$this->assertInstanceOf("Doctrine\Common\Collections\Expr\Comparison", $expr);
-    	$this->assertEquals(Comparison::ISNOT, $expr->getOperator());
+    	$this->assertEquals(Comparison::IS_NOT, $expr->getOperator());
     }
 
     public function testContains()


### PR DESCRIPTION
Allows to filter Collections with a 'IsNotNull'-Criteria
