### PR TITLE
Update ClosureExpressionVisitor.php

### DIFF
--- a/lib/Doctrine/Common/Collections/Expr/ClosureExpressionVisitor.php
+++ b/lib/Doctrine/Common/Collections/Expr/ClosureExpressionVisitor.php
@@ -112,12 +112,12 @@ class ClosureExpressionVisitor extends ExpressionVisitor
         switch ($comparison->getOperator()) {
             case Comparison::EQ:
                 return function ($object) use ($field, $value) {
-                    return ClosureExpressionVisitor::getObjectFieldValue($object, $field) === $value;
+                    return ClosureExpressionVisitor::getObjectFieldValue($object, $field) == $value;
                 };
 
             case Comparison::NEQ:
                 return function ($object) use ($field, $value) {
-                    return ClosureExpressionVisitor::getObjectFieldValue($object, $field) !== $value;
+                    return ClosureExpressionVisitor::getObjectFieldValue($object, $field) != $value;
                 };
 
             case Comparison::LT:


### PR DESCRIPTION
Searching for elements within ArrayCollection using element's \DateTime attributes fails, since until now the comparison uses === instead of ==.

I would like to change the cases ::EQ and ::NEQ – is this ok?

(The matching functionality in PersistentCollection works fine, if I use EXTRA_LAZY...)
