### PR TITLE
Added Collection::reduce() and unit test.

### DIFF
--- a/lib/Doctrine/Common/Collections/AbstractLazyCollection.php
+++ b/lib/Doctrine/Common/Collections/AbstractLazyCollection.php
@@ -242,6 +242,15 @@ abstract class AbstractLazyCollection implements Collection
     /**
      * {@inheritDoc}
      */
+    public function reduce(Closure $func, $initial = null)
+    {
+        $this->initialize();
+        return $this->collection->reduce($func, $initial);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function partition(Closure $p)
     {
         $this->initialize();

--- a/lib/Doctrine/Common/Collections/ArrayCollection.php
+++ b/lib/Doctrine/Common/Collections/ArrayCollection.php
@@ -290,6 +290,14 @@ class ArrayCollection implements Collection, Selectable
     /**
      * {@inheritDoc}
      */
+    public function reduce(Closure $func, $initial = null)
+    {
+        return array_reduce($this->elements, $func, $initial);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function filter(Closure $p)
     {
         return new static(array_filter($this->elements, $p));

--- a/lib/Doctrine/Common/Collections/Collection.php
+++ b/lib/Doctrine/Common/Collections/Collection.php
@@ -225,6 +225,16 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
     public function map(Closure $func);
 
     /**
+     * Iteratively reduce the array to a single value using a callback function.
+     *
+     * @param Closure $func
+     * @param mixed   $initial
+     *
+     * @return mixed
+     */
+    public function reduce(Closure $func, $initial = null);
+
+    /**
      * Partitions this collection in two collections according to a predicate.
      * Keys are preserved in the resulting collections.
      *

--- a/tests/Doctrine/Tests/Common/Collections/CollectionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/CollectionTest.php
@@ -56,6 +56,33 @@ class CollectionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array(2, 4), $res->toArray());
     }
 
+    public function testReduce()
+    {
+        $sum = function ($carry, $item) {
+            return $carry + $item;
+        };
+
+        $product = function ($carry, $item) {
+            return $carry * $item;
+        };
+
+        $this->collection->add(1);
+        $this->collection->add(2);
+        $this->collection->add(3);
+        $this->collection->add(4);
+        $this->collection->add(5);
+
+        $res = $this->collection->reduce($sum);
+        $this->assertEquals(15, $res);
+
+        $res = $this->collection->reduce($product, 10);
+        $this->assertEquals(1200, $res);
+
+        $this->collection->clear();
+        $res = $this->collection->reduce($sum, "No data to reduce");
+        $this->assertEquals("No data to reduce", $res);
+    }
+
     public function testFilter()
     {
         $this->collection->add(1);


### PR DESCRIPTION
I sometimes miss the ability to call `::reduce()` on a Collection, to reduce it to a single value using a callback. The unit test is based on the example code from the documentation page for `array_reduce()` [on php.net](http://php.net/manual/en/function.array-reduce.php#example-5092).