### PR TITLE
Add reduce method and tests

### DIFF
--- a/lib/Doctrine/Common/Collections/AbstractLazyCollection.php
+++ b/lib/Doctrine/Common/Collections/AbstractLazyCollection.php
@@ -242,6 +242,15 @@ abstract class AbstractLazyCollection implements Collection
     /**
      * {@inheritDoc}
      */
+    public function reduce(Closure $func, $initial = null)
+    {
+        $this->initialize();
+        return $this->collection->reduce($func, $initial);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function partition(Closure $p)
     {
         $this->initialize();

--- a/lib/Doctrine/Common/Collections/ArrayCollection.php
+++ b/lib/Doctrine/Common/Collections/ArrayCollection.php
@@ -313,6 +313,16 @@ class ArrayCollection implements Collection, Selectable
     /**
      * {@inheritDoc}
      *
+     * @return mixed
+     */
+    public function reduce(Closure $func, $initial = null)
+    {
+        return array_reduce($this->toArray(), $func, $initial);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
      * @return static
      */
     public function filter(Closure $p)

--- a/lib/Doctrine/Common/Collections/Collection.php
+++ b/lib/Doctrine/Common/Collections/Collection.php
@@ -225,6 +225,17 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
     public function map(Closure $func);
 
     /**
+     * Applies the given function and initialization value to each element in
+     * the collection to reduce it to a single value.
+     *
+     * @param Closure $func
+     * @param mixed   $initial
+     *
+     * @return mixed
+     */
+    public function reduce(Closure $func, $initial = null);
+
+    /**
      * Partitions this collection in two collections according to a predicate.
      * Keys are preserved in the resulting collections.
      *

--- a/tests/Doctrine/Tests/Common/Collections/BaseCollectionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/BaseCollectionTest.php
@@ -49,6 +49,17 @@ abstract class BaseCollectionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals([2, 4], $res->toArray());
     }
 
+    public function testReduce() : void
+    {
+        $this->collection->add(1);
+        $this->collection->add(2);
+        $res = $this->collection->reduce(function($carry, $e) {
+            $carry += $e;
+            return $carry;
+        }, 1);
+        $this->assertSame(4, $res);
+    }
+
     public function testFilter() : void
     {
         $this->collection->add(1);


### PR DESCRIPTION
This pull requests adds a `reduce` method to the `Collection` interface as well as a simple implementation. Additionally, I added a test for this new method.  

Following the pattern set by the `map` method, this is really just a wrapper for the native `array_reduce` function.

Let me know if there is anything you'd like in addition to this.