### PR TITLE
travis: PHP 7.0 nightly added + few improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,17 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - 7.0
   - hhvm
   - hhvm-nightly
 
+matrix:
+  fast_finish: true
+  allow_failures:
+    - php: 7.0
+
 before_script:
-    - composer --prefer-source --dev install
+    - composer --prefer-source install
 
 script:
-    - ./vendor/bin/phpunit
+    - phpunit


### PR DESCRIPTION
- `--dev` is by default for almost a year
- use Travis' PHPUnit, it handles it for us