### PR TITLE
Upd ArrayCollection.php (implement JsonSerializable)

### DIFF
--- a/lib/Doctrine/Common/Collections/ArrayCollection.php
+++ b/lib/Doctrine/Common/Collections/ArrayCollection.php
@@ -22,6 +22,7 @@ namespace Doctrine\Common\Collections;
 use ArrayIterator;
 use Closure;
 use Doctrine\Common\Collections\Expr\ClosureExpressionVisitor;
+use JsonSerializable;
 
 /**
  * An ArrayCollection is a Collection implementation that wraps a regular PHP array.
@@ -36,7 +37,7 @@ use Doctrine\Common\Collections\Expr\ClosureExpressionVisitor;
  * @author Jonathan Wage <jonwage@gmail.com>
  * @author Roman Borschel <roman@code-factory.org>
  */
-class ArrayCollection implements Collection, Selectable
+class ArrayCollection implements Collection, Selectable, JsonSerializable
 {
     /**
      * An array containing the entries of this collection.
@@ -61,6 +62,16 @@ class ArrayCollection implements Collection, Selectable
     public function toArray()
     {
         return $this->elements;
+    }
+
+    /**
+     * Returns an array representation of this object.
+     *
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        return $this->toArray();
     }
 
     /**


### PR DESCRIPTION
ArrayCollection can be encoded with json_encode() after implementation of JsonSerializable.
(PHP 5 >= 5.4.0, PHP 7)
http://fi2.php.net/manual/en/class.jsonserializable.php