### PR TITLE
ignore eclipse project files and composer.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,3 @@
 # standalone application
 /vendor/
 /composer.lock
-
-# ignore eclipse project
-/.project
-/.buildpath
-/.settings


### PR DESCRIPTION
Added composer.lock to .gitignore because it should never be committed in this repository.

More open for discussion: adding eclipse project files to .gitignore
