### PR TITLE
change _elements property to protected

### DIFF
--- a/lib/Doctrine/Common/Collections/ArrayCollection.php
+++ b/lib/Doctrine/Common/Collections/ArrayCollection.php
@@ -37,7 +37,7 @@ class ArrayCollection implements Collection, Selectable
      *
      * @var array
      */
-    private $_elements;
+    protected $_elements;
 
     /**
      * Initializes a new ArrayCollection.


### PR DESCRIPTION
currently private $_elements prevents ArrayCollection from being extended. Any good reason why it can't be protected instead?

Background: I'm wanting to use a different Visitor, probably using the Symfony PropertyAccess component, so that sorting and filtering can operate on arbitrarily-deeply nested arrays or objects.
