### PR TITLE
Fix the branch alias for master

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.2.x-dev"
+            "dev-master": "1.3.x-dev"
         }
     }
 }


### PR DESCRIPTION
1.3.0 is already released, so the master branch cannot be 1.2.x-dev

I bumped it to 1.3.x as the branch does not currently contain any new feature compared to 1.3.0, so the next release could be 1.3.1 or 1.4.0 and I don't know it yet (it depends of what will happen)