### PR TITLE
Allow null as argument of ArrayCollection->filter() method

### DIFF
--- a/lib/Doctrine/Common/Collections/ArrayCollection.php
+++ b/lib/Doctrine/Common/Collections/ArrayCollection.php
@@ -295,7 +295,7 @@ class ArrayCollection implements Collection, Selectable
     /**
      * {@inheritDoc}
      */
-    public function filter(Closure $p)
+    public function filter(Closure $p = null)
     {
         return new static(array_filter($this->elements, $p));
     }


### PR DESCRIPTION
Allow null as argument of filter() method, same as array_filter does