### PR TITLE
Extend Collection with Selectable

### DIFF
--- a/lib/Doctrine/Common/Collections/AbstractLazyCollection.php
+++ b/lib/Doctrine/Common/Collections/AbstractLazyCollection.php
@@ -312,6 +312,15 @@ abstract class AbstractLazyCollection implements Collection
     }
 
     /**
+     * {@inheritDoc}
+     */
+    public function matching(Criteria $criteria)
+    {
+        $this->initialize();
+        $this->collection->matching($criteria);
+    }
+
+    /**
      * Is the lazy collection already initialized?
      *
      * @return bool

--- a/lib/Doctrine/Common/Collections/ArrayCollection.php
+++ b/lib/Doctrine/Common/Collections/ArrayCollection.php
@@ -30,7 +30,7 @@ use Doctrine\Common\Collections\Expr\ClosureExpressionVisitor;
  * @author Jonathan Wage <jonwage@gmail.com>
  * @author Roman Borschel <roman@code-factory.org>
  */
-class ArrayCollection implements Collection, Selectable
+class ArrayCollection implements Collection
 {
     /**
      * An array containing the entries of this collection.

--- a/lib/Doctrine/Common/Collections/Collection.php
+++ b/lib/Doctrine/Common/Collections/Collection.php
@@ -43,7 +43,7 @@ use Closure, Countable, IteratorAggregate, ArrayAccess;
  * @author Jonathan Wage <jonwage@gmail.com>
  * @author Roman Borschel <roman@code-factory.org>
  */
-interface Collection extends Countable, IteratorAggregate, ArrayAccess
+interface Collection extends Countable, IteratorAggregate, ArrayAccess, Selectable
 {
     /**
      * Adds an element at the end of the collection.


### PR DESCRIPTION
This is a proposition to fix some OOP disadvantages.

In entity we always use a type hint for collection, for example

```php
class Category
{
    public function __construct()
    {
        $this->articles = new ArrayCollection();
    }

    /**
     * @var \Doctrine\Common\Collections\Collection
     */
    protected $articles;

    /**
     * @param \Doctrine\Common\Collections\Colleciton $articles
     * @return Category
     */
    public function setArticles(Colleciton $articles)
    {
        $this->articles = $articles;

        return $this;
    }

    /**
     * @return \Doctrine\Common\Collections\Colleciton
     */
    public function getArticles()
    {
        return $this->articles;
    }
}
```

But if I want to use method matching I must to check that collection is instanceof Selectable because in Collection interface this method missed. But ArrayCollection and PersistentCollection implement both of this interfaces. Example

```php
    public function getPublishedArticles()
    {
        return $this->articles->matching(Criteria::create()->where(Criteria::expr()->eq('published', true)));
    }
```
In this case I will check instance of Seletable and after that only will use method matching. In another case I must transform this colleciton to another one what implements Selectable interface, but this is overkill.

In other case this PR will be changed with adding new interface, like SelectableCollection, that will extend with Collection and Selectable, and ArrayCollection with PersistentCollection will be extended from this one.