### PR TITLE
Added prev to collections

### DIFF
--- a/lib/Doctrine/Common/Collections/AbstractLazyCollection.php
+++ b/lib/Doctrine/Common/Collections/AbstractLazyCollection.php
@@ -206,6 +206,15 @@ abstract class AbstractLazyCollection implements Collection
     /**
      * {@inheritDoc}
      */
+    public function prev()
+    {
+        $this->initialize();
+        return $this->collection->prev();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function exists(Closure $p)
     {
         $this->initialize();

--- a/lib/Doctrine/Common/Collections/ArrayCollection.php
+++ b/lib/Doctrine/Common/Collections/ArrayCollection.php
@@ -93,6 +93,14 @@ class ArrayCollection implements Collection, Selectable
     /**
      * {@inheritDoc}
      */
+    public function prev()
+    {
+        return prev($this->elements);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function current()
     {
         return current($this->elements);

--- a/lib/Doctrine/Common/Collections/Collection.php
+++ b/lib/Doctrine/Common/Collections/Collection.php
@@ -187,6 +187,13 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
     public function next();
 
     /**
+     * Moves the internal iterator position to the prev element and returns this element.
+     *
+     * @return mixed
+     */
+    public function prev();
+
+    /**
      * Tests for the existence of an element that satisfies the given predicate.
      *
      * @param Closure $p The predicate.

--- a/tests/Doctrine/Tests/Common/Collections/ArrayCollectionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/ArrayCollectionTest.php
@@ -95,6 +95,27 @@ class ArrayCollectionTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider provideDifferentElements
      */
+    public function testPrev($elements)
+    {
+        $collection = new ArrayCollection($elements);
+
+        while (true) {
+            $collectionNext = $collection->prev();
+            $arrayNext = prev($elements);
+
+            if(!$collectionNext || !$arrayNext) {
+                break;
+            }
+
+            $this->assertSame($arrayNext,      $collectionNext,        "Returned value of ArrayCollection::next() and next() not match");
+            $this->assertSame(key($elements),     $collection->key(),     "Keys not match");
+            $this->assertSame(current($elements), $collection->current(), "Current values not match");
+        }
+    }
+
+    /**
+     * @dataProvider provideDifferentElements
+     */
     public function testCurrent($elements)
     {
         $collection = new ArrayCollection($elements);

--- a/tests/Doctrine/Tests/Common/Collections/ArrayCollectionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/ArrayCollectionTest.php
@@ -99,15 +99,17 @@ class ArrayCollectionTest extends \PHPUnit_Framework_TestCase
     {
         $collection = new ArrayCollection($elements);
 
-        while (true) {
-            $collectionNext = $collection->prev();
-            $arrayNext = prev($elements);
+        $this->assertSame(end($elements), $collection->last());
 
-            if(!$collectionNext || !$arrayNext) {
+        while (true) {
+            $collectionPrev = $collection->prev();
+            $arrayPrev = prev($elements);
+
+            if(!$collectionPrev || !$arrayPrev) {
                 break;
             }
 
-            $this->assertSame($arrayNext,      $collectionNext,        "Returned value of ArrayCollection::next() and next() not match");
+            $this->assertSame($arrayPrev,      $collectionPrev,        "Returned value of ArrayCollection::next() and next() not match");
             $this->assertSame(key($elements),     $collection->key(),     "Keys not match");
             $this->assertSame(current($elements), $collection->current(), "Current values not match");
         }


### PR DESCRIPTION
Added prev() to array collections.  This is needed when you want to cycle through the array in reverse order.  