### PR TITLE
Fix DocBlock for derived classes

### DIFF
--- a/lib/Doctrine/Common/Collections/Collection.php
+++ b/lib/Doctrine/Common/Collections/Collection.php
@@ -201,7 +201,7 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      *
      * @param Closure $p The predicate used for filtering.
      *
-     * @return Collection A collection with the results of the filter operation.
+     * @return static A collection with the results of the filter operation.
      */
     public function filter(Closure $p);
 
@@ -220,7 +220,7 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      *
      * @param Closure $func
      *
-     * @return Collection
+     * @return static
      */
     public function map(Closure $func);
 


### PR DESCRIPTION
This goes hand in hand with https://github.com/doctrine/collections/pull/91

If you add new method in your derived class, IDE without this patch doesn't know it's there after you call some fluent method.