### PR TITLE
DDC-3016 Support using embeddables in criterias with ArrayCollection

### DIFF
--- a/lib/Doctrine/Common/Collections/Expr/ClosureExpressionVisitor.php
+++ b/lib/Doctrine/Common/Collections/Expr/ClosureExpressionVisitor.php
@@ -42,6 +42,12 @@ class ClosureExpressionVisitor extends ExpressionVisitor
      */
     public static function getObjectFieldValue($object, $field)
     {
+        if (strpos($field, '.') !== false) {
+            list($field, $subField) = explode('.', $field, 2);
+            $object = ClosureExpressionVisitor::getObjectFieldValue($object, $field);
+            return ClosureExpressionVisitor::getObjectFieldValue($object, $subField);
+        }
+
         if (is_array($object)) {
             return $object[$field];
         }

--- a/tests/Doctrine/Tests/Common/Collections/ClosureExpressionVisitorTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/ClosureExpressionVisitorTest.php
@@ -27,7 +27,13 @@ use Doctrine\Common\Collections\ExpressionBuilder;
  */
 class ClosureExpressionVisitorTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @var ClosureExpressionVisitor
+     */
     private $visitor;
+    /**
+     * @var ExpressionBuilder
+     */
     private $builder;
 
     public function setUp()
@@ -200,6 +206,14 @@ class ClosureExpressionVisitorTest extends \PHPUnit_Framework_TestCase
         $closure = $this->visitor->walkComparison($this->builder->eq("foo", 42));
 
         $this->assertTrue($closure(array('foo' => 42)));
+    }
+
+    public function testEmbeddedObjectComparison()
+    {
+        $closure = $this->visitor->walkComparison($this->builder->eq("foo.foo", 1));
+
+        $this->assertTrue($closure(new TestObject(new TestObject(1))));
+        $this->assertFalse($closure(new TestObject(new TestObject(2))));
     }
 }
 


### PR DESCRIPTION
Fix for: [DDC-3016 - Criterias do not work with embeddables when matching in memory](http://www.doctrine-project.org/jira/browse/DDC-3016).

---

When using criterias and doing the matching on a collection already loaded in memory, it will not work if filtering on embeddable objects.

Example:

``` php
$criteria = new Criteria();
$criteria->andWhere($criteria->expr()->eq('actions.view', true));

$authorizations = $this->authorizations->matching($criteria);
```

Here the ClosureExpressionVisitor will try to get the property named `->actions.view` instead of `->actions->view`.

```
PHPUnit_Framework_Error_Notice : Undefined property: Tests\...\Model\ArticleAuthorization::$actions.view
```

Criterias in PersistentCollection work perfectly with embeddables, so it makes sense to have ArrayCollection also support it (else there's a mismatch between both implementations).
