### PR TITLE
Fix DocBlock for derived classes

### DIFF
--- a/lib/Doctrine/Common/Collections/ArrayCollection.php
+++ b/lib/Doctrine/Common/Collections/ArrayCollection.php
@@ -301,6 +301,8 @@ class ArrayCollection implements Collection, Selectable
 
     /**
      * {@inheritDoc}
+     *
+     * @return static
      */
     public function map(Closure $func)
     {
@@ -309,6 +311,8 @@ class ArrayCollection implements Collection, Selectable
 
     /**
      * {@inheritDoc}
+     *
+     * @return static
      */
     public function filter(Closure $p)
     {


### PR DESCRIPTION
This goes hand in hand with https://github.com/doctrine/collections/pull/91

If you add new method in your derived class, IDE without this patch doesn't know it's there after you call some fluent method.