### PR TITLE
Add Criteria::fromFindCriteria

### DIFF
--- a/lib/Doctrine/Common/Collections/Criteria.php
+++ b/lib/Doctrine/Common/Collections/Criteria.php
@@ -76,6 +76,31 @@ class Criteria
     }
 
     /**
+     * Creates an instance with same behaviour as criteria parameters passed on ORM find methods.
+     *
+     * @param mixed[] $findCriteria Array of different keys and values. Gets the same format as argument expected on
+     *                              Doctrine\Common\Persistence\ObjectRepository::findBy and
+     *                              Doctrine\Common\Persistence\ObjectRepository::findOneBy methods.
+     *
+     * @return Criteria
+     */
+    public static function fromFindCriteria(array $findCriteria)
+    {
+        $criteria = static::create();
+
+        foreach ($findCriteria as $key => $value) {
+            $criteria->andWhere(!is_array($value)
+                ? static::expr()->eq($key, $value)
+                : new CompositeExpression(CompositeExpression::TYPE_OR, \array_map(function ($v) use ($key) {
+                    return static::expr()->eq($key, $v);
+                }, $value))
+            );
+        }
+
+        return $criteria;
+    }
+
+    /**
      * Returns the expression builder.
      *
      * @return \Doctrine\Common\Collections\ExpressionBuilder

--- a/tests/Doctrine/Tests/Common/Collections/CriteriaTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/CriteriaTest.php
@@ -16,6 +16,21 @@ class CriteriaTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf(Criteria::class, $criteria);
     }
 
+    public function testFromFindCriteria() : void
+    {
+        $criteria = Criteria::fromFindCriteria(['name' => 'test', 'foo' => [42, 1337]]);
+
+        /** @var CompositeExpression $where */
+        $where = $criteria->getWhereExpression();
+        $this->assertInstanceOf(CompositeExpression::class, $where);
+
+        $this->assertSame(CompositeExpression::TYPE_AND, $where->getType());
+        $this->assertCount(2, $where->getExpressionList());
+        $this->assertInstanceOf(Comparison::class, $where->getExpressionList()[0]);
+        $this->assertInstanceOf(CompositeExpression::class, $where->getExpressionList()[1]);
+        $this->assertSame(CompositeExpression::TYPE_OR, $where->getExpressionList()[1]->getType());
+    }
+
     public function testConstructor() : void
     {
         $expr     = new Comparison("field", "=", "value");


### PR DESCRIPTION
## Subject

The goals is to be able to quick reproduce a criteria looking like parameters given to ORM find methods.
## Concrete case

On a REST controller action, I would like to setup basic filter and apply them with the `findBy` method of the ORM.

I have a `Server` entity containing many `User` entities.

When the user calling the api method is not an admin, I have to filter the server list to get only related ones.

But the `findBy` does not allow us to do a search on a `ManyToMany` relationship.

I would like to keep same method on criteria to apply it on a query builder:

``` php
public function cgetAction(ParamFetcherInterface $paramFetcher)
{
    $view = $this->view();

    $filters = [
        'name' => $paramFetcher->get('name'),
    ];
    $filters = array_filter($filters, function ($value) {
        return null !== $value;
    });

    if ($this->get('admin.server')->isGranted('LIST')) {
        $servers = $this->getDoctrine()->getRepository('AppBundle:Server')->findBy($filters);
        $view->getSerializationContext()->setGroups(['list', 'list_admin']);
    } else {
        $servers = $this->getDoctrine()->getRepository('AppBundle:Server')->getByOwnerQB($this->getUser())
            ->addCriteria(Criteria::fromFindCriteria($filters))
            ->getQuery()->getResult();
        $view->getSerializationContext()->setGroups('list');
    }

    $view->setData($servers);

    return $view;
}
```

Having this method would simplify the logic.
