### PR TITLE
Add extension point to match conditions using closure

### DIFF
--- a/lib/Doctrine/Common/Collections/Expr/ClosureExpressionVisitor.php
+++ b/lib/Doctrine/Common/Collections/Expr/ClosureExpressionVisitor.php
@@ -124,78 +124,7 @@ class ClosureExpressionVisitor extends ExpressionVisitor
      */
     public function walkComparison(Comparison $comparison)
     {
-        $field = $comparison->getField();
-        $value = $comparison->getValue()->getValue(); // shortcut for walkValue()
-
-        switch ($comparison->getOperator()) {
-            case Comparison::EQ:
-                return function ($object) use ($field, $value) {
-                    return ClosureExpressionVisitor::getObjectFieldValue($object, $field) === $value;
-                };
-
-            case Comparison::NEQ:
-                return function ($object) use ($field, $value) {
-                    return ClosureExpressionVisitor::getObjectFieldValue($object, $field) !== $value;
-                };
-
-            case Comparison::LT:
-                return function ($object) use ($field, $value) {
-                    return ClosureExpressionVisitor::getObjectFieldValue($object, $field) < $value;
-                };
-
-            case Comparison::LTE:
-                return function ($object) use ($field, $value) {
-                    return ClosureExpressionVisitor::getObjectFieldValue($object, $field) <= $value;
-                };
-
-            case Comparison::GT:
-                return function ($object) use ($field, $value) {
-                    return ClosureExpressionVisitor::getObjectFieldValue($object, $field) > $value;
-                };
-
-            case Comparison::GTE:
-                return function ($object) use ($field, $value) {
-                    return ClosureExpressionVisitor::getObjectFieldValue($object, $field) >= $value;
-                };
-
-            case Comparison::IN:
-                return function ($object) use ($field, $value) {
-                    return in_array(ClosureExpressionVisitor::getObjectFieldValue($object, $field), $value);
-                };
-
-            case Comparison::NIN:
-                return function ($object) use ($field, $value) {
-                    return ! in_array(ClosureExpressionVisitor::getObjectFieldValue($object, $field), $value);
-                };
-
-            case Comparison::CONTAINS:
-                return function ($object) use ($field, $value) {
-                    return false !== strpos(ClosureExpressionVisitor::getObjectFieldValue($object, $field), $value);
-                };
-
-            case Comparison::MEMBER_OF:
-                return function ($object) use ($field, $value) {
-                    $fieldValues = ClosureExpressionVisitor::getObjectFieldValue($object, $field);
-                    if (!is_array($fieldValues)) {
-                        $fieldValues = iterator_to_array($fieldValues);
-                    }
-                    return in_array($value, $fieldValues);
-                };
-
-            case Comparison::STARTS_WITH:
-                return function ($object) use ($field, $value) {
-                    return 0 === strpos(ClosureExpressionVisitor::getObjectFieldValue($object, $field), $value);
-                };
-
-            case Comparison::ENDS_WITH:
-                return function ($object) use ($field, $value) {
-                    return $value === substr(ClosureExpressionVisitor::getObjectFieldValue($object, $field), -strlen($value));
-                };
-
-
-            default:
-                throw new \RuntimeException("Unknown comparison operator: " . $comparison->getOperator());
-        }
+        return $comparison->getFilterCallback();
     }
 
     /**

--- a/lib/Doctrine/Common/Collections/Expr/Comparison.php
+++ b/lib/Doctrine/Common/Collections/Expr/Comparison.php
@@ -39,7 +39,7 @@ class Comparison implements Expression
     const CONTAINS   = 'CONTAINS';
     const MEMBER_OF  = 'MEMBER_OF';
     const STARTS_WITH  = 'STARTS_WITH';
-    const ENDS_WITH    = 'ENDS_WITH';    
+    const ENDS_WITH    = 'ENDS_WITH';
     /**
      * @var string
      */
@@ -101,5 +101,14 @@ class Comparison implements Expression
     public function visit(ExpressionVisitor $visitor)
     {
         return $visitor->walkComparison($this);
+    }
+
+    /**
+     * @return \Closure
+     */
+    public function getFilterCallback()
+    {
+        // todo should be abstract, defined for BC
+        throw new \RuntimeException(__METHOD__ . ' is not defined yet, you can override it.');
     }
 }

--- a/lib/Doctrine/Common/Collections/Expr/Comparison/Contains.php
+++ b/lib/Doctrine/Common/Collections/Expr/Comparison/Contains.php
@@ -1,0 +1,55 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\Common\Collections\Expr\Comparison;
+
+use Doctrine\Common\Collections\Expr\ClosureExpressionVisitor;
+use Doctrine\Common\Collections\Expr\Comparison;
+use Doctrine\Common\Collections\Expr\Value;
+
+/**
+ * @author Yannick Voyer (http://github.com/yvoyer)
+ */
+final class Contains extends Comparison
+{
+    /**
+     * @param string $field
+     * @param mixed|Value $value
+     */
+    public function __construct($field, $value)
+    {
+        parent::__construct($field, Comparison::CONTAINS, $value);
+    }
+
+    /**
+     * @return callable
+     */
+    public function getFilterCallback()
+    {
+        $value = $this->getValue()->getValue();
+        $field = $this->getField();
+
+        return function ($object) use ($value, $field) {
+            return false !== strpos(
+                ClosureExpressionVisitor::getObjectFieldValue($object, $field),
+                $value
+            );
+        };
+    }
+}

--- a/lib/Doctrine/Common/Collections/Expr/Comparison/EndsWith.php
+++ b/lib/Doctrine/Common/Collections/Expr/Comparison/EndsWith.php
@@ -1,0 +1,55 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\Common\Collections\Expr\Comparison;
+
+use Doctrine\Common\Collections\Expr\ClosureExpressionVisitor;
+use Doctrine\Common\Collections\Expr\Comparison;
+use Doctrine\Common\Collections\Expr\Value;
+
+/**
+ * @author Yannick Voyer (http://github.com/yvoyer)
+ */
+final class EndsWith extends Comparison
+{
+    /**
+     * @param string $field
+     * @param mixed|Value $value
+     */
+    public function __construct($field, $value)
+    {
+        parent::__construct($field, Comparison::ENDS_WITH, $value);
+    }
+
+    /**
+     * @return callable
+     */
+    public function getFilterCallback()
+    {
+        $value = $this->getValue()->getValue();
+        $field = $this->getField();
+
+        return function ($object) use ($value, $field) {
+            return $value === substr(
+                ClosureExpressionVisitor::getObjectFieldValue($object, $field),
+                -strlen($this->getValue()->getValue())
+            );
+        };
+    }
+}

--- a/lib/Doctrine/Common/Collections/Expr/Comparison/Equal.php
+++ b/lib/Doctrine/Common/Collections/Expr/Comparison/Equal.php
@@ -1,0 +1,52 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\Common\Collections\Expr\Comparison;
+
+use Doctrine\Common\Collections\Expr\ClosureExpressionVisitor;
+use Doctrine\Common\Collections\Expr\Comparison;
+use Doctrine\Common\Collections\Expr\Value;
+
+/**
+ * @author Yannick Voyer (http://github.com/yvoyer)
+ */
+final class Equal extends Comparison
+{
+    /**
+     * @param string $field
+     * @param mixed|Value $value
+     */
+    public function __construct($field, $value)
+    {
+        parent::__construct($field, Comparison::EQ, $value);
+    }
+
+    /**
+     * @return callable
+     */
+    public function getFilterCallback()
+    {
+        $value = $this->getValue()->getValue();
+        $field = $this->getField();
+
+        return function ($object) use ($value, $field) {
+            return ClosureExpressionVisitor::getObjectFieldValue($object, $field) === $value;
+        };
+    }
+}

--- a/lib/Doctrine/Common/Collections/Expr/Comparison/GreaterThan.php
+++ b/lib/Doctrine/Common/Collections/Expr/Comparison/GreaterThan.php
@@ -1,0 +1,52 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\Common\Collections\Expr\Comparison;
+
+use Doctrine\Common\Collections\Expr\ClosureExpressionVisitor;
+use Doctrine\Common\Collections\Expr\Comparison;
+use Doctrine\Common\Collections\Expr\Value;
+
+/**
+ * @author Yannick Voyer (http://github.com/yvoyer)
+ */
+final class GreaterThan extends Comparison
+{
+    /**
+     * @param string $field
+     * @param mixed|Value $value
+     */
+    public function __construct($field, $value)
+    {
+        parent::__construct($field, Comparison::GT, $value);
+    }
+
+    /**
+     * @return callable
+     */
+    public function getFilterCallback()
+    {
+        $value = $this->getValue()->getValue();
+        $field = $this->getField();
+
+        return function ($object) use ($value, $field) {
+            return ClosureExpressionVisitor::getObjectFieldValue($object, $field) > $value;
+        };
+    }
+}

--- a/lib/Doctrine/Common/Collections/Expr/Comparison/GreaterThanEqual.php
+++ b/lib/Doctrine/Common/Collections/Expr/Comparison/GreaterThanEqual.php
@@ -1,0 +1,52 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\Common\Collections\Expr\Comparison;
+
+use Doctrine\Common\Collections\Expr\ClosureExpressionVisitor;
+use Doctrine\Common\Collections\Expr\Comparison;
+use Doctrine\Common\Collections\Expr\Value;
+
+/**
+ * @author Yannick Voyer (http://github.com/yvoyer)
+ */
+final class GreaterThanEqual extends Comparison
+{
+    /**
+     * @param string $field
+     * @param mixed|Value $value
+     */
+    public function __construct($field, $value)
+    {
+        parent::__construct($field, Comparison::GTE, $value);
+    }
+
+    /**
+     * @return callable
+     */
+    public function getFilterCallback()
+    {
+        $value = $this->getValue()->getValue();
+        $field = $this->getField();
+
+        return function ($object) use ($value, $field) {
+            return ClosureExpressionVisitor::getObjectFieldValue($object, $field) >= $value;
+        };
+    }
+}

--- a/lib/Doctrine/Common/Collections/Expr/Comparison/In.php
+++ b/lib/Doctrine/Common/Collections/Expr/Comparison/In.php
@@ -1,0 +1,52 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\Common\Collections\Expr\Comparison;
+
+use Doctrine\Common\Collections\Expr\ClosureExpressionVisitor;
+use Doctrine\Common\Collections\Expr\Comparison;
+use Doctrine\Common\Collections\Expr\Value;
+
+/**
+ * @author Yannick Voyer (http://github.com/yvoyer)
+ */
+final class In extends Comparison
+{
+    /**
+     * @param string $field
+     * @param mixed|Value $value
+     */
+    public function __construct($field, $value)
+    {
+        parent::__construct($field, Comparison::IN, $value);
+    }
+
+    /**
+     * @return callable
+     */
+    public function getFilterCallback()
+    {
+        $value = $this->getValue()->getValue();
+        $field = $this->getField();
+
+        return function ($object) use ($value, $field) {
+            return in_array(ClosureExpressionVisitor::getObjectFieldValue($object, $field), $value);
+        };
+    }
+}

--- a/lib/Doctrine/Common/Collections/Expr/Comparison/LowerThan.php
+++ b/lib/Doctrine/Common/Collections/Expr/Comparison/LowerThan.php
@@ -1,0 +1,52 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\Common\Collections\Expr\Comparison;
+
+use Doctrine\Common\Collections\Expr\ClosureExpressionVisitor;
+use Doctrine\Common\Collections\Expr\Comparison;
+use Doctrine\Common\Collections\Expr\Value;
+
+/**
+ * @author Yannick Voyer (http://github.com/yvoyer)
+ */
+final class LowerThan extends Comparison
+{
+    /**
+     * @param string $field
+     * @param mixed|Value $value
+     */
+    public function __construct($field, $value)
+    {
+        parent::__construct($field, Comparison::LT, $value);
+    }
+
+    /**
+     * @return callable
+     */
+    public function getFilterCallback()
+    {
+        $value = $this->getValue()->getValue();
+        $field = $this->getField();
+
+        return function ($object) use ($value, $field) {
+            return ClosureExpressionVisitor::getObjectFieldValue($object, $field) < $value;
+        };
+    }
+}

--- a/lib/Doctrine/Common/Collections/Expr/Comparison/LowerThanEqual.php
+++ b/lib/Doctrine/Common/Collections/Expr/Comparison/LowerThanEqual.php
@@ -1,0 +1,52 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\Common\Collections\Expr\Comparison;
+
+use Doctrine\Common\Collections\Expr\ClosureExpressionVisitor;
+use Doctrine\Common\Collections\Expr\Comparison;
+use Doctrine\Common\Collections\Expr\Value;
+
+/**
+ * @author Yannick Voyer (http://github.com/yvoyer)
+ */
+final class LowerThanEqual extends Comparison
+{
+    /**
+     * @param string $field
+     * @param mixed|Value $value
+     */
+    public function __construct($field, $value)
+    {
+        parent::__construct($field, Comparison::LTE, $value);
+    }
+
+    /**
+     * @return callable
+     */
+    public function getFilterCallback()
+    {
+        $value = $this->getValue()->getValue();
+        $field = $this->getField();
+
+        return function ($object) use ($value, $field) {
+            return ClosureExpressionVisitor::getObjectFieldValue($object, $field) <= $value;
+        };
+    }
+}

--- a/lib/Doctrine/Common/Collections/Expr/Comparison/MatchClosure.php
+++ b/lib/Doctrine/Common/Collections/Expr/Comparison/MatchClosure.php
@@ -1,0 +1,49 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\Common\Collections\Expr\Comparison;
+
+use Doctrine\Common\Collections\Expr\Comparison;
+
+/**
+ * @author Yannick Voyer (http://github.com/yvoyer)
+ */
+final class MatchClosure extends Comparison
+{
+    /**
+     * @var \Closure
+     */
+    private $closure;
+
+    /**
+     * @param callable $closure
+     */
+    public function __construct(\Closure $closure)
+    {
+        $this->closure = $closure;
+    }
+
+    /**
+     * @return \Closure
+     */
+    public function getFilterCallback()
+    {
+        return $this->closure;
+    }
+}

--- a/lib/Doctrine/Common/Collections/Expr/Comparison/MemberOf.php
+++ b/lib/Doctrine/Common/Collections/Expr/Comparison/MemberOf.php
@@ -1,0 +1,56 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\Common\Collections\Expr\Comparison;
+
+use Doctrine\Common\Collections\Expr\ClosureExpressionVisitor;
+use Doctrine\Common\Collections\Expr\Comparison;
+use Doctrine\Common\Collections\Expr\Value;
+
+/**
+ * @author Yannick Voyer (http://github.com/yvoyer)
+ */
+final class MemberOf extends Comparison
+{
+    /**
+     * @param string $field
+     * @param mixed|Value $value
+     */
+    public function __construct($field, $value)
+    {
+        parent::__construct($field, Comparison::MEMBER_OF, $value);
+    }
+
+    /**
+     * @return callable
+     */
+    public function getFilterCallback()
+    {
+        $value = $this->getValue()->getValue();
+        $field = $this->getField();
+
+        return function ($object) use ($value, $field) {
+            $fieldValues = ClosureExpressionVisitor::getObjectFieldValue($object, $field);
+            if (!is_array($fieldValues)) {
+                $fieldValues = iterator_to_array($fieldValues);
+            }
+            return in_array($value, $fieldValues);
+        };
+    }
+}

--- a/lib/Doctrine/Common/Collections/Expr/Comparison/NotEqual.php
+++ b/lib/Doctrine/Common/Collections/Expr/Comparison/NotEqual.php
@@ -1,0 +1,52 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\Common\Collections\Expr\Comparison;
+
+use Doctrine\Common\Collections\Expr\ClosureExpressionVisitor;
+use Doctrine\Common\Collections\Expr\Comparison;
+use Doctrine\Common\Collections\Expr\Value;
+
+/**
+ * @author Yannick Voyer (http://github.com/yvoyer)
+ */
+final class NotEqual extends Comparison
+{
+    /**
+     * @param string $field
+     * @param mixed|Value $value
+     */
+    public function __construct($field, $value)
+    {
+        parent::__construct($field, Comparison::NEQ, $value);
+    }
+
+    /**
+     * @return callable
+     */
+    public function getFilterCallback()
+    {
+        $value = $this->getValue()->getValue();
+        $field = $this->getField();
+
+        return function ($object) use ($value, $field) {
+            return ClosureExpressionVisitor::getObjectFieldValue($object, $field) !== $value;
+        };
+    }
+}

--- a/lib/Doctrine/Common/Collections/Expr/Comparison/NotIn.php
+++ b/lib/Doctrine/Common/Collections/Expr/Comparison/NotIn.php
@@ -1,0 +1,52 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\Common\Collections\Expr\Comparison;
+
+use Doctrine\Common\Collections\Expr\ClosureExpressionVisitor;
+use Doctrine\Common\Collections\Expr\Comparison;
+use Doctrine\Common\Collections\Expr\Value;
+
+/**
+ * @author Yannick Voyer (http://github.com/yvoyer)
+ */
+final class NotIn extends Comparison
+{
+    /**
+     * @param string $field
+     * @param mixed|Value $value
+     */
+    public function __construct($field, $value)
+    {
+        parent::__construct($field, Comparison::NIN, $value);
+    }
+
+    /**
+     * @return callable
+     */
+    public function getFilterCallback()
+    {
+        $value = $this->getValue()->getValue();
+        $field = $this->getField();
+
+        return function ($object) use ($value, $field) {
+            return ! in_array(ClosureExpressionVisitor::getObjectFieldValue($object, $field), $value);
+        };
+    }
+}

--- a/lib/Doctrine/Common/Collections/Expr/Comparison/StartsWith.php
+++ b/lib/Doctrine/Common/Collections/Expr/Comparison/StartsWith.php
@@ -1,0 +1,52 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\Common\Collections\Expr\Comparison;
+
+use Doctrine\Common\Collections\Expr\ClosureExpressionVisitor;
+use Doctrine\Common\Collections\Expr\Comparison;
+use Doctrine\Common\Collections\Expr\Value;
+
+/**
+ * @author Yannick Voyer (http://github.com/yvoyer)
+ */
+final class StartsWith extends Comparison
+{
+    /**
+     * @param string $field
+     * @param mixed|Value $value
+     */
+    public function __construct($field, $value)
+    {
+        parent::__construct($field, Comparison::STARTS_WITH, $value);
+    }
+
+    /**
+     * @return callable
+     */
+    public function getFilterCallback()
+    {
+        $value = $this->getValue()->getValue();
+        $field = $this->getField();
+
+        return function ($object) use ($value, $field) {
+            return 0 === strpos(ClosureExpressionVisitor::getObjectFieldValue($object, $field), $value);
+        };
+    }
+}

--- a/lib/Doctrine/Common/Collections/ExpressionBuilder.php
+++ b/lib/Doctrine/Common/Collections/ExpressionBuilder.php
@@ -63,7 +63,7 @@ class ExpressionBuilder
      */
     public function eq($field, $value)
     {
-        return new Comparison($field, Comparison::EQ, new Value($value));
+        return new Comparison\Equal($field, new Value($value));
     }
 
     /**
@@ -74,7 +74,7 @@ class ExpressionBuilder
      */
     public function gt($field, $value)
     {
-        return new Comparison($field, Comparison::GT, new Value($value));
+        return new Comparison\GreaterThan($field, new Value($value));
     }
 
     /**
@@ -85,7 +85,7 @@ class ExpressionBuilder
      */
     public function lt($field, $value)
     {
-        return new Comparison($field, Comparison::LT, new Value($value));
+        return new Comparison\LowerThan($field, new Value($value));
     }
 
     /**
@@ -96,7 +96,7 @@ class ExpressionBuilder
      */
     public function gte($field, $value)
     {
-        return new Comparison($field, Comparison::GTE, new Value($value));
+        return new Comparison\GreaterThanEqual($field, new Value($value));
     }
 
     /**
@@ -107,7 +107,7 @@ class ExpressionBuilder
      */
     public function lte($field, $value)
     {
-        return new Comparison($field, Comparison::LTE, new Value($value));
+        return new Comparison\LowerThanEqual($field, new Value($value));
     }
 
     /**
@@ -118,7 +118,7 @@ class ExpressionBuilder
      */
     public function neq($field, $value)
     {
-        return new Comparison($field, Comparison::NEQ, new Value($value));
+        return new Comparison\NotEqual($field, new Value($value));
     }
 
     /**
@@ -128,7 +128,7 @@ class ExpressionBuilder
      */
     public function isNull($field)
     {
-        return new Comparison($field, Comparison::EQ, new Value(null));
+        return new Comparison\Equal($field, new Value(null));
     }
 
     /**
@@ -139,7 +139,7 @@ class ExpressionBuilder
      */
     public function in($field, array $values)
     {
-        return new Comparison($field, Comparison::IN, new Value($values));
+        return new Comparison\In($field, new Value($values));
     }
 
     /**
@@ -150,7 +150,7 @@ class ExpressionBuilder
      */
     public function notIn($field, array $values)
     {
-        return new Comparison($field, Comparison::NIN, new Value($values));
+        return new Comparison\NotIn($field, new Value($values));
     }
 
     /**
@@ -161,7 +161,7 @@ class ExpressionBuilder
      */
     public function contains($field, $value)
     {
-        return new Comparison($field, Comparison::CONTAINS, new Value($value));
+        return new Comparison\Contains($field, new Value($value));
     }
 
     /**
@@ -170,9 +170,9 @@ class ExpressionBuilder
      *
      * @return Comparison
      */
-    public function memberOf ($field, $value)
+    public function memberOf($field, $value)
     {
-        return new Comparison($field, Comparison::MEMBER_OF, new Value($value));
+        return new Comparison\MemberOf($field, new Value($value));
     }
 
     /**
@@ -183,7 +183,7 @@ class ExpressionBuilder
      */
     public function startsWith($field, $value)
     {
-        return new Comparison($field, Comparison::STARTS_WITH, new Value($value));
+        return new Comparison\StartsWith($field, new Value($value));
     }
 
     /**
@@ -194,7 +194,15 @@ class ExpressionBuilder
      */
     public function endsWith($field, $value)
     {
-        return new Comparison($field, Comparison::ENDS_WITH, new Value($value));
-    }    
+        return new Comparison\EndsWith($field, new Value($value));
+    }
 
+    /**
+     * @param callable $closure
+     *
+     * @return Comparison
+     */
+    public function matchingClosure(\Closure $closure) {
+        return new Comparison\MatchClosure($closure);
+    }
 }

--- a/tests/Doctrine/Tests/Common/Collections/ClosureExpressionVisitorTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/ClosureExpressionVisitorTest.php
@@ -269,6 +269,33 @@ class ClosureExpressionVisitorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue($closure(array('foo' => 42)));
     }
+
+    public function testClosureComparison() {
+        $closure = $this->visitor->walkComparison(
+            $this->builder->matchingClosure(
+                function (TestObject $context) {
+                    return $context->getFoo() == 43;
+                }
+            )
+        );
+        $this->assertTrue($closure(new TestObject(43)));
+    }
+
+    public function testClosureComparisonWithArgumentInContextObject() {
+        $compareTo = new TestObject('foo', 'bar');
+        $context = new TestObject('foo', 'bar', 'baz');
+        $this->assertNotEquals($context, $compareTo, 'The data in object should not be the same');
+
+        $closure = $this->visitor->walkComparison(
+            $this->builder->matchingClosure(
+                function (TestObject $context) use ($compareTo) {
+                    return $context->matchValueObject($compareTo);
+                }
+            )
+        );
+
+        $this->assertTrue($closure($context));
+    }
 }
 
 class TestObject
@@ -306,6 +333,15 @@ class TestObject
     public function isBaz()
     {
         return $this->baz;
+    }
+
+    /**
+     * @param TestObject $object
+     *
+     * @return bool
+     */
+    public function matchValueObject(TestObject $object) {
+        return $this->foo === $object->foo && $this->bar === $object->bar;
     }
 }
 

--- a/tests/Doctrine/Tests/Common/Collections/CollectionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/CollectionTest.php
@@ -62,4 +62,21 @@ class CollectionTest extends BaseCollectionTest
         $this->assertEquals(1, count($col));
         $this->assertEquals('baz', $col[0]->foo);
     }
+
+    public function testMatchWithClosureCriteria()
+    {
+        $dateTime = new \DateTime();
+        $this->collection->add(new \DateTime('2000-01-01'));
+        $this->collection->add(new \DateTime());
+        $this->collection->add(new \DateTime());
+
+        $criteria = Criteria::create()
+            ->andWhere(
+                Criteria::expr()->matchingClosure(function(\DateTimeInterface $date) use ($dateTime) {
+                        return $date->format('Y-m-d') === $dateTime->format('Y-m-d');
+                    })
+            )
+        ;
+        $this->assertCount(2, $this->collection->matching($criteria));
+    }
 }


### PR DESCRIPTION
This PR will give the opportunity to provide a custom entry point in the matching of objects without relying on the inner `get*` `is*` format supported in the `ClosureExpressionVisitor::getObjectFieldValue()`.

Clients will now be able to have their own mechanism (whatever the name format, with or without arguments).

```php 
class Person
{
    public function matchAddress(Address $address) {
         return $this->streetNumber == $address->streetNumber();
    }
}

$collection = new ArrayCollection(
    array(
        new Person($streetNumber = 1),
        new Person($streetNumber = 45),
        new Person($streetNumber = 78),
    )
);
$santaAddress = Address::fromString('1 main street, North Pole H0H 0H0');

$criteria = Criteria::create(
    andWhere(
        Criteria::expr()->matchingClosure(
            function (Person $context) use ($santaAddress){
                return $context->matchAddress($santaAddress);
            }
        )
    );

$collection->match($criteria); // returns the persons with addresses that match the street number
```

This PR could potentially help close #95, #68, #62, #50, #45, #28, #27 (if we do not plan on adding a fix), since the reporters could define a callback for their use case.

I am not sure what it would mean for `PersistentCollection` in the ORM package, but at least it do not affects the pattern used to access the data for checking the value.

