### PR TITLE
[2.0] Strict types, native parameter & return types

### DIFF
--- a/UPGRADING-2.0.md
+++ b/UPGRADING-2.0.md
@@ -1,0 +1,61 @@
+Upgrading from 1.x to 2.0
+=========================
+
+
+## BC breaking changes
+
+Native parameter and return types were added.
+As a consequence, some signatures were changed and will have to be adjusted in sub-classes.
+
+
+Note that in order to keep compatibility with both 1.x and 2.x versions, extending code would have to omit the added parameter types and add the return types. This would only work in PHP 7.2+ which is the first version featuring [parameter widening](https://wiki.php.net/rfc/parameter-no-type-variance).
+
+
+You can find a list of major changes to public API below.
+
+#### Doctrine\Common\Collections\Collection
+
+|             before             |                  after                         |
+|-------------------------------:|:-----------------------------------------------|
+| add($element)                  | add($element): bool                            |
+| clear()                        | clear(): void                                  |
+| contains($element)             | contains($element): bool                       |
+| isEmpty()                      | isEmpty(): bool                                |
+| removeElement($element)        | removeElement($element): bool                  |
+| containsKey($key)              | containsKey($key): bool                        |
+| getKeys()                      | getKeys(): array                               |
+| getValues()                    | getValues(): array                             |
+| set($key, $value)              | set($key, $value): void                        |
+| toArray()                      | toArray(): array                               |
+| exists(Closure $p)             | exists(Closure $p): bool                       |
+| filter(Closure $p)             | filter(Closure $p): self                       |
+| forAll(Closure $p)             | forAll(Closure $p): bool                       |
+| map(Closure $func)             | map(Closure $func): self                       |
+| partition(Closure $p)          | partition(Closure $p): array                   |
+| slice($offset, $length = null) | slice(int $offset, ?int $length = null): array |
+| count()                        | count(): int                                   |
+| getIterator()                  | getIterator(): \Traversable                    |
+| offsetSet($offset, $value)     | offsetSet($offset, $value): void               |
+| offsetUnset($offset)           | offsetUnset($offset): void                     |
+| offsetExists($offset)          | offsetExists($offset): bool                    |
+
+#### Doctrine\Common\Collections\AbstractLazyCollection
+
+|      before     |         after         |
+|----------------:|:----------------------|
+| isInitialized() | isInitialized(): bool |
+| initialize()    | initialize(): void    |
+| doInitialize()  | doInitialize(): void  |
+
+#### Doctrine\Common\Collections\ArrayCollection
+
+|            before           |               after               |
+|----------------------------:|:----------------------------------|
+| createFrom(array $elements) | createFrom(array $elements): self |
+| __toString()                | __toString(): string              |
+
+#### Doctrine\Common\Collections\Selectable
+
+|             before           |                   after                  |
+|-----------------------------:|:-----------------------------------------|
+| matching(Criteria $criteria) | matching(Criteria $criteria): Collection |

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.3.x-dev"
+            "dev-master": "2.0.x-dev"
         }
     }
 }

--- a/lib/Doctrine/Common/Collections/AbstractLazyCollection.php
+++ b/lib/Doctrine/Common/Collections/AbstractLazyCollection.php
@@ -46,7 +46,7 @@ abstract class AbstractLazyCollection implements Collection
     /**
      * {@inheritDoc}
      */
-    public function count()
+    public function count(): int
     {
         $this->initialize();
         return $this->collection->count();
@@ -55,7 +55,7 @@ abstract class AbstractLazyCollection implements Collection
     /**
      * {@inheritDoc}
      */
-    public function add($element)
+    public function add($element): bool
     {
         $this->initialize();
         return $this->collection->add($element);
@@ -64,7 +64,7 @@ abstract class AbstractLazyCollection implements Collection
     /**
      * {@inheritDoc}
      */
-    public function clear()
+    public function clear(): void
     {
         $this->initialize();
         $this->collection->clear();
@@ -73,7 +73,7 @@ abstract class AbstractLazyCollection implements Collection
     /**
      * {@inheritDoc}
      */
-    public function contains($element)
+    public function contains($element): bool
     {
         $this->initialize();
         return $this->collection->contains($element);
@@ -82,7 +82,7 @@ abstract class AbstractLazyCollection implements Collection
     /**
      * {@inheritDoc}
      */
-    public function isEmpty()
+    public function isEmpty(): bool
     {
         $this->initialize();
         return $this->collection->isEmpty();
@@ -100,7 +100,7 @@ abstract class AbstractLazyCollection implements Collection
     /**
      * {@inheritDoc}
      */
-    public function removeElement($element)
+    public function removeElement($element): bool
     {
         $this->initialize();
         return $this->collection->removeElement($element);
@@ -109,7 +109,7 @@ abstract class AbstractLazyCollection implements Collection
     /**
      * {@inheritDoc}
      */
-    public function containsKey($key)
+    public function containsKey($key): bool
     {
         $this->initialize();
         return $this->collection->containsKey($key);
@@ -127,7 +127,7 @@ abstract class AbstractLazyCollection implements Collection
     /**
      * {@inheritDoc}
      */
-    public function getKeys()
+    public function getKeys(): array
     {
         $this->initialize();
         return $this->collection->getKeys();
@@ -136,7 +136,7 @@ abstract class AbstractLazyCollection implements Collection
     /**
      * {@inheritDoc}
      */
-    public function getValues()
+    public function getValues(): array
     {
         $this->initialize();
         return $this->collection->getValues();
@@ -145,7 +145,7 @@ abstract class AbstractLazyCollection implements Collection
     /**
      * {@inheritDoc}
      */
-    public function set($key, $value)
+    public function set($key, $value): void
     {
         $this->initialize();
         $this->collection->set($key, $value);
@@ -154,7 +154,7 @@ abstract class AbstractLazyCollection implements Collection
     /**
      * {@inheritDoc}
      */
-    public function toArray()
+    public function toArray(): array
     {
         $this->initialize();
         return $this->collection->toArray();
@@ -208,7 +208,7 @@ abstract class AbstractLazyCollection implements Collection
     /**
      * {@inheritDoc}
      */
-    public function exists(Closure $p)
+    public function exists(Closure $p): bool
     {
         $this->initialize();
         return $this->collection->exists($p);
@@ -217,7 +217,7 @@ abstract class AbstractLazyCollection implements Collection
     /**
      * {@inheritDoc}
      */
-    public function filter(Closure $p)
+    public function filter(Closure $p): Collection
     {
         $this->initialize();
         return $this->collection->filter($p);
@@ -226,7 +226,7 @@ abstract class AbstractLazyCollection implements Collection
     /**
      * {@inheritDoc}
      */
-    public function forAll(Closure $p)
+    public function forAll(Closure $p): bool
     {
         $this->initialize();
         return $this->collection->forAll($p);
@@ -235,7 +235,7 @@ abstract class AbstractLazyCollection implements Collection
     /**
      * {@inheritDoc}
      */
-    public function map(Closure $func)
+    public function map(Closure $func): Collection
     {
         $this->initialize();
         return $this->collection->map($func);
@@ -244,7 +244,7 @@ abstract class AbstractLazyCollection implements Collection
     /**
      * {@inheritDoc}
      */
-    public function partition(Closure $p)
+    public function partition(Closure $p): array
     {
         $this->initialize();
         return $this->collection->partition($p);
@@ -262,7 +262,7 @@ abstract class AbstractLazyCollection implements Collection
     /**
      * {@inheritDoc}
      */
-    public function slice($offset, $length = null)
+    public function slice(int $offset, ?int $length = null): array
     {
         $this->initialize();
         return $this->collection->slice($offset, $length);
@@ -271,7 +271,7 @@ abstract class AbstractLazyCollection implements Collection
     /**
      * {@inheritDoc}
      */
-    public function getIterator()
+    public function getIterator(): \Traversable
     {
         $this->initialize();
         return $this->collection->getIterator();
@@ -280,7 +280,7 @@ abstract class AbstractLazyCollection implements Collection
     /**
      * {@inheritDoc}
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         $this->initialize();
         return $this->collection->offsetExists($offset);
@@ -298,7 +298,7 @@ abstract class AbstractLazyCollection implements Collection
     /**
      * {@inheritDoc}
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         $this->initialize();
         $this->collection->offsetSet($offset, $value);
@@ -307,7 +307,7 @@ abstract class AbstractLazyCollection implements Collection
     /**
      * {@inheritDoc}
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         $this->initialize();
         $this->collection->offsetUnset($offset);
@@ -318,7 +318,7 @@ abstract class AbstractLazyCollection implements Collection
      *
      * @return bool
      */
-    public function isInitialized()
+    public function isInitialized(): bool
     {
         return $this->initialized;
     }
@@ -328,7 +328,7 @@ abstract class AbstractLazyCollection implements Collection
      *
      * @return void
      */
-    protected function initialize()
+    protected function initialize(): void
     {
         if ( ! $this->initialized) {
             $this->doInitialize();
@@ -341,5 +341,5 @@ abstract class AbstractLazyCollection implements Collection
      *
      * @return void
      */
-    abstract protected function doInitialize();
+    abstract protected function doInitialize(): void;
 }

--- a/lib/Doctrine/Common/Collections/AbstractLazyCollection.php
+++ b/lib/Doctrine/Common/Collections/AbstractLazyCollection.php
@@ -17,6 +17,8 @@
  * <http://www.doctrine-project.org>.
  */
 
+declare(strict_types=1);
+
 namespace Doctrine\Common\Collections;
 
 use Closure;

--- a/lib/Doctrine/Common/Collections/ArrayCollection.php
+++ b/lib/Doctrine/Common/Collections/ArrayCollection.php
@@ -17,6 +17,8 @@
  * <http://www.doctrine-project.org>.
  */
 
+declare(strict_types=1);
+
 namespace Doctrine\Common\Collections;
 
 use ArrayIterator;

--- a/lib/Doctrine/Common/Collections/ArrayCollection.php
+++ b/lib/Doctrine/Common/Collections/ArrayCollection.php
@@ -67,7 +67,7 @@ class ArrayCollection implements Collection, Selectable
      *
      * @return static
      */
-    protected function createFrom(array $elements)
+    protected function createFrom(array $elements): self
     {
         return new static($elements);
     }
@@ -75,7 +75,7 @@ class ArrayCollection implements Collection, Selectable
     /**
      * {@inheritDoc}
      */
-    public function toArray()
+    public function toArray(): array
     {
         return $this->elements;
     }
@@ -138,7 +138,7 @@ class ArrayCollection implements Collection, Selectable
     /**
      * {@inheritDoc}
      */
-    public function removeElement($element)
+    public function removeElement($element): bool
     {
         $key = array_search($element, $this->elements, true);
 
@@ -156,7 +156,7 @@ class ArrayCollection implements Collection, Selectable
      *
      * {@inheritDoc}
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return $this->containsKey($offset);
     }
@@ -176,7 +176,7 @@ class ArrayCollection implements Collection, Selectable
      *
      * {@inheritDoc}
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if ( ! isset($offset)) {
             $this->add($value);
@@ -191,7 +191,7 @@ class ArrayCollection implements Collection, Selectable
      *
      * {@inheritDoc}
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         $this->remove($offset);
     }
@@ -199,7 +199,7 @@ class ArrayCollection implements Collection, Selectable
     /**
      * {@inheritDoc}
      */
-    public function containsKey($key)
+    public function containsKey($key): bool
     {
         return isset($this->elements[$key]) || array_key_exists($key, $this->elements);
     }
@@ -207,7 +207,7 @@ class ArrayCollection implements Collection, Selectable
     /**
      * {@inheritDoc}
      */
-    public function contains($element)
+    public function contains($element): bool
     {
         return in_array($element, $this->elements, true);
     }
@@ -215,7 +215,7 @@ class ArrayCollection implements Collection, Selectable
     /**
      * {@inheritDoc}
      */
-    public function exists(Closure $p)
+    public function exists(Closure $p): bool
     {
         foreach ($this->elements as $key => $element) {
             if ($p($key, $element)) {
@@ -245,7 +245,7 @@ class ArrayCollection implements Collection, Selectable
     /**
      * {@inheritDoc}
      */
-    public function getKeys()
+    public function getKeys(): array
     {
         return array_keys($this->elements);
     }
@@ -253,7 +253,7 @@ class ArrayCollection implements Collection, Selectable
     /**
      * {@inheritDoc}
      */
-    public function getValues()
+    public function getValues(): array
     {
         return array_values($this->elements);
     }
@@ -261,7 +261,7 @@ class ArrayCollection implements Collection, Selectable
     /**
      * {@inheritDoc}
      */
-    public function count()
+    public function count(): int
     {
         return count($this->elements);
     }
@@ -269,7 +269,7 @@ class ArrayCollection implements Collection, Selectable
     /**
      * {@inheritDoc}
      */
-    public function set($key, $value)
+    public function set($key, $value): void
     {
         $this->elements[$key] = $value;
     }
@@ -277,7 +277,7 @@ class ArrayCollection implements Collection, Selectable
     /**
      * {@inheritDoc}
      */
-    public function add($element)
+    public function add($element): bool
     {
         $this->elements[] = $element;
 
@@ -287,7 +287,7 @@ class ArrayCollection implements Collection, Selectable
     /**
      * {@inheritDoc}
      */
-    public function isEmpty()
+    public function isEmpty(): bool
     {
         return empty($this->elements);
     }
@@ -297,7 +297,7 @@ class ArrayCollection implements Collection, Selectable
      *
      * {@inheritDoc}
      */
-    public function getIterator()
+    public function getIterator(): \Traversable
     {
         return new ArrayIterator($this->elements);
     }
@@ -307,7 +307,7 @@ class ArrayCollection implements Collection, Selectable
      *
      * @return static
      */
-    public function map(Closure $func)
+    public function map(Closure $func): Collection
     {
         return $this->createFrom(array_map($func, $this->elements));
     }
@@ -317,7 +317,7 @@ class ArrayCollection implements Collection, Selectable
      *
      * @return static
      */
-    public function filter(Closure $p)
+    public function filter(Closure $p): Collection
     {
         return $this->createFrom(array_filter($this->elements, $p));
     }
@@ -325,7 +325,7 @@ class ArrayCollection implements Collection, Selectable
     /**
      * {@inheritDoc}
      */
-    public function forAll(Closure $p)
+    public function forAll(Closure $p): bool
     {
         foreach ($this->elements as $key => $element) {
             if ( ! $p($key, $element)) {
@@ -339,7 +339,7 @@ class ArrayCollection implements Collection, Selectable
     /**
      * {@inheritDoc}
      */
-    public function partition(Closure $p)
+    public function partition(Closure $p): array
     {
         $matches = $noMatches = [];
 
@@ -359,7 +359,7 @@ class ArrayCollection implements Collection, Selectable
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return __CLASS__ . '@' . spl_object_hash($this);
     }
@@ -367,7 +367,7 @@ class ArrayCollection implements Collection, Selectable
     /**
      * {@inheritDoc}
      */
-    public function clear()
+    public function clear(): void
     {
         $this->elements = [];
     }
@@ -375,7 +375,7 @@ class ArrayCollection implements Collection, Selectable
     /**
      * {@inheritDoc}
      */
-    public function slice($offset, $length = null)
+    public function slice(int $offset, ?int $length = null): array
     {
         return array_slice($this->elements, $offset, $length, true);
     }
@@ -383,7 +383,7 @@ class ArrayCollection implements Collection, Selectable
     /**
      * {@inheritDoc}
      */
-    public function matching(Criteria $criteria)
+    public function matching(Criteria $criteria): Collection
     {
         $expr     = $criteria->getWhereExpression();
         $filtered = $this->elements;

--- a/lib/Doctrine/Common/Collections/Collection.php
+++ b/lib/Doctrine/Common/Collections/Collection.php
@@ -17,6 +17,8 @@
  * <http://www.doctrine-project.org>.
  */
 
+declare(strict_types=1);
+
 namespace Doctrine\Common\Collections;
 
 use ArrayAccess;

--- a/lib/Doctrine/Common/Collections/Collection.php
+++ b/lib/Doctrine/Common/Collections/Collection.php
@@ -57,14 +57,14 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      *
      * @return boolean Always TRUE.
      */
-    public function add($element);
+    public function add($element): bool;
 
     /**
      * Clears the collection, removing all elements.
      *
      * @return void
      */
-    public function clear();
+    public function clear(): void;
 
     /**
      * Checks whether an element is contained in the collection.
@@ -74,14 +74,14 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      *
      * @return boolean TRUE if the collection contains the element, FALSE otherwise.
      */
-    public function contains($element);
+    public function contains($element): bool;
 
     /**
      * Checks whether the collection is empty (contains no elements).
      *
      * @return boolean TRUE if the collection is empty, FALSE otherwise.
      */
-    public function isEmpty();
+    public function isEmpty(): bool;
 
     /**
      * Removes the element at the specified index from the collection.
@@ -99,7 +99,7 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      *
      * @return boolean TRUE if this collection contained the specified element, FALSE otherwise.
      */
-    public function removeElement($element);
+    public function removeElement($element): bool;
 
     /**
      * Checks whether the collection contains an element with the specified key/index.
@@ -109,7 +109,7 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      * @return boolean TRUE if the collection contains an element with the specified key/index,
      *                 FALSE otherwise.
      */
-    public function containsKey($key);
+    public function containsKey($key): bool;
 
     /**
      * Gets the element at the specified key/index.
@@ -126,7 +126,7 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      * @return array The keys/indices of the collection, in the order of the corresponding
      *               elements in the collection.
      */
-    public function getKeys();
+    public function getKeys(): array;
 
     /**
      * Gets all values of the collection.
@@ -134,7 +134,7 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      * @return array The values of all elements in the collection, in the order they
      *               appear in the collection.
      */
-    public function getValues();
+    public function getValues(): array;
 
     /**
      * Sets an element in the collection at the specified key/index.
@@ -144,14 +144,14 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      *
      * @return void
      */
-    public function set($key, $value);
+    public function set($key, $value): void;
 
     /**
      * Gets a native PHP array representation of the collection.
      *
      * @return array
      */
-    public function toArray();
+    public function toArray(): array;
 
     /**
      * Sets the internal iterator to the first element in the collection and returns this element.
@@ -195,7 +195,7 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      *
      * @return boolean TRUE if the predicate is TRUE for at least one element, FALSE otherwise.
      */
-    public function exists(Closure $p);
+    public function exists(Closure $p): bool;
 
     /**
      * Returns all the elements of this collection that satisfy the predicate p.
@@ -205,7 +205,7 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      *
      * @return Collection A collection with the results of the filter operation.
      */
-    public function filter(Closure $p);
+    public function filter(Closure $p): self;
 
     /**
      * Tests whether the given predicate p holds for all elements of this collection.
@@ -214,7 +214,7 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      *
      * @return boolean TRUE, if the predicate yields TRUE for all elements, FALSE otherwise.
      */
-    public function forAll(Closure $p);
+    public function forAll(Closure $p): bool;
 
     /**
      * Applies the given function to each element in the collection and returns
@@ -224,7 +224,7 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      *
      * @return Collection
      */
-    public function map(Closure $func);
+    public function map(Closure $func): self;
 
     /**
      * Partitions this collection in two collections according to a predicate.
@@ -236,7 +236,7 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      *               of elements where the predicate returned TRUE, the second element
      *               contains the collection of elements where the predicate returned FALSE.
      */
-    public function partition(Closure $p);
+    public function partition(Closure $p): array;
 
     /**
      * Gets the index/key of a given element. The comparison of two elements is strict,
@@ -261,5 +261,35 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      *
      * @return array
      */
-    public function slice($offset, $length = null);
+    public function slice(int $offset, ?int $length = null): array;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function count(): int;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIterator(): \Traversable;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function offsetGet($offset);
+
+    /**
+     * {@inheritdoc}
+     */
+    public function offsetSet($offset, $value): void;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function offsetUnset($offset): void;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function offsetExists($offset): bool;
 }

--- a/lib/Doctrine/Common/Collections/Criteria.php
+++ b/lib/Doctrine/Common/Collections/Criteria.php
@@ -17,6 +17,8 @@
  * <http://www.doctrine-project.org>.
  */
 
+declare(strict_types=1);
+
 namespace Doctrine\Common\Collections;
 
 use Doctrine\Common\Collections\Expr\Expression;

--- a/lib/Doctrine/Common/Collections/Criteria.php
+++ b/lib/Doctrine/Common/Collections/Criteria.php
@@ -35,12 +35,12 @@ class Criteria
     /**
      * @var string
      */
-    const ASC  = 'ASC';
+    public const ASC  = 'ASC';
 
     /**
      * @var string
      */
-    const DESC = 'DESC';
+    public const DESC = 'DESC';
 
     /**
      * @var \Doctrine\Common\Collections\ExpressionBuilder|null

--- a/lib/Doctrine/Common/Collections/Criteria.php
+++ b/lib/Doctrine/Common/Collections/Criteria.php
@@ -72,7 +72,7 @@ class Criteria
      *
      * @return Criteria
      */
-    public static function create()
+    public static function create(): self
     {
         return new static();
     }
@@ -82,7 +82,7 @@ class Criteria
      *
      * @return \Doctrine\Common\Collections\ExpressionBuilder
      */
-    public static function expr()
+    public static function expr(): ExpressionBuilder
     {
         if (self::$expressionBuilder === null) {
             self::$expressionBuilder = new ExpressionBuilder();
@@ -99,7 +99,7 @@ class Criteria
      * @param int|null      $firstResult
      * @param int|null      $maxResults
      */
-    public function __construct(Expression $expression = null, array $orderings = null, $firstResult = null, $maxResults = null)
+    public function __construct(?Expression $expression = null, ?array $orderings = null, ?int $firstResult = null, ?int $maxResults = null)
     {
         $this->expression = $expression;
 
@@ -118,7 +118,7 @@ class Criteria
      *
      * @return Criteria
      */
-    public function where(Expression $expression)
+    public function where(Expression $expression): self
     {
         $this->expression = $expression;
 
@@ -133,7 +133,7 @@ class Criteria
      *
      * @return Criteria
      */
-    public function andWhere(Expression $expression)
+    public function andWhere(Expression $expression): self
     {
         if ($this->expression === null) {
             return $this->where($expression);
@@ -155,7 +155,7 @@ class Criteria
      *
      * @return Criteria
      */
-    public function orWhere(Expression $expression)
+    public function orWhere(Expression $expression): self
     {
         if ($this->expression === null) {
             return $this->where($expression);
@@ -174,7 +174,7 @@ class Criteria
      *
      * @return Expression|null
      */
-    public function getWhereExpression()
+    public function getWhereExpression(): ?Expression
     {
         return $this->expression;
     }
@@ -184,7 +184,7 @@ class Criteria
      *
      * @return string[]
      */
-    public function getOrderings()
+    public function getOrderings(): array
     {
         return $this->orderings;
     }
@@ -201,7 +201,7 @@ class Criteria
      *
      * @return Criteria
      */
-    public function orderBy(array $orderings)
+    public function orderBy(array $orderings): self
     {
         $this->orderings = array_map(
             function (string $ordering) : string {
@@ -218,7 +218,7 @@ class Criteria
      *
      * @return int|null
      */
-    public function getFirstResult()
+    public function getFirstResult(): ?int
     {
         return $this->firstResult;
     }
@@ -230,7 +230,7 @@ class Criteria
      *
      * @return Criteria
      */
-    public function setFirstResult($firstResult)
+    public function setFirstResult(?int $firstResult): self
     {
         $this->firstResult = null === $firstResult ? null : (int) $firstResult;
 
@@ -242,7 +242,7 @@ class Criteria
      *
      * @return int|null
      */
-    public function getMaxResults()
+    public function getMaxResults(): ?int
     {
         return $this->maxResults;
     }
@@ -254,7 +254,7 @@ class Criteria
      *
      * @return Criteria
      */
-    public function setMaxResults($maxResults)
+    public function setMaxResults(?int $maxResults): self
     {
         $this->maxResults = null === $maxResults ? null : (int) $maxResults;
 

--- a/lib/Doctrine/Common/Collections/Expr/ClosureExpressionVisitor.php
+++ b/lib/Doctrine/Common/Collections/Expr/ClosureExpressionVisitor.php
@@ -17,6 +17,8 @@
  * <http://www.doctrine-project.org>.
  */
 
+declare(strict_types=1);
+
 namespace Doctrine\Common\Collections\Expr;
 
 /**

--- a/lib/Doctrine/Common/Collections/Expr/ClosureExpressionVisitor.php
+++ b/lib/Doctrine/Common/Collections/Expr/ClosureExpressionVisitor.php
@@ -42,7 +42,7 @@ class ClosureExpressionVisitor extends ExpressionVisitor
      *
      * @return mixed
      */
-    public static function getObjectFieldValue($object, $field)
+    public static function getObjectFieldValue($object, string $field)
     {
         if (is_array($object)) {
             return $object[$field];
@@ -101,7 +101,7 @@ class ClosureExpressionVisitor extends ExpressionVisitor
      *
      * @return \Closure
      */
-    public static function sortByField($name, $orientation = 1, \Closure $next = null)
+    public static function sortByField(string $name, int $orientation = 1, ?\Closure $next = null): \Closure
     {
         if ( ! $next) {
             $next = function() : int {

--- a/lib/Doctrine/Common/Collections/Expr/Comparison.php
+++ b/lib/Doctrine/Common/Collections/Expr/Comparison.php
@@ -17,6 +17,8 @@
  * <http://www.doctrine-project.org>.
  */
 
+declare(strict_types=1);
+
 namespace Doctrine\Common\Collections\Expr;
 
 /**

--- a/lib/Doctrine/Common/Collections/Expr/Comparison.php
+++ b/lib/Doctrine/Common/Collections/Expr/Comparison.php
@@ -29,19 +29,19 @@ namespace Doctrine\Common\Collections\Expr;
  */
 class Comparison implements Expression
 {
-    const EQ           = '=';
-    const NEQ          = '<>';
-    const LT           = '<';
-    const LTE          = '<=';
-    const GT           = '>';
-    const GTE          = '>=';
-    const IS           = '='; // no difference with EQ
-    const IN           = 'IN';
-    const NIN          = 'NIN';
-    const CONTAINS     = 'CONTAINS';
-    const MEMBER_OF    = 'MEMBER_OF';
-    const STARTS_WITH  = 'STARTS_WITH';
-    const ENDS_WITH    = 'ENDS_WITH';
+    public const EQ           = '=';
+    public const NEQ          = '<>';
+    public const LT           = '<';
+    public const LTE          = '<=';
+    public const GT           = '>';
+    public const GTE          = '>=';
+    public const IS           = '='; // no difference with EQ
+    public const IN           = 'IN';
+    public const NIN          = 'NIN';
+    public const CONTAINS     = 'CONTAINS';
+    public const MEMBER_OF    = 'MEMBER_OF';
+    public const STARTS_WITH  = 'STARTS_WITH';
+    public const ENDS_WITH    = 'ENDS_WITH';
 
     /**
      * @var string

--- a/lib/Doctrine/Common/Collections/Expr/Comparison.php
+++ b/lib/Doctrine/Common/Collections/Expr/Comparison.php
@@ -63,7 +63,7 @@ class Comparison implements Expression
      * @param string $operator
      * @param mixed  $value
      */
-    public function __construct($field, $operator, $value)
+    public function __construct(string $field, string $operator, $value)
     {
         if ( ! ($value instanceof Value)) {
             $value = new Value($value);
@@ -77,13 +77,13 @@ class Comparison implements Expression
     /**
      * @return string
      */
-    public function getField()
+    public function getField(): string
     {
         return $this->field;
     }
 
     /**
-     * @return Value
+     * @return mixed
      */
     public function getValue()
     {
@@ -93,7 +93,7 @@ class Comparison implements Expression
     /**
      * @return string
      */
-    public function getOperator()
+    public function getOperator(): string
     {
         return $this->op;
     }

--- a/lib/Doctrine/Common/Collections/Expr/CompositeExpression.php
+++ b/lib/Doctrine/Common/Collections/Expr/CompositeExpression.php
@@ -48,7 +48,7 @@ class CompositeExpression implements Expression
      *
      * @throws \RuntimeException
      */
-    public function __construct($type, array $expressions)
+    public function __construct(string $type, array $expressions)
     {
         $this->type = $type;
 
@@ -69,7 +69,7 @@ class CompositeExpression implements Expression
      *
      * @return Expression[]
      */
-    public function getExpressionList()
+    public function getExpressionList(): array
     {
         return $this->expressions;
     }
@@ -77,7 +77,7 @@ class CompositeExpression implements Expression
     /**
      * @return string
      */
-    public function getType()
+    public function getType(): string
     {
         return $this->type;
     }

--- a/lib/Doctrine/Common/Collections/Expr/CompositeExpression.php
+++ b/lib/Doctrine/Common/Collections/Expr/CompositeExpression.php
@@ -17,6 +17,8 @@
  * <http://www.doctrine-project.org>.
  */
 
+declare(strict_types=1);
+
 namespace Doctrine\Common\Collections\Expr;
 
 /**

--- a/lib/Doctrine/Common/Collections/Expr/CompositeExpression.php
+++ b/lib/Doctrine/Common/Collections/Expr/CompositeExpression.php
@@ -29,8 +29,8 @@ namespace Doctrine\Common\Collections\Expr;
  */
 class CompositeExpression implements Expression
 {
-    const TYPE_AND = 'AND';
-    const TYPE_OR = 'OR';
+    public const TYPE_AND = 'AND';
+    public const TYPE_OR = 'OR';
 
     /**
      * @var string

--- a/lib/Doctrine/Common/Collections/Expr/Expression.php
+++ b/lib/Doctrine/Common/Collections/Expr/Expression.php
@@ -17,6 +17,8 @@
  * <http://www.doctrine-project.org>.
  */
 
+declare(strict_types=1);
+
 namespace Doctrine\Common\Collections\Expr;
 
 /**

--- a/lib/Doctrine/Common/Collections/Expr/ExpressionVisitor.php
+++ b/lib/Doctrine/Common/Collections/Expr/ExpressionVisitor.php
@@ -17,6 +17,8 @@
  * <http://www.doctrine-project.org>.
  */
 
+declare(strict_types=1);
+
 namespace Doctrine\Common\Collections\Expr;
 
 /**

--- a/lib/Doctrine/Common/Collections/Expr/Value.php
+++ b/lib/Doctrine/Common/Collections/Expr/Value.php
@@ -17,6 +17,8 @@
  * <http://www.doctrine-project.org>.
  */
 
+declare(strict_types=1);
+
 namespace Doctrine\Common\Collections\Expr;
 
 class Value implements Expression

--- a/lib/Doctrine/Common/Collections/ExpressionBuilder.php
+++ b/lib/Doctrine/Common/Collections/ExpressionBuilder.php
@@ -42,7 +42,7 @@ class ExpressionBuilder
      *
      * @return CompositeExpression
      */
-    public function andX($x = null)
+    public function andX($x = null): CompositeExpression
     {
         return new CompositeExpression(CompositeExpression::TYPE_AND, func_get_args());
     }
@@ -52,7 +52,7 @@ class ExpressionBuilder
      *
      * @return CompositeExpression
      */
-    public function orX($x = null)
+    public function orX($x = null): CompositeExpression
     {
         return new CompositeExpression(CompositeExpression::TYPE_OR, func_get_args());
     }
@@ -63,7 +63,7 @@ class ExpressionBuilder
      *
      * @return Comparison
      */
-    public function eq($field, $value)
+    public function eq(string $field, $value): Comparison
     {
         return new Comparison($field, Comparison::EQ, new Value($value));
     }
@@ -74,7 +74,7 @@ class ExpressionBuilder
      *
      * @return Comparison
      */
-    public function gt($field, $value)
+    public function gt(string $field, $value): Comparison
     {
         return new Comparison($field, Comparison::GT, new Value($value));
     }
@@ -96,7 +96,7 @@ class ExpressionBuilder
      *
      * @return Comparison
      */
-    public function gte($field, $value)
+    public function gte(string $field, $value): Comparison
     {
         return new Comparison($field, Comparison::GTE, new Value($value));
     }
@@ -107,7 +107,7 @@ class ExpressionBuilder
      *
      * @return Comparison
      */
-    public function lte($field, $value)
+    public function lte(string $field, $value): Comparison
     {
         return new Comparison($field, Comparison::LTE, new Value($value));
     }
@@ -118,7 +118,7 @@ class ExpressionBuilder
      *
      * @return Comparison
      */
-    public function neq($field, $value)
+    public function neq(string $field, $value): Comparison
     {
         return new Comparison($field, Comparison::NEQ, new Value($value));
     }
@@ -128,7 +128,7 @@ class ExpressionBuilder
      *
      * @return Comparison
      */
-    public function isNull($field)
+    public function isNull(string $field): Comparison
     {
         return new Comparison($field, Comparison::EQ, new Value(null));
     }
@@ -139,7 +139,7 @@ class ExpressionBuilder
      *
      * @return Comparison
      */
-    public function in($field, array $values)
+    public function in(string $field, array $values): Comparison
     {
         return new Comparison($field, Comparison::IN, new Value($values));
     }
@@ -150,7 +150,7 @@ class ExpressionBuilder
      *
      * @return Comparison
      */
-    public function notIn($field, array $values)
+    public function notIn(string $field, array $values): Comparison
     {
         return new Comparison($field, Comparison::NIN, new Value($values));
     }
@@ -161,7 +161,7 @@ class ExpressionBuilder
      *
      * @return Comparison
      */
-    public function contains($field, $value)
+    public function contains(string $field, $value): Comparison
     {
         return new Comparison($field, Comparison::CONTAINS, new Value($value));
     }
@@ -172,7 +172,7 @@ class ExpressionBuilder
      *
      * @return Comparison
      */
-    public function memberOf ($field, $value)
+    public function memberOf(string $field, $value): Comparison
     {
         return new Comparison($field, Comparison::MEMBER_OF, new Value($value));
     }
@@ -183,7 +183,7 @@ class ExpressionBuilder
      *
      * @return Comparison
      */
-    public function startsWith($field, $value)
+    public function startsWith(string $field, $value): Comparison
     {
         return new Comparison($field, Comparison::STARTS_WITH, new Value($value));
     }
@@ -194,7 +194,7 @@ class ExpressionBuilder
      *
      * @return Comparison
      */
-    public function endsWith($field, $value)
+    public function endsWith(string $field, $value): Comparison
     {
         return new Comparison($field, Comparison::ENDS_WITH, new Value($value));
     }    

--- a/lib/Doctrine/Common/Collections/ExpressionBuilder.php
+++ b/lib/Doctrine/Common/Collections/ExpressionBuilder.php
@@ -17,6 +17,8 @@
  * <http://www.doctrine-project.org>.
  */
 
+declare(strict_types=1);
+
 namespace Doctrine\Common\Collections;
 
 use Doctrine\Common\Collections\Expr\Comparison;

--- a/lib/Doctrine/Common/Collections/Selectable.php
+++ b/lib/Doctrine/Common/Collections/Selectable.php
@@ -17,6 +17,8 @@
  * <http://www.doctrine-project.org>.
  */
 
+declare(strict_types=1);
+
 namespace Doctrine\Common\Collections;
 
 /**

--- a/lib/Doctrine/Common/Collections/Selectable.php
+++ b/lib/Doctrine/Common/Collections/Selectable.php
@@ -46,5 +46,5 @@ interface Selectable
      *
      * @return Collection
      */
-    public function matching(Criteria $criteria);
+    public function matching(Criteria $criteria): Collection;
 }

--- a/tests/Doctrine/Tests/Common/Collections/AbstractLazyArrayCollectionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/AbstractLazyArrayCollectionTest.php
@@ -17,6 +17,8 @@
  * <http://www.doctrine-project.org>.
  */
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\Common\Collections;
 
 use Doctrine\Common\Collections\ArrayCollection;

--- a/tests/Doctrine/Tests/Common/Collections/AbstractLazyCollectionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/AbstractLazyCollectionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\Common\Collections;
 
 use Doctrine\Common\Collections\ArrayCollection;

--- a/tests/Doctrine/Tests/Common/Collections/ArrayCollectionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/ArrayCollectionTest.php
@@ -17,6 +17,8 @@
  * <http://www.doctrine-project.org>.
  */
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\Common\Collections;
 
 use Doctrine\Common\Collections\ArrayCollection;

--- a/tests/Doctrine/Tests/Common/Collections/BaseArrayCollectionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/BaseArrayCollectionTest.php
@@ -17,6 +17,8 @@
  * <http://www.doctrine-project.org>.
  */
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\Common\Collections;
 
 use Doctrine\Common\Collections\Collection;

--- a/tests/Doctrine/Tests/Common/Collections/BaseCollectionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/BaseCollectionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\Common\Collections;
 
 use Doctrine\Common\Collections\Collection;

--- a/tests/Doctrine/Tests/Common/Collections/ClosureExpressionVisitorTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/ClosureExpressionVisitorTest.php
@@ -17,6 +17,8 @@
  * <http://www.doctrine-project.org>.
  */
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\Common\Collections;
 
 use Doctrine\Common\Collections\Expr\ClosureExpressionVisitor;

--- a/tests/Doctrine/Tests/Common/Collections/CollectionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/CollectionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\Common\Collections;
 
 use Doctrine\Common\Collections\ArrayCollection;

--- a/tests/Doctrine/Tests/Common/Collections/CriteriaTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/CriteriaTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\Common\Collections;
 
 use Doctrine\Common\Collections\Criteria;

--- a/tests/Doctrine/Tests/Common/Collections/DerivedCollectionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/DerivedCollectionTest.php
@@ -17,6 +17,8 @@
  * <http://www.doctrine-project.org>.
  */
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\Common\Collections;
 
 use Doctrine\Common\Collections\Criteria;

--- a/tests/Doctrine/Tests/Common/Collections/Expr/CompositeExpressionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/Expr/CompositeExpressionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\Common\Collections\Expr;
 
 use Doctrine\Common\Collections\Expr\CompositeExpression;

--- a/tests/Doctrine/Tests/Common/Collections/Expr/ValueTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/Expr/ValueTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\Common\Collections\Expr;
 
 use Doctrine\Common\Collections\Expr\ExpressionVisitor;

--- a/tests/Doctrine/Tests/Common/Collections/ExpressionBuilderTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/ExpressionBuilderTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\Common\Collections;
 
 use Doctrine\Common\Collections\ExpressionBuilder;

--- a/tests/Doctrine/Tests/DerivedArrayCollection.php
+++ b/tests/Doctrine/Tests/DerivedArrayCollection.php
@@ -20,7 +20,7 @@ final class DerivedArrayCollection extends ArrayCollection
         parent::__construct($elements);
     }
 
-    protected function createFrom(array $elements) : self
+    protected function createFrom(array $elements) : parent
     {
         return new static($this->foo, $elements);
     }

--- a/tests/Doctrine/Tests/DerivedArrayCollection.php
+++ b/tests/Doctrine/Tests/DerivedArrayCollection.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests;
 
 use Doctrine\Common\Collections\ArrayCollection;

--- a/tests/Doctrine/Tests/LazyArrayCollection.php
+++ b/tests/Doctrine/Tests/LazyArrayCollection.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests;
 
 use Doctrine\Common\Collections\AbstractLazyCollection;


### PR DESCRIPTION
Migrating code to PHP 7.1:
* opened 2.0.x-dev
* enabled strict types
* added parameter & return types
* added const visibility
* added brief upgrading notes

No changes in tests needed except one inheritance violation.

There is no develop branch yet, thus targetting master - let me know how to proceed or when to change base branch. 😎 