### PR TITLE
Use of keyword "static::" to call getObjectFieldValue in ClosureExpressionVisitor

### DIFF
--- a/lib/Doctrine/Common/Collections/Expr/ClosureExpressionVisitor.php
+++ b/lib/Doctrine/Common/Collections/Expr/ClosureExpressionVisitor.php
@@ -108,8 +108,8 @@ class ClosureExpressionVisitor extends ExpressionVisitor
         }
 
         return function ($a, $b) use ($name, $next, $orientation) : int {
-            $aValue = ClosureExpressionVisitor::getObjectFieldValue($a, $name);
-            $bValue = ClosureExpressionVisitor::getObjectFieldValue($b, $name);
+            $aValue = static::getObjectFieldValue($a, $name);
+            $bValue = static::getObjectFieldValue($b, $name);
 
             if ($aValue === $bValue) {
                 return $next($a, $b);
@@ -130,52 +130,52 @@ class ClosureExpressionVisitor extends ExpressionVisitor
         switch ($comparison->getOperator()) {
             case Comparison::EQ:
                 return function ($object) use ($field, $value) : bool {
-                    return ClosureExpressionVisitor::getObjectFieldValue($object, $field) === $value;
+                    return static::getObjectFieldValue($object, $field) === $value;
                 };
 
             case Comparison::NEQ:
                 return function ($object) use ($field, $value) : bool {
-                    return ClosureExpressionVisitor::getObjectFieldValue($object, $field) !== $value;
+                    return static::getObjectFieldValue($object, $field) !== $value;
                 };
 
             case Comparison::LT:
                 return function ($object) use ($field, $value) : bool {
-                    return ClosureExpressionVisitor::getObjectFieldValue($object, $field) < $value;
+                    return static::getObjectFieldValue($object, $field) < $value;
                 };
 
             case Comparison::LTE:
                 return function ($object) use ($field, $value) : bool {
-                    return ClosureExpressionVisitor::getObjectFieldValue($object, $field) <= $value;
+                    return static::getObjectFieldValue($object, $field) <= $value;
                 };
 
             case Comparison::GT:
                 return function ($object) use ($field, $value) : bool {
-                    return ClosureExpressionVisitor::getObjectFieldValue($object, $field) > $value;
+                    return static::getObjectFieldValue($object, $field) > $value;
                 };
 
             case Comparison::GTE:
                 return function ($object) use ($field, $value) : bool {
-                    return ClosureExpressionVisitor::getObjectFieldValue($object, $field) >= $value;
+                    return static::getObjectFieldValue($object, $field) >= $value;
                 };
 
             case Comparison::IN:
                 return function ($object) use ($field, $value) : bool {
-                    return in_array(ClosureExpressionVisitor::getObjectFieldValue($object, $field), $value);
+                    return in_array(static::getObjectFieldValue($object, $field), $value);
                 };
 
             case Comparison::NIN:
                 return function ($object) use ($field, $value) : bool {
-                    return ! in_array(ClosureExpressionVisitor::getObjectFieldValue($object, $field), $value);
+                    return ! in_array(static::getObjectFieldValue($object, $field), $value);
                 };
 
             case Comparison::CONTAINS:
                 return function ($object) use ($field, $value) {
-                    return false !== strpos(ClosureExpressionVisitor::getObjectFieldValue($object, $field), $value);
+                    return false !== strpos(static::getObjectFieldValue($object, $field), $value);
                 };
 
             case Comparison::MEMBER_OF:
                 return function ($object) use ($field, $value) : bool {
-                    $fieldValues = ClosureExpressionVisitor::getObjectFieldValue($object, $field);
+                    $fieldValues = static::getObjectFieldValue($object, $field);
                     if (!is_array($fieldValues)) {
                         $fieldValues = iterator_to_array($fieldValues);
                     }
@@ -184,12 +184,12 @@ class ClosureExpressionVisitor extends ExpressionVisitor
 
             case Comparison::STARTS_WITH:
                 return function ($object) use ($field, $value) : bool {
-                    return 0 === strpos(ClosureExpressionVisitor::getObjectFieldValue($object, $field), $value);
+                    return 0 === strpos(static::getObjectFieldValue($object, $field), $value);
                 };
 
             case Comparison::ENDS_WITH:
                 return function ($object) use ($field, $value) : bool {
-                    return $value === substr(ClosureExpressionVisitor::getObjectFieldValue($object, $field), -strlen($value));
+                    return $value === substr(static::getObjectFieldValue($object, $field), -strlen($value));
                 };
 
 


### PR DESCRIPTION
Use of Late static bindings to access ClosureExpressionVisitor::getObjectFieldValue depending of the class for which it is called. Allows ClosureExpressionVisitor.php to to be extended.