### PR TITLE
non-camel-case variable code conventions (with extra tests)

### DIFF
--- a/lib/Doctrine/Common/Collections/Expr/ClosureExpressionVisitor.php
+++ b/lib/Doctrine/Common/Collections/Expr/ClosureExpressionVisitor.php
@@ -58,18 +58,6 @@ class ClosureExpressionVisitor extends ExpressionVisitor
             return $object->$accessor();
         }
 
-        // camelcase field name to support different variable naming conventions
-        $ccField = preg_replace_callback('/_(.?)/', function($matches) { return strtoupper($matches[1]); }, $field);
-
-        foreach ($accessors as $accessor) {
-            $accessor .= $ccField;
-
-            if ( ! method_exists($object, $accessor)) {
-                continue;
-            }
-
-            return $object->$accessor();
-        }
 
         // __call should be triggered for get.
         $accessor = $accessors[0] . $field;
@@ -80,6 +68,24 @@ class ClosureExpressionVisitor extends ExpressionVisitor
 
         if ($object instanceof \ArrayAccess) {
             return $object[$field];
+        }
+
+        if (isset($object->$field)) {
+            return $object->$field;
+        }
+
+        // camelcase field name to support different variable naming conventions
+        $ccField   = preg_replace_callback('/_(.?)/', function($matches) { return strtoupper($matches[1]); }, $field);
+
+        foreach ($accessors as $accessor) {
+            $accessor .= $ccField;
+
+
+            if ( ! method_exists($object, $accessor)) {
+                continue;
+            }
+
+            return $object->$accessor();
         }
 
         return $object->$field;

--- a/lib/Doctrine/Common/Collections/Expr/ClosureExpressionVisitor.php
+++ b/lib/Doctrine/Common/Collections/Expr/ClosureExpressionVisitor.php
@@ -58,7 +58,6 @@ class ClosureExpressionVisitor extends ExpressionVisitor
             return $object->$accessor();
         }
 
-
         // __call should be triggered for get.
         $accessor = $accessors[0] . $field;
 

--- a/lib/Doctrine/Common/Collections/Expr/ClosureExpressionVisitor.php
+++ b/lib/Doctrine/Common/Collections/Expr/ClosureExpressionVisitor.php
@@ -58,6 +58,19 @@ class ClosureExpressionVisitor extends ExpressionVisitor
             return $object->$accessor();
         }
 
+        // camelcase field name to support different variable naming conventions
+        $ccField = preg_replace_callback('/_(.?)/', function($matches) { return strtoupper($matches[1]); }, $field);
+
+        foreach ($accessors as $accessor) {
+            $accessor .= $ccField;
+
+            if ( ! method_exists($object, $accessor)) {
+                continue;
+            }
+
+            return $object->$accessor();
+        }
+
         // __call should be triggered for get.
         $accessor = $accessors[0] . $field;
 

--- a/tests/Doctrine/Tests/Common/Collections/ClosureExpressionVisitorTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/ClosureExpressionVisitorTest.php
@@ -50,6 +50,15 @@ class ClosureExpressionVisitorTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($this->visitor->getObjectFieldValue($object, 'baz'));
     }
 
+    public function testGetObjectFieldValueIsAccessorCamelCase()
+    {
+        $object = new TestObject(1, 2);
+
+        $this->assertEquals([1, 2], $this->visitor->getObjectFieldValue($object, 'foo_bar'));
+        $this->assertEquals([1, 2], $this->visitor->getObjectFieldValue($object, 'foobar'));
+        $this->assertEquals([1, 2], $this->visitor->getObjectFieldValue($object, 'fooBar'));
+    }
+
     public function testGetObjectFieldValueMagicCallMethod()
     {
         $object = new TestObject(1, 2, true, 3);
@@ -245,6 +254,11 @@ class TestObject
     public function isBaz()
     {
         return $this->baz;
+    }
+    
+    public function getFooBar()
+    {
+        return array($this->foo, $this->bar);
     }
 }
 

--- a/tests/Doctrine/Tests/Common/Collections/ClosureExpressionVisitorTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/ClosureExpressionVisitorTest.php
@@ -54,9 +54,9 @@ class ClosureExpressionVisitorTest extends \PHPUnit_Framework_TestCase
     {
         $object = new TestObject(1, 2);
 
-        $this->assertEquals([1, 2], $this->visitor->getObjectFieldValue($object, 'foo_bar'));
-        $this->assertEquals([1, 2], $this->visitor->getObjectFieldValue($object, 'foobar'));
-        $this->assertEquals([1, 2], $this->visitor->getObjectFieldValue($object, 'fooBar'));
+        $this->assertEquals(array(1, 2), $this->visitor->getObjectFieldValue($object, 'foo_bar'));
+        $this->assertEquals(array(1, 2), $this->visitor->getObjectFieldValue($object, 'foobar'));
+        $this->assertEquals(array(1, 2), $this->visitor->getObjectFieldValue($object, 'fooBar'));
     }
 
     public function testGetObjectFieldValueMagicCallMethod()

--- a/tests/Doctrine/Tests/Common/Collections/ClosureExpressionVisitorTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/ClosureExpressionVisitorTest.php
@@ -255,11 +255,6 @@ class TestObject
     {
         return $this->baz;
     }
-
-    public function getFooBar()
-    {
-        return array($this->foo, $this->bar);
-    }
 }
 
 class TestObjectNotCamelCase

--- a/tests/Doctrine/Tests/Common/Collections/ClosureExpressionVisitorTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/ClosureExpressionVisitorTest.php
@@ -59,6 +59,33 @@ class ClosureExpressionVisitorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(1, $this->visitor->getObjectFieldValue($object, 'fooBar'));
     }
 
+    public function testGetObjectFieldValueIsAccessorBoth()
+    {
+        $object = new TestObjectBothCamelCaseAndUnderscore(1, 2);
+
+        $this->assertEquals(2, $this->visitor->getObjectFieldValue($object, 'foo_bar'));
+        $this->assertEquals(2, $this->visitor->getObjectFieldValue($object, 'foobar'));
+        $this->assertEquals(2, $this->visitor->getObjectFieldValue($object, 'fooBar'));
+    }
+
+    public function testGetObjectFieldValueIsAccessorOnePublic()
+    {
+        $object = new TestObjectPublicCamelCaseAndPrivateUnderscore(1, 2);
+
+        $this->assertEquals(2, $this->visitor->getObjectFieldValue($object, 'foo_bar'));
+        $this->assertEquals(2, $this->visitor->getObjectFieldValue($object, 'foobar'));
+        $this->assertEquals(2, $this->visitor->getObjectFieldValue($object, 'fooBar'));
+    }
+
+    public function testGetObjectFieldValueIsAccessorBothPublic()
+    {
+        $object = new TestObjectPublicCamelCaseAndPrivateUnderscore(1, 2);
+
+        $this->assertEquals(2, $this->visitor->getObjectFieldValue($object, 'foo_bar'));
+        $this->assertEquals(2, $this->visitor->getObjectFieldValue($object, 'foobar'));
+        $this->assertEquals(2, $this->visitor->getObjectFieldValue($object, 'fooBar'));
+    }
+
     public function testGetObjectFieldValueMagicCallMethod()
     {
         $object = new TestObject(1, 2, true, 3);
@@ -272,3 +299,53 @@ class TestObjectNotCamelCase
     }
 }
 
+class TestObjectBothCamelCaseAndUnderscore
+{
+    private $foo_bar;
+    private $fooBar;
+
+    public function __construct($foo_bar = null, $fooBar = null)
+    {
+        $this->foo_bar = $foo_bar;
+        $this->fooBar = $fooBar;
+    }
+
+    public function getFooBar()
+    {
+        return $this->fooBar;
+    }
+}
+
+class TestObjectPublicCamelCaseAndPrivateUnderscore
+{
+    private $foo_bar;
+    public $fooBar;
+
+    public function __construct($foo_bar = null, $fooBar = null)
+    {
+        $this->foo_bar = $foo_bar;
+        $this->fooBar = $fooBar;
+    }
+
+    public function getFooBar()
+    {
+        return $this->fooBar;
+    }
+}
+
+class TestObjectBothPublic
+{
+    public $foo_bar;
+    public $fooBar;
+
+    public function __construct($foo_bar = null, $fooBar = null)
+    {
+        $this->foo_bar = $foo_bar;
+        $this->fooBar = $fooBar;
+    }
+
+    public function getFooBar()
+    {
+        return $this->foo_bar;
+    }
+}

--- a/tests/Doctrine/Tests/Common/Collections/ClosureExpressionVisitorTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/ClosureExpressionVisitorTest.php
@@ -52,11 +52,11 @@ class ClosureExpressionVisitorTest extends \PHPUnit_Framework_TestCase
 
     public function testGetObjectFieldValueIsAccessorCamelCase()
     {
-        $object = new TestObject(1, 2);
+        $object = new TestObjectNotCamelCase(1);
 
-        $this->assertEquals(array(1, 2), $this->visitor->getObjectFieldValue($object, 'foo_bar'));
-        $this->assertEquals(array(1, 2), $this->visitor->getObjectFieldValue($object, 'foobar'));
-        $this->assertEquals(array(1, 2), $this->visitor->getObjectFieldValue($object, 'fooBar'));
+        $this->assertEquals(1, $this->visitor->getObjectFieldValue($object, 'foo_bar'));
+        $this->assertEquals(1, $this->visitor->getObjectFieldValue($object, 'foobar'));
+        $this->assertEquals(1, $this->visitor->getObjectFieldValue($object, 'fooBar'));
     }
 
     public function testGetObjectFieldValueMagicCallMethod()
@@ -255,10 +255,25 @@ class TestObject
     {
         return $this->baz;
     }
-    
+
     public function getFooBar()
     {
         return array($this->foo, $this->bar);
+    }
+}
+
+class TestObjectNotCamelCase
+{
+    private $foo_bar;
+
+    public function __construct($foo_bar = null)
+    {
+        $this->foo_bar = $foo_bar;
+    }
+
+    public function getFooBar()
+    {
+        return $this->foo_bar;
     }
 }
 


### PR DESCRIPTION
Because people keep running into issues with collections and `$underscore_properties` , I have added extra tests on the changes of #29 to to prove that it's backwards compatible. It seems like that one won't be merged because the test cases are missing.

This PR includes the exact same changes as #29 but with 3 extra tests.