### PR TITLE
Fix: Ignore composer.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 vendor/
+composer.lock


### PR DESCRIPTION
This PR

* [x] adds `composer.lock` to `.gitignore`

:information_desk_person: It's apparently not checked in, so it should be ignored, right?