### PR TITLE
Keep keys when using array collection's matching()

### DIFF
--- a/lib/Doctrine/Common/Collections/ArrayCollection.php
+++ b/lib/Doctrine/Common/Collections/ArrayCollection.php
@@ -372,7 +372,7 @@ class ArrayCollection implements Collection, Selectable
                 $next = ClosureExpressionVisitor::sortByField($field, $ordering == Criteria::DESC ? -1 : 1);
             }
 
-            usort($filtered, $next);
+            uksort($filtered, $next);
         }
 
         $offset = $criteria->getFirstResult();

--- a/lib/Doctrine/Common/Collections/ArrayCollection.php
+++ b/lib/Doctrine/Common/Collections/ArrayCollection.php
@@ -372,7 +372,7 @@ class ArrayCollection implements Collection, Selectable
                 $next = ClosureExpressionVisitor::sortByField($field, $ordering == Criteria::DESC ? -1 : 1);
             }
 
-            uksort($filtered, $next);
+            uasort($filtered, $next);
         }
 
         $offset = $criteria->getFirstResult();


### PR DESCRIPTION
Use `uksort()` instead of `usort()`.