### PR TITLE
Remove the hhvm-nightly job from the matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ php:
   - 5.6
   - 7.0
   - hhvm
-  - hhvm-nightly
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
hhvm-nightly is not available anymore on Travis for now, because HHVM dropped support for Ubuntu 10.04