### PR TITLE
Add ability to use custom method name in ClosureExpressionVisitor

### DIFF
--- a/lib/Doctrine/Common/Collections/Expr/ClosureExpressionVisitor.php
+++ b/lib/Doctrine/Common/Collections/Expr/ClosureExpressionVisitor.php
@@ -46,11 +46,13 @@ class ClosureExpressionVisitor extends ExpressionVisitor
             return $object[$field];
         }
 
-        $accessors = array('get', 'is');
+        $accessors = array(
+            'get' . $field,
+            'is' . $field,
+            $field, // non-standard method
+        );
 
         foreach ($accessors as $accessor) {
-            $accessor .= $field;
-
             if ( ! method_exists($object, $accessor)) {
                 continue;
             }
@@ -59,7 +61,7 @@ class ClosureExpressionVisitor extends ExpressionVisitor
         }
 
         // __call should be triggered for get.
-        $accessor = $accessors[0] . $field;
+        $accessor = $accessors[0];
 
         if (method_exists($object, '__call')) {
             return $object->$accessor();

--- a/tests/Doctrine/Tests/Common/Collections/ClosureExpressionVisitorTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/ClosureExpressionVisitorTest.php
@@ -208,6 +208,13 @@ class ClosureExpressionVisitorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue($closure(array('foo' => 42)));
     }
+
+    public function testObjectMethodUseNonStandardName()
+    {
+        $object = new TestObject();
+
+        $this->assertSame('result', $this->visitor->getObjectFieldValue($object, 'useNonStandardName'));
+    }
 }
 
 class TestObject
@@ -245,6 +252,11 @@ class TestObject
     public function isBaz()
     {
         return $this->baz;
+    }
+
+    public function useNonStandardName()
+    {
+        return 'result';
     }
 }
 


### PR DESCRIPTION
This would enable the developper to control the naming of its methods instead of having to name it `get` or `is`. 

**Use case**:

```
require_once 'vendor/autoload.php';

use Doctrine\Common\Collections\Criteria;
use Doctrine\Common\Collections\ArrayCollection;
use PHPUnit_Framework_Assert as Assert;

class Foo
{
    public function returnsTrue()
    {
        return true;
    }
}

$object = new Foo();
$collection = new ArrayCollection(array($object));
$criteria = Criteria::create()->andWhere(Criteria::expr()->eq('returnsTrue', true));
Assert::assertSame($object, $collection->matching($criteria)->first());
```

**Before**: would produce this error:

```
PHP Notice:  Undefined property: Foo::$returnsTrue in /home/yvoyer/git/warlord/vendor/doctrine/collections/lib/Doctrine/Common/Collections/Expr/ClosureExpressionVisitor.php on line 72
PHP Stack trace:
PHP   1. {main}() /home/yvoyer/git/warlord/test.php:0
PHP   2. Doctrine\Common\Collections\ArrayCollection->matching() /home/yvoyer/git/warlord/test.php:24
PHP   3. array_filter() /home/yvoyer/git/warlord/vendor/doctrine/collections/lib/Doctrine/Common/Collections/ArrayCollection.php:367
PHP   4. Doctrine\Common\Collections\Expr\ClosureExpressionVisitor->Doctrine\Common\Collections\Expr\{closure}() /home/yvoyer/git/warlord/vendor/doctrine/collections/lib/Doctrine/Common/Collections/ArrayCollection.php:367
PHP   5. Doctrine\Common\Collections\Expr\ClosureExpressionVisitor::getObjectFieldValue() /home/yvoyer/git/warlord/vendor/doctrine/collections/lib/Doctrine/Common/Collections/Expr/ClosureExpressionVisitor.php:115
PHP Fatal error:  Uncaught Failed asserting that false is identical to an object of class "Foo".

thrown in /home/yvoyer/git/warlord/vendor/phpunit/phpunit/src/Framework/Constraint.php on line 110
```

**After**: Applying the patch would resolve the problem, and the script will pass. 
