### PR TITLE
Null as default value of first() and last()

### DIFF
--- a/lib/Doctrine/Common/Collections/ArrayCollection.php
+++ b/lib/Doctrine/Common/Collections/ArrayCollection.php
@@ -79,6 +79,9 @@ class ArrayCollection implements Collection, Selectable
      */
     public function last()
     {
+        if (!$this->elements) {
+            return null;
+        }
         return end($this->elements);
     }
 

--- a/lib/Doctrine/Common/Collections/ArrayCollection.php
+++ b/lib/Doctrine/Common/Collections/ArrayCollection.php
@@ -68,6 +68,9 @@ class ArrayCollection implements Collection, Selectable
      */
     public function first()
     {
+        if (!$this->elements) {
+            return null;
+        }
         return reset($this->elements);
     }
 

--- a/lib/Doctrine/Common/Collections/Collection.php
+++ b/lib/Doctrine/Common/Collections/Collection.php
@@ -152,9 +152,9 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
     public function toArray();
 
     /**
-     * Sets the internal iterator to the first element in the collection and returns this element.
+     * Sets the internal iterator to the first element in the collection and returns this element (or null if no element).
      *
-     * @return mixed
+     * @return mixed|null
      */
     public function first();
 

--- a/lib/Doctrine/Common/Collections/Collection.php
+++ b/lib/Doctrine/Common/Collections/Collection.php
@@ -159,9 +159,9 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
     public function first();
 
     /**
-     * Sets the internal iterator to the last element in the collection and returns this element.
+     * Sets the internal iterator to the last element in the collection and returns this element (or null if no element).
      *
-     * @return mixed
+     * @return mixed|null
      */
     public function last();
 

--- a/tests/Doctrine/Tests/Common/Collections/ArrayCollectionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/ArrayCollectionTest.php
@@ -48,6 +48,12 @@ class ArrayCollectionTest extends \PHPUnit_Framework_TestCase
         $this->assertSame(reset($elements), $collection->first());
     }
 
+    public function testFirstWithEmptyElements()
+    {
+        $collection = new ArrayCollection([]);
+        $this->assertNull($collection->first());
+    }
+
     /**
      * @dataProvider provideDifferentElements
      */
@@ -163,6 +169,7 @@ class ArrayCollectionTest extends \PHPUnit_Framework_TestCase
             'indexed'     => array(array(1, 2, 3, 4, 5)),
             'associative' => array(array('A' => 'a', 'B' => 'b', 'C' => 'c')),
             'mixed'       => array(array('A' => 'a', 1, 'B' => 'b', 2, 3)),
+            'falsy'       => array(array(false)),
         );
     }
 

--- a/tests/Doctrine/Tests/Common/Collections/ArrayCollectionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/ArrayCollectionTest.php
@@ -63,6 +63,12 @@ class ArrayCollectionTest extends \PHPUnit_Framework_TestCase
         $this->assertSame(end($elements), $collection->last());
     }
 
+    public function testLastWithEmptyElements()
+    {
+        $collection = new ArrayCollection([]);
+        $this->assertNull($collection->last());
+    }
+
     /**
      * @dataProvider provideDifferentElements
      */


### PR DESCRIPTION
Change first() and last() methods to return NULL as default value.
Because NULL is the default value of an object when we use type hinting, we can give directly the result of first/last method without worry to know if there is an object in the collection.

So, allow to code this:

```
function foo (Bar $bar = null) { /*...*/ }

$collection = new ArrayCollection();
foo($collection->first());
```

Instead of:

```
function foo (Bar $bar = null) { /*...*/ }

$collection = new ArrayCollection();
foo($collection->first() ? $collection->first() : null);
```

