### PR TITLE
 Offer single entry point to add / set elements

### DIFF
--- a/lib/Doctrine/Common/Collections/ArrayCollection.php
+++ b/lib/Doctrine/Common/Collections/ArrayCollection.php
@@ -37,7 +37,7 @@ class ArrayCollection implements Collection, Selectable
      *
      * @var array
      */
-    private $elements = [];
+    private $elements = array();
 
     /**
      * Initializes a new ArrayCollection.

--- a/lib/Doctrine/Common/Collections/ArrayCollection.php
+++ b/lib/Doctrine/Common/Collections/ArrayCollection.php
@@ -250,7 +250,7 @@ class ArrayCollection implements Collection, Selectable
      */
     public function set($key, $value)
     {
-        $this->offsetSet($key, $value);
+        $this->offsetSet(null === $key ? '' : $key, $value);
     }
 
     /**

--- a/lib/Doctrine/Common/Collections/ArrayCollection.php
+++ b/lib/Doctrine/Common/Collections/ArrayCollection.php
@@ -37,7 +37,7 @@ class ArrayCollection implements Collection, Selectable
      *
      * @var array
      */
-    private $elements;
+    private $elements = [];
 
     /**
      * Initializes a new ArrayCollection.
@@ -46,7 +46,9 @@ class ArrayCollection implements Collection, Selectable
      */
     public function __construct(array $elements = array())
     {
-        $this->elements = $elements;
+        foreach ($elements as $key => $element) {
+            $this->offsetSet($key, $element);
+        }
     }
 
     /**
@@ -155,11 +157,12 @@ class ArrayCollection implements Collection, Selectable
      */
     public function offsetSet($offset, $value)
     {
-        if ( ! isset($offset)) {
-            return $this->add($value);
+        if (null === $offset) {
+            $this->elements[] = $value;
         }
-
-        $this->set($offset, $value);
+        else {
+            $this->elements[$offset] = $value;
+        }
     }
 
     /**
@@ -247,7 +250,7 @@ class ArrayCollection implements Collection, Selectable
      */
     public function set($key, $value)
     {
-        $this->elements[$key] = $value;
+        $this->offsetSet($key, $value);
     }
 
     /**
@@ -255,8 +258,7 @@ class ArrayCollection implements Collection, Selectable
      */
     public function add($value)
     {
-        $this->elements[] = $value;
-
+        $this->offsetSet(null, $value);
         return true;
     }
 

--- a/lib/Doctrine/Common/Collections/ArrayCollection.php
+++ b/lib/Doctrine/Common/Collections/ArrayCollection.php
@@ -159,8 +159,7 @@ class ArrayCollection implements Collection, Selectable
     {
         if (null === $offset) {
             $this->elements[] = $value;
-        }
-        else {
+        } else {
             $this->elements[$offset] = $value;
         }
     }
@@ -259,6 +258,7 @@ class ArrayCollection implements Collection, Selectable
     public function add($value)
     {
         $this->offsetSet(null, $value);
+
         return true;
     }
 

--- a/tests/Doctrine/Tests/Common/Collections/ArrayCollectionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/ArrayCollectionTest.php
@@ -268,4 +268,26 @@ class ArrayCollectionTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('a',  $collection->get('A'),            'Get element by name');
         $this->assertSame(null, $collection->get('non-existent'), 'Get non existent element');
     }
+
+    public function testSet()
+    {
+        $collection = new ArrayCollection();
+        $this->assertNull($collection->set('key', 'val'));
+        $this->assertSame(['key' => 'val'], $collection->toArray());
+    }
+
+    public function testAdd()
+    {
+        $collection = new ArrayCollection();
+        $this->assertTrue($collection->add('element1'));
+        $this->assertSame(['element1'], $collection->toArray());
+    }
+
+    public function testOffsetSet()
+    {
+        $collection = new ArrayCollection();
+        $this->assertNull($collection->offsetSet(null, 'element'));
+        $this->assertNull($collection->offsetSet('2', 'element'));
+        $this->assertSame(['element', '2' => 'element'], $collection->toArray());
+    }
 }

--- a/tests/Doctrine/Tests/Common/Collections/ArrayCollectionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/ArrayCollectionTest.php
@@ -272,8 +272,9 @@ class ArrayCollectionTest extends \PHPUnit_Framework_TestCase
     public function testSet()
     {
         $collection = new ArrayCollection();
-        $this->assertNull($collection->set('key', 'val'));
-        $this->assertSame(['key' => 'val'], $collection->toArray());
+        $collection->set('key', 'val');
+        $collection->set(null, 'val');
+        $this->assertSame(['key' => 'val', '' => 'val'], $collection->toArray(), 'null index is casted to empty string');
     }
 
     public function testAdd()
@@ -286,8 +287,9 @@ class ArrayCollectionTest extends \PHPUnit_Framework_TestCase
     public function testOffsetSet()
     {
         $collection = new ArrayCollection();
-        $this->assertNull($collection->offsetSet(null, 'element'));
-        $this->assertNull($collection->offsetSet('2', 'element'));
-        $this->assertSame(['element', '2' => 'element'], $collection->toArray());
+        $collection->offsetSet(null, 'element');
+        $collection->offsetSet(null, 'element');
+        $collection->offsetSet('key', 'element');
+        $this->assertSame(['element', 'element', 'key' => 'element'], $collection->toArray(), 'null indexes are incremented');
     }
 }

--- a/tests/Doctrine/Tests/Common/Collections/ArrayCollectionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/ArrayCollectionTest.php
@@ -274,14 +274,14 @@ class ArrayCollectionTest extends \PHPUnit_Framework_TestCase
         $collection = new ArrayCollection();
         $collection->set('key', 'val');
         $collection->set(null, 'val');
-        $this->assertSame(['key' => 'val', '' => 'val'], $collection->toArray(), 'null index is casted to empty string');
+        $this->assertSame(array('key' => 'val', '' => 'val'), $collection->toArray(), 'null index is casted to empty string');
     }
 
     public function testAdd()
     {
         $collection = new ArrayCollection();
         $this->assertTrue($collection->add('element1'));
-        $this->assertSame(['element1'], $collection->toArray());
+        $this->assertSame(array('element1'), $collection->toArray());
     }
 
     public function testOffsetSet()
@@ -290,6 +290,6 @@ class ArrayCollectionTest extends \PHPUnit_Framework_TestCase
         $collection->offsetSet(null, 'element');
         $collection->offsetSet(null, 'element');
         $collection->offsetSet('key', 'element');
-        $this->assertSame(['element', 'element', 'key' => 'element'], $collection->toArray(), 'null indexes are incremented');
+        $this->assertSame(array('element', 'element', 'key' => 'element'), $collection->toArray(), 'null indexes are incremented');
     }
 }


### PR DESCRIPTION
To simplify implementation of specific behavior (i.e: validating data) when extending ArrayCollection, a single entry point for all "set" operations would be welcome.
The main downside of this PR is the operation made in constructor: we need to manually loop through elements in order to add them one by one. This have a significant performance impact on very large collections.