### PR TITLE
Enable strict comparison for arrays

### DIFF
--- a/lib/Doctrine/Common/Collections/Expr/ClosureExpressionVisitor.php
+++ b/lib/Doctrine/Common/Collections/Expr/ClosureExpressionVisitor.php
@@ -160,12 +160,12 @@ class ClosureExpressionVisitor extends ExpressionVisitor
 
             case Comparison::IN:
                 return function ($object) use ($field, $value) {
-                    return in_array(ClosureExpressionVisitor::getObjectFieldValue($object, $field), $value);
+                    return in_array(ClosureExpressionVisitor::getObjectFieldValue($object, $field), $value, true);
                 };
 
             case Comparison::NIN:
                 return function ($object) use ($field, $value) {
-                    return ! in_array(ClosureExpressionVisitor::getObjectFieldValue($object, $field), $value);
+                    return ! in_array(ClosureExpressionVisitor::getObjectFieldValue($object, $field), $value, true);
                 };
 
             case Comparison::CONTAINS:
@@ -179,7 +179,7 @@ class ClosureExpressionVisitor extends ExpressionVisitor
                     if (!is_array($fieldValues)) {
                         $fieldValues = iterator_to_array($fieldValues);
                     }
-                    return in_array($value, $fieldValues);
+                    return in_array($value, $fieldValues, true);
                 };
 
             case Comparison::STARTS_WITH:

--- a/tests/Doctrine/Tests/Common/Collections/ClosureExpressionVisitorTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/ClosureExpressionVisitorTest.php
@@ -146,21 +146,24 @@ class ClosureExpressionVisitorTest extends \PHPUnit_Framework_TestCase
 
     public function testWalkInComparison()
     {
-        $closure = $this->visitor->walkComparison($this->builder->in("foo", array(1, 2, 3)));
+        $closure = $this->visitor->walkComparison($this->builder->in("foo", array(1, 2, 3, '04')));
 
         $this->assertTrue($closure(new TestObject(2)));
         $this->assertTrue($closure(new TestObject(1)));
         $this->assertFalse($closure(new TestObject(0)));
+        $this->assertFalse($closure(new TestObject(4)));
+        $this->assertTrue($closure(new TestObject('04')));
     }
 
     public function testWalkNotInComparison()
     {
-        $closure = $this->visitor->walkComparison($this->builder->notIn("foo", array(1, 2, 3)));
+        $closure = $this->visitor->walkComparison($this->builder->notIn("foo", array(1, 2, 3, '04')));
 
         $this->assertFalse($closure(new TestObject(1)));
         $this->assertFalse($closure(new TestObject(2)));
         $this->assertTrue($closure(new TestObject(0)));
         $this->assertTrue($closure(new TestObject(4)));
+        $this->assertFalse($closure(new TestObject('04')));
     }
 
     public function testWalkContainsComparison()
@@ -178,6 +181,7 @@ class ClosureExpressionVisitorTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($closure(new TestObject(array(1,2,3))));
         $this->assertTrue($closure(new TestObject(array(2))));
         $this->assertFalse($closure(new TestObject(array(1,3,5))));
+        $this->assertFalse($closure(new TestObject(array(1,'02'))));
     }
 
     public function testWalkStartsWithComparison()


### PR DESCRIPTION
I found a bug in the comparison strings starting with 0.