### PR TITLE
Make the ArrayCollection extendable

### DIFF
--- a/lib/Doctrine/Common/Collections/ArrayCollection.php
+++ b/lib/Doctrine/Common/Collections/ArrayCollection.php
@@ -43,7 +43,7 @@ class ArrayCollection implements Collection, Selectable
      *
      * @var array
      */
-    private $elements;
+    protected $elements;
 
     /**
      * Initializes a new ArrayCollection.


### PR DESCRIPTION
Hello,

I wanted to extends the ArrayCollection of doctrine to add some cool features. But unfortunately the elements are private so I can't implement new methods. I felt too bad (to copy/paste the class entire class) for a so little word like `protected` missing :) .

Of course you can stay on position that you don't want doctrine collection to be inheritable, but if you want that I suggest to set this class final... But I don't get why it would be.