### PR TITLE
[access] added prev acces method to collections

### DIFF
--- a/lib/Doctrine/Common/Collections/AbstractLazyCollection.php
+++ b/lib/Doctrine/Common/Collections/AbstractLazyCollection.php
@@ -340,4 +340,13 @@ abstract class AbstractLazyCollection implements Collection
      * @return void
      */
     abstract protected function doInitialize();
+
+    /**
+     * {@inheritDoc}
+     */
+    public function prev()
+    {
+        $this->initialize();
+        return $this->collection->prev();
+    }
 }

--- a/lib/Doctrine/Common/Collections/ArrayCollection.php
+++ b/lib/Doctrine/Common/Collections/ArrayCollection.php
@@ -405,4 +405,12 @@ class ArrayCollection implements Collection, Selectable
 
         return $this->createFrom($filtered);
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function prev()
+    {
+        return prev($this->elements);
+    }
 }

--- a/lib/Doctrine/Common/Collections/Collection.php
+++ b/lib/Doctrine/Common/Collections/Collection.php
@@ -260,4 +260,11 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      * @return array
      */
     public function slice($offset, $length = null);
+
+    /**
+     * Moves the internal iterator position to the previous element and returns this element.
+     *
+     * @return mixed
+     */
+    public function prev();
 }

--- a/tests/Doctrine/Tests/Common/Collections/BaseArrayCollectionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/BaseArrayCollectionTest.php
@@ -325,4 +325,25 @@ abstract class BaseArrayCollectionTest extends \PHPUnit_Framework_TestCase
                 ->toArray()
         );
     }
+
+    /**
+     * @dataProvider provideDifferentElements
+     */
+    public function testPrevious($elements)
+    {
+        $collection = $this->buildCollection($elements);
+
+        while (true) {
+            $collectionPrev = $collection->prev();
+            $arrayPrev = prev($elements);
+
+            if (!$collectionPrev || !$arrayPrev) {
+                break;
+            }
+
+            $this->assertSame($arrayPrev, $collectionPrev, 'Returned value of ArrayCollection::prev() and prev() not match');
+            $this->assertSame(key($elements), $collection->key(), 'Keys not match');
+            $this->assertSame(current($elements), $collection->current(), 'Current values not match');
+        }
+    }
 }


### PR DESCRIPTION
Good afternoon, 
i needed this method in order to make something I wrote work. I thought you might like to implement it in the lib so next time me (or someone who needs this) doesn't need to first retrieve the array and execute the native `prev` method on it.