### PR TITLE
Use PSR-4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "doctrine/coding-standard": "~0.1@dev"
     },
     "autoload": {
-        "psr-0": { "Doctrine\\Common\\Collections\\": "lib/" }
+        "psr-4": { "Doctrine\\Common\\Collections\\": "lib/Doctrine/Common/Collections" }
     },
     "autoload-dev": {
         "psr-4": {


### PR DESCRIPTION
Sorry for bothering this super stable package. May I ask to consider to update to PSR-4?

Im using https://github.com/humbug/php-scoper which automatically rewrites the namespace before Im building a PHAR. 