### PR TITLE
Add Collection::previous()

### DIFF
--- a/lib/Doctrine/Common/Collections/AbstractLazyCollection.php
+++ b/lib/Doctrine/Common/Collections/AbstractLazyCollection.php
@@ -197,6 +197,15 @@ abstract class AbstractLazyCollection implements Collection
     /**
      * {@inheritDoc}
      */
+    public function previous()
+    {
+        $this->initialize();
+        return $this->collection->previous();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function next()
     {
         $this->initialize();

--- a/lib/Doctrine/Common/Collections/ArrayCollection.php
+++ b/lib/Doctrine/Common/Collections/ArrayCollection.php
@@ -84,6 +84,14 @@ class ArrayCollection implements Collection, Selectable
     /**
      * {@inheritDoc}
      */
+    public function previous()
+    {
+        return prev($this->elements);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function next()
     {
         return next($this->elements);

--- a/lib/Doctrine/Common/Collections/Collection.php
+++ b/lib/Doctrine/Common/Collections/Collection.php
@@ -177,6 +177,13 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
     public function current();
 
     /**
+     * Moves the internal iterator position to the previous element and returns this element.
+     *
+     * @return mixed
+     */
+    function previous();
+
+    /**
      * Moves the internal iterator position to the next element and returns this element.
      *
      * @return mixed

--- a/tests/Doctrine/Tests/Common/Collections/ArrayCollectionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/ArrayCollectionTest.php
@@ -74,6 +74,30 @@ class ArrayCollectionTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider provideDifferentElements
      */
+    public function testPrevious($elements)
+    {
+        $collection = new ArrayCollection($elements);
+
+        $collection->last();
+        end($elements);
+
+        while (true) {
+            $collectionPrevious = $collection->previous();
+            $arrayPrevious = prev($elements);
+
+            if (!$collectionPrevious || !$arrayPrevious) {
+                break;
+            }
+
+            $this->assertSame($arrayPrevious,     $collectionPrevious,    "Returned value of ArrayCollection::previous() and prev() not match");
+            $this->assertSame(key($elements),     $collection->key(),     "Keys not match");
+            $this->assertSame(current($elements), $collection->current(), "Current values not match");
+        }
+    }
+
+    /**
+     * @dataProvider provideDifferentElements
+     */
     public function testNext($elements)
     {
         $collection = new ArrayCollection($elements);
@@ -82,11 +106,11 @@ class ArrayCollectionTest extends \PHPUnit_Framework_TestCase
             $collectionNext = $collection->next();
             $arrayNext = next($elements);
 
-            if(!$collectionNext || !$arrayNext) {
+            if (!$collectionNext || !$arrayNext) {
                 break;
             }
 
-            $this->assertSame($arrayNext,      $collectionNext,        "Returned value of ArrayCollection::next() and next() not match");
+            $this->assertSame($arrayNext,         $collectionNext,        "Returned value of ArrayCollection::next() and next() not match");
             $this->assertSame(key($elements),     $collection->key(),     "Keys not match");
             $this->assertSame(current($elements), $collection->current(), "Current values not match");
         }


### PR DESCRIPTION
For symmetry with Collection::next() I suggest adding a new method, Collection::previous().

Some iterators may be optimized against iterating over the elements one by one using next(). However, the Collection interface otherwise assumes that the collection is random-access, so implementing the new previous() method should not be difficult.
