### PR TITLE
Add reduce method, add unit test

### DIFF
--- a/lib/Doctrine/Common/Collections/AbstractLazyCollection.php
+++ b/lib/Doctrine/Common/Collections/AbstractLazyCollection.php
@@ -242,6 +242,15 @@ abstract class AbstractLazyCollection implements Collection
     /**
      * {@inheritDoc}
      */
+    public function reduce(Closure $func, $initial = null)
+    {
+        $this->initialize();
+        return $this->collection->reduce($func, $initial);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function partition(Closure $p)
     {
         $this->initialize();

--- a/lib/Doctrine/Common/Collections/ArrayCollection.php
+++ b/lib/Doctrine/Common/Collections/ArrayCollection.php
@@ -298,6 +298,14 @@ class ArrayCollection implements Collection, Selectable
     /**
      * {@inheritDoc}
      */
+    public function reduce(Closure $func, $initial = null)
+    {
+        return array_reduce($this->elements, $func, $initial);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function forAll(Closure $p)
     {
         foreach ($this->elements as $key => $element) {

--- a/lib/Doctrine/Common/Collections/Collection.php
+++ b/lib/Doctrine/Common/Collections/Collection.php
@@ -225,6 +225,17 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
     public function map(Closure $func);
 
     /**
+     * Iteratively reduce collection  to a single value using a callback function
+     *
+     *
+     * @param Closure $func
+     * @param mixed   $initial
+     *
+     * @return mixed
+     */
+    public function reduce(Closure $func, $initial = null);
+
+    /**
      * Partitions this collection in two collections according to a predicate.
      * Keys are preserved in the resulting collections.
      *

--- a/tests/Doctrine/Tests/Common/Collections/CollectionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/CollectionTest.php
@@ -56,6 +56,15 @@ class CollectionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array(2, 4), $res->toArray());
     }
 
+    public function testReduce()
+    {
+        $this->collection->add(1);
+        $this->collection->add(2);
+        $callback = function($curry, $e) { return $curry +  $e * 2; };
+        $this->assertEquals(6, $this->collection->reduce($callback));
+        $this->assertEquals(7, $this->collection->reduce($callback, 1));
+    }
+
     public function testFilter()
     {
         $this->collection->add(1);


### PR DESCRIPTION
All attempts to use http://php.net/manual/en/function.array-reduce.php leads to warning
Warning: array_reduce() expects parameter 1 to be array, object given
There is some workaround about it, but as we have map method in collection it make sense to have also reduce.
What was done
- Added reduce method
- Added unit test to CollectionTest