### PR TITLE
Add missing PHP version bumping to 7.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         {"name": "Johannes Schmitt", "email": "schmittjoh@gmail.com"}
     ],
     "require": {
-        "php": "^7.0"
+        "php": "^7.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7",


### PR DESCRIPTION
7.1 is required since #119, but composer was not updated.