### PR TITLE
Made initialized protected for extensibility.

### DIFF
--- a/lib/Doctrine/Common/Collections/AbstractLazyCollection.php
+++ b/lib/Doctrine/Common/Collections/AbstractLazyCollection.php
@@ -37,9 +37,9 @@ abstract class AbstractLazyCollection implements Collection
     protected $collection;
 
     /**
-     * @var bool
+     * @var boolean
      */
-    private $initialized = false;
+    protected $initialized = false;
 
     /**
      * {@inheritDoc}


### PR DESCRIPTION
I'm working on making PersistentCollection extends AbstractLazyCollection and it is required to have access to initialized property. This PR allows that.