### PR TITLE
Enable accessor for underscore naming strategy

### DIFF
--- a/lib/Doctrine/Common/Collections/Expr/ClosureExpressionVisitor.php
+++ b/lib/Doctrine/Common/Collections/Expr/ClosureExpressionVisitor.php
@@ -46,7 +46,7 @@ class ClosureExpressionVisitor extends ExpressionVisitor
             return $object[$field];
         }
 
-        $accessors = array('get', 'is');
+        $accessors = array('get', 'is', 'get_');
 
         foreach ($accessors as $accessor) {
             $accessor .= $field;


### PR DESCRIPTION
A small fix for those of us forced to use projects with the underscore naming strategy and want to use the Criteria class. 