### PR TITLE
Add unit tests for value and composite expression

### DIFF
--- a/tests/Doctrine/Tests/Common/Collections/Expr/CompositeExpressionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/Expr/CompositeExpressionTest.php
@@ -4,6 +4,7 @@ namespace Doctrine\Tests\Common\Collections\Expr;
 
 use Doctrine\Common\Collections\Expr\CompositeExpression;
 use Doctrine\Common\Collections\Expr\ExpressionVisitor;
+use Doctrine\Common\Collections\Expr\Value;
 use PHPUnit_Framework_TestCase as TestCase;
 
 /**
@@ -13,25 +14,45 @@ use PHPUnit_Framework_TestCase as TestCase;
 class CompositeExpressionTest extends TestCase
 {
     /**
-     * @return CompositeExpression
+     * @return array
      */
-    public function testConstructor()
+    public function invalidDataProvider()
     {
-        $type = CompositeExpression::TYPE_AND;
-        $expressions = array(
-            $this->getMock('Doctrine\Common\Collections\Expr\Expression'),
+        return array(
+            array(
+                'expression' => new Value('value'),
+            ),
+            array(
+                'expression' => 'wrong-type',
+            ),
         );
-
-        return new CompositeExpression($type, $expressions);
     }
 
     /**
-     * @depends testConstructor
+     * @dataProvider invalidDataProvider
      *
-     * @param CompositeExpression $compositeExpression The given expression.
+     * @param $expression
+     * @return void
      */
-    public function testGetType(CompositeExpression $compositeExpression)
+    public function testExceptions($expression)
     {
+        $this->setExpectedException('\RuntimeException');
+
+        $type = CompositeExpression::TYPE_AND;
+        $expressions = array(
+            $expression,
+        );
+
+        new CompositeExpression($type, $expressions);
+    }
+
+    /**
+     * @return void
+     */
+    public function testGetType()
+    {
+        $compositeExpression = $this->createCompositeExpression();
+
         $expectedType = CompositeExpression::TYPE_AND;
         $actualType = $compositeExpression->getType();
 
@@ -39,12 +60,27 @@ class CompositeExpressionTest extends TestCase
     }
 
     /**
-     * @depends testConstructor
-     *
-     * @param CompositeExpression $compositeExpression The given expression.
+     * @return CompositeExpression
      */
-    public function testGetExpressionList(CompositeExpression $compositeExpression)
+    protected function createCompositeExpression()
     {
+        $type = CompositeExpression::TYPE_AND;
+        $expressions = array(
+            $this->getMock('Doctrine\Common\Collections\Expr\Expression'),
+        );
+
+        $compositeExpression = new CompositeExpression($type, $expressions);
+
+        return $compositeExpression;
+    }
+
+    /**
+     * @return void
+     */
+    public function testGetExpressionList()
+    {
+        $compositeExpression = $this->createCompositeExpression();
+
         $expectedExpressionList = array(
             $this->getMock('Doctrine\Common\Collections\Expr\Expression'),
         );
@@ -54,12 +90,12 @@ class CompositeExpressionTest extends TestCase
     }
 
     /**
-     * @depends testConstructor
-     *
-     * @param CompositeExpression $compositeExpression The given expression.
+     * @return void
      */
-    public function testVisitor(CompositeExpression $compositeExpression)
+    public function testVisitor()
     {
+        $compositeExpression = $this->createCompositeExpression();
+
         $visitor = $this->getMockForAbstractClass('Doctrine\Common\Collections\Expr\ExpressionVisitor');
         $visitor
             ->expects($this->once())

--- a/tests/Doctrine/Tests/Common/Collections/Expr/CompositeExpressionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/Expr/CompositeExpressionTest.php
@@ -4,7 +4,6 @@ namespace Doctrine\Tests\Common\Collections\Expr;
 
 use Doctrine\Common\Collections\Expr\CompositeExpression;
 use Doctrine\Common\Collections\Expr\ExpressionVisitor;
-use Doctrine\Common\Collections\Expr\Value;
 use PHPUnit_Framework_TestCase as TestCase;
 
 /**
@@ -17,38 +16,6 @@ use PHPUnit_Framework_TestCase as TestCase;
  */
 class CompositeExpressionTest extends TestCase
 {
-    /**
-     * @return array
-     */
-    public function invalidDataProvider()
-    {
-        return array(
-            array(
-                'expression' => new Value('value'),
-            ),
-            array(
-                'expression' => 'wrong-type',
-            ),
-        );
-    }
-
-    /**
-     * @dataProvider invalidDataProvider
-     *
-     * @param $expression
-     * @return void
-     */
-    public function testExceptions($expression)
-    {
-        $type = CompositeExpression::TYPE_AND;
-        $expressions = array(
-            $expression,
-        );
-
-        $this->setExpectedException('\RuntimeException');
-        $compositeExpression = new CompositeExpression($type, $expressions);
-    }
-
     /**
      * @return CompositeExpression
      */

--- a/tests/Doctrine/Tests/Common/Collections/Expr/CompositeExpressionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/Expr/CompositeExpressionTest.php
@@ -12,11 +12,8 @@ use PHPUnit_Framework_TestCase as TestCase;
  *
  * PHP Version 5
  *
- * @category  PHP
- * @package   Doctrine\Tests\Common\Collections\Expr
- * @author    Tobias Oberrauch <hello@tobiasoberrauch.com>
- *
- * @covers \Doctrine\Common\Collections\Expr\CompositeExpression
+ * @author  Tobias Oberrauch <hello@tobiasoberrauch.com>
+ * @covers  \Doctrine\Common\Collections\Expr\CompositeExpression
  */
 class CompositeExpressionTest extends TestCase
 {

--- a/tests/Doctrine/Tests/Common/Collections/Expr/CompositeExpressionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/Expr/CompositeExpressionTest.php
@@ -7,10 +7,6 @@ use Doctrine\Common\Collections\Expr\ExpressionVisitor;
 use PHPUnit_Framework_TestCase as TestCase;
 
 /**
- * Class CompositeExpressionTest
- *
- * PHP Version 5
- *
  * @author  Tobias Oberrauch <hello@tobiasoberrauch.com>
  * @covers  \Doctrine\Common\Collections\Expr\CompositeExpression
  */

--- a/tests/Doctrine/Tests/Common/Collections/Expr/CompositeExpressionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/Expr/CompositeExpressionTest.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Doctrine\Tests\Common\Collections\Expr;
+
+use Doctrine\Common\Collections\Expr\CompositeExpression;
+use Doctrine\Common\Collections\Expr\ExpressionVisitor;
+use Doctrine\Common\Collections\Expr\Value;
+use PHPUnit_Framework_TestCase as TestCase;
+
+/**
+ * Class CompositeExpressionTest
+ *
+ * PHP Version 5
+ *
+ * @category  PHP
+ * @package   Doctrine\Tests\Common\Collections\Expr
+ * @author    Tobias Oberrauch <hello@tobiasoberrauch.com>
+ *
+ * @covers \Doctrine\Common\Collections\Expr\CompositeExpression
+ */
+class CompositeExpressionTest extends TestCase
+{
+    /**
+     * @return array
+     */
+    public function invalidDataProvider()
+    {
+        return array(
+            array(
+                'expression' => new Value('value'),
+            ),
+            array(
+                'expression' => 'wrong-type',
+            ),
+        );
+    }
+
+    /**
+     * @dataProvider invalidDataProvider
+     *
+     * @param $expression
+     * @return void
+     */
+    public function testExceptions($expression)
+    {
+        $this->setExpectedException('\RuntimeException');
+
+        $type = CompositeExpression::TYPE_AND;
+        $expressions = array(
+            $expression,
+        );
+
+        $compositeExpression = new CompositeExpression($type, $expressions);
+    }
+
+    /**
+     * @return CompositeExpression
+     */
+    public function testConstructor()
+    {
+        $type = CompositeExpression::TYPE_AND;
+        $expressions = array(
+            $this->getMock('Doctrine\Common\Collections\Expr\Expression'),
+        );
+
+        return new CompositeExpression($type, $expressions);
+    }
+
+    /**
+     * @depends testConstructor
+     *
+     * @param CompositeExpression $compositeExpression The given expression.
+     */
+    public function testGetType(CompositeExpression $compositeExpression)
+    {
+        $expectedType = CompositeExpression::TYPE_AND;
+        $actualType = $compositeExpression->getType();
+
+        $this->assertSame($expectedType, $actualType);
+    }
+
+    /**
+     * @depends testConstructor
+     *
+     * @param CompositeExpression $compositeExpression The given expression.
+     */
+    public function testGetExpressionList(CompositeExpression $compositeExpression)
+    {
+        $expectedExpressionList = array(
+            $this->getMock('Doctrine\Common\Collections\Expr\Expression'),
+        );
+        $actualExpressionList = $compositeExpression->getExpressionList();
+
+        $this->assertEquals($expectedExpressionList, $actualExpressionList);
+    }
+
+    /**
+     * @depends testConstructor
+     *
+     * @param CompositeExpression $compositeExpression The given expression.
+     */
+    public function testVisitor(CompositeExpression $compositeExpression)
+    {
+        $visitor = $this->getMockForAbstractClass('Doctrine\Common\Collections\Expr\ExpressionVisitor');
+        $visitor
+            ->expects($this->once())
+            ->method('walkCompositeExpression');
+
+        /** @var ExpressionVisitor $visitor */
+        $compositeExpression->visit($visitor);
+    }
+}

--- a/tests/Doctrine/Tests/Common/Collections/Expr/CompositeExpressionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/Expr/CompositeExpressionTest.php
@@ -40,13 +40,12 @@ class CompositeExpressionTest extends TestCase
      */
     public function testExceptions($expression)
     {
-        $this->setExpectedException('\RuntimeException');
-
         $type = CompositeExpression::TYPE_AND;
         $expressions = array(
             $expression,
         );
 
+        $this->setExpectedException('\RuntimeException');
         $compositeExpression = new CompositeExpression($type, $expressions);
     }
 

--- a/tests/Doctrine/Tests/Common/Collections/Expr/CompositeExpressionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/Expr/CompositeExpressionTest.php
@@ -36,13 +36,12 @@ class CompositeExpressionTest extends TestCase
      */
     public function testExceptions($expression)
     {
-        $this->setExpectedException('\RuntimeException');
-
         $type = CompositeExpression::TYPE_AND;
         $expressions = array(
             $expression,
         );
 
+        $this->setExpectedException('\RuntimeException');
         new CompositeExpression($type, $expressions);
     }
 

--- a/tests/Doctrine/Tests/Common/Collections/Expr/ValueTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/Expr/ValueTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Doctrine\Tests\Common\Collections\Expr;
+
+use Doctrine\Common\Collections\Expr\ExpressionVisitor;
+use Doctrine\Common\Collections\Expr\Value;
+use PHPUnit_Framework_TestCase as TestCase;
+
+/**
+ * Class ValueTest
+ *
+ * PHP Version 5
+ *
+ * @category  PHP
+ * @package   Doctrine\Tests\Common\Collections\Expr
+ * @author    Tobias Oberrauch <hello@tobiasoberrauch.com>
+ *
+ * @covers \Doctrine\Common\Collections\Expr\Value
+ */
+class ValueTest extends TestCase
+{
+    /**
+     * @return void
+     */
+    public function testGetter()
+    {
+        $value = 'foo';
+        $valueExpression = new Value($value);
+
+        $actualValue = $valueExpression->getValue();
+
+        $this->assertEquals($value, $actualValue);
+    }
+
+    /**
+     * @return void
+     */
+    public function testVisitor()
+    {
+        $visitor = $this->getMockForAbstractClass('Doctrine\Common\Collections\Expr\ExpressionVisitor');
+        $visitor
+            ->expects($this->once())
+            ->method('walkValue');
+
+        /** @var ExpressionVisitor $visitor */
+        $value = 'foo';
+        $valueExpression = new Value($value);
+        $valueExpression->visit($visitor);
+    }
+}

--- a/tests/Doctrine/Tests/Common/Collections/Expr/ValueTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/Expr/ValueTest.php
@@ -11,11 +11,8 @@ use PHPUnit_Framework_TestCase as TestCase;
  *
  * PHP Version 5
  *
- * @category  PHP
- * @package   Doctrine\Tests\Common\Collections\Expr
- * @author    Tobias Oberrauch <hello@tobiasoberrauch.com>
- *
- * @covers \Doctrine\Common\Collections\Expr\Value
+ * @author  Tobias Oberrauch <hello@tobiasoberrauch.com>
+ * @covers  \Doctrine\Common\Collections\Expr\Value
  */
 class ValueTest extends TestCase
 {

--- a/tests/Doctrine/Tests/Common/Collections/Expr/ValueTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/Expr/ValueTest.php
@@ -7,10 +7,6 @@ use Doctrine\Common\Collections\Expr\Value;
 use PHPUnit_Framework_TestCase as TestCase;
 
 /**
- * Class ValueTest
- *
- * PHP Version 5
- *
  * @author  Tobias Oberrauch <hello@tobiasoberrauch.com>
  * @covers  \Doctrine\Common\Collections\Expr\Value
  */


### PR DESCRIPTION
I added two unit tests. One for ValueExpression and the other for CompositeExpression.
The @covers annotation defines clearly which class I want to test (Subject under test)

I hope that this will fit to the standards :)
Cheers Tobias