### PR TITLE
more comparisons: STARTS_WITH and ENDS_WITH

### DIFF
--- a/lib/Doctrine/Common/Collections/Expr/ClosureExpressionVisitor.php
+++ b/lib/Doctrine/Common/Collections/Expr/ClosureExpressionVisitor.php
@@ -155,6 +155,16 @@ class ClosureExpressionVisitor extends ExpressionVisitor
                     return false !== strpos(ClosureExpressionVisitor::getObjectFieldValue($object, $field), $value);
                 };
 
+            case Comparison::STARTS_WITH:
+                return function ($object) use ($field, $value) {
+                    return 0 === strpos(ClosureExpressionVisitor::getObjectFieldValue($object, $field), $value);
+                };
+
+            case Comparison::ENDS_WITH:
+                return function ($object) use ($field, $value) {
+                    return $value === substr(ClosureExpressionVisitor::getObjectFieldValue($object, $field), -strlen($value));
+                };
+
             default:
                 throw new \RuntimeException("Unknown comparison operator: " . $comparison->getOperator());
         }

--- a/lib/Doctrine/Common/Collections/Expr/Comparison.php
+++ b/lib/Doctrine/Common/Collections/Expr/Comparison.php
@@ -27,16 +27,18 @@ namespace Doctrine\Common\Collections\Expr;
  */
 class Comparison implements Expression
 {
-    const EQ        = '=';
-    const NEQ       = '<>';
-    const LT        = '<';
-    const LTE       = '<=';
-    const GT        = '>';
-    const GTE       = '>=';
-    const IS        = '='; // no difference with EQ
-    const IN        = 'IN';
-    const NIN       = 'NIN';
-    const CONTAINS  = 'CONTAINS';
+    const EQ           = '=';
+    const NEQ          = '<>';
+    const LT           = '<';
+    const LTE          = '<=';
+    const GT           = '>';
+    const GTE          = '>=';
+    const IS           = '='; // no difference with EQ
+    const IN           = 'IN';
+    const NIN          = 'NIN';
+    const CONTAINS     = 'CONTAINS';
+    const STARTS_WITH  = 'STARTS_WITH';
+    const ENDS_WITH    = 'ENDS_WITH';
 
     /**
      * @var string

--- a/lib/Doctrine/Common/Collections/ExpressionBuilder.php
+++ b/lib/Doctrine/Common/Collections/ExpressionBuilder.php
@@ -159,4 +159,26 @@ class ExpressionBuilder
     {
         return new Comparison($field, Comparison::CONTAINS, new Value($value));
     }
+
+    /**
+     * @param string $field
+     * @param mixed  $value
+     *
+     * @return Comparison
+     */
+    public function startsWith($field, $value)
+    {
+        return new Comparison($field, Comparison::STARTS_WITH, new Value($value));
+    }
+
+    /**
+     * @param string $field
+     * @param mixed  $value
+     *
+     * @return Comparison
+     */
+    public function endsWith($field, $value)
+    {
+        return new Comparison($field, Comparison::ENDS_WITH, new Value($value));
+    }
 }

--- a/tests/Doctrine/Tests/Common/Collections/ClosureExpressionVisitorTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/ClosureExpressionVisitorTest.php
@@ -128,6 +128,22 @@ class ClosureExpressionVisitorTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($closure(new TestObject('world')));
     }
 
+    public function testWalkStartsWithComparison()
+    {
+        $closure = $this->visitor->walkComparison($this->builder->startsWith('foo', 'hello'));
+
+        $this->assertTrue($closure(new TestObject('hello world')));
+        $this->assertFalse($closure(new TestObject('world')));
+    }
+
+    public function testWalkEndsWithComparison()
+    {
+        $closure = $this->visitor->walkComparison($this->builder->endsWith('foo', 'world'));
+
+        $this->assertTrue($closure(new TestObject('hello world')));
+        $this->assertFalse($closure(new TestObject('hello')));
+    }
+    
     public function testWalkAndCompositeExpression()
     {
         $closure = $this->visitor->walkCompositeExpression(

--- a/tests/Doctrine/Tests/Common/Collections/ExpressionBuilderTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/ExpressionBuilderTest.php
@@ -118,5 +118,21 @@ class ExpressionBuilderTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf("Doctrine\Common\Collections\Expr\Comparison", $expr);
         $this->assertEquals(Comparison::CONTAINS, $expr->getOperator());
     }
+
+    public function testStartsWith()
+    {
+        $expr = $this->builder->startsWith("a", "b");
+
+        $this->assertInstanceOf("Doctrine\Common\Collections\Expr\Comparison", $expr);
+        $this->assertEquals(Comparison::STARTS_WITH, $expr->getOperator());
+    }
+
+    public function testEndsWith()
+    {
+        $expr = $this->builder->endsWith("a", "b");
+
+        $this->assertInstanceOf("Doctrine\Common\Collections\Expr\Comparison", $expr);
+        $this->assertEquals(Comparison::ENDS_WITH, $expr->getOperator());
+    }
 }
 


### PR DESCRIPTION
Initial support in ArrayCollection elements for partial start/end string matching to be extended in the ORM library (Doctrine\ORM\Persisters\BasicEntityPersister and Doctrine\ORM\Persisters\SqlValueVisitor) for LIKE '{starts}%' and LIKE '%{end}' DQL/SQL conditions
