### PR TITLE
Added prev method

### DIFF
--- a/lib/Doctrine/Common/Collections/ArrayCollection.php
+++ b/lib/Doctrine/Common/Collections/ArrayCollection.php
@@ -88,6 +88,17 @@ class ArrayCollection implements Collection, Selectable
     {
         return next($this->elements);
     }
+    
+    /**
+     * Moves the internal iterator position to the previous element and returns this element.
+     *
+     * @return mixed
+     * @todo add to Collection interface
+     */
+    public function prev()
+    {
+        return prev($this->elements);
+    }
 
     /**
      * {@inheritDoc}


### PR DESCRIPTION
Simplifies usage of ArrayCollection when needing to move the array pointer to the previous element and coincide with array functions.
