### PR TITLE
Add same field name method accessor support to ClosureExpressionVisitor#getObjectFieldValue.

### DIFF
--- a/lib/Doctrine/Common/Collections/Expr/ClosureExpressionVisitor.php
+++ b/lib/Doctrine/Common/Collections/Expr/ClosureExpressionVisitor.php
@@ -32,8 +32,8 @@ class ClosureExpressionVisitor extends ExpressionVisitor
 {
     /**
      * Accesses the field of a given object. This field has to be public
-     * directly or indirectly (through an accessor get*, is*, or a magic
-     * method, __get, __call).
+     * directly or indirectly (through a method with the same name,
+     * an accessor get*, is*, or a magic method, __get, __call).
      *
      * @param object $object
      * @param string $field
@@ -44,6 +44,11 @@ class ClosureExpressionVisitor extends ExpressionVisitor
     {
         if (is_array($object)) {
             return $object[$field];
+        }
+
+        if (method_exists($object, $field))
+        {
+            return $object->$field();
         }
 
         $accessors = array('get', 'is');

--- a/tests/Doctrine/Tests/Common/Collections/ClosureExpressionVisitorTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/ClosureExpressionVisitorTest.php
@@ -93,6 +93,13 @@ class ClosureExpressionVisitorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(3, $this->visitor->getObjectFieldValue($object, 'qux'));
     }
 
+    public function testGetObjectFieldValueSameNameMethod()
+    {
+        $object = new TestObject(1, 2, true, 3, 4);
+
+        $this->assertEquals(4, $this->visitor->getObjectFieldValue($object, 'quux'));
+    }
+
     public function testWalkEqualsComparison()
     {
         $closure = $this->visitor->walkComparison($this->builder->eq("foo", 1));
@@ -277,13 +284,15 @@ class TestObject
     private $bar;
     private $baz;
     private $qux;
+    private $quux;
 
-    public function __construct($foo = null, $bar = null, $baz = null, $qux = null)
+    public function __construct($foo = null, $bar = null, $baz = null, $qux = null, $quux = null)
     {
-        $this->foo = $foo;
-        $this->bar = $bar;
-        $this->baz = $baz;
-        $this->qux = $qux;
+        $this->foo  = $foo;
+        $this->bar  = $bar;
+        $this->baz  = $baz;
+        $this->qux  = $qux;
+        $this->quux = $quux;
     }
 
     public function __call($name, $arguments)
@@ -306,6 +315,11 @@ class TestObject
     public function isBaz()
     {
         return $this->baz;
+    }
+
+    public function quux()
+    {
+        return $this->quux;
     }
 }
 


### PR DESCRIPTION
It's been an extended practice using the same name of a private property for the method returning its value. Actually getObjectFieldValue don't check for the existence of a method with the field name, only is*, get*, the field itself if it's public, or using `__get` or `__call` magic methods.

I've added the implementation and additional tests to include this feature.