### PR TITLE
ClosureExpressionVisitor > Don't duplicate the accessor when the field already starts with it

### DIFF
--- a/lib/Doctrine/Common/Collections/Expr/ClosureExpressionVisitor.php
+++ b/lib/Doctrine/Common/Collections/Expr/ClosureExpressionVisitor.php
@@ -9,6 +9,7 @@ use function in_array;
 use function is_array;
 use function iterator_to_array;
 use function method_exists;
+use function preg_match;
 use function preg_replace_callback;
 use function strlen;
 use function strpos;
@@ -44,11 +45,13 @@ class ClosureExpressionVisitor extends ExpressionVisitor
         foreach ($accessors as $accessor) {
             $accessor .= $field;
 
-            if (! method_exists($object, $accessor)) {
-                continue;
+            if (method_exists($object, $accessor)) {
+                return $object->$accessor();
             }
+        }
 
-            return $object->$accessor();
+        if (preg_match('/^is[A-Z]+/', $field) === 1 && method_exists($object, $field)) {
+            return $object->$field();
         }
 
         // __call should be triggered for get.
@@ -74,11 +77,9 @@ class ClosureExpressionVisitor extends ExpressionVisitor
         foreach ($accessors as $accessor) {
             $accessor .= $ccField;
 
-            if (! method_exists($object, $accessor)) {
-                continue;
+            if (method_exists($object, $accessor)) {
+                return $object->$accessor();
             }
-
-            return $object->$accessor();
         }
 
         return $object->$field;

--- a/tests/Doctrine/Tests/Common/Collections/ClosureExpressionVisitorTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/ClosureExpressionVisitorTest.php
@@ -31,6 +31,13 @@ class ClosureExpressionVisitorTest extends TestCase
         self::assertTrue($this->visitor->getObjectFieldValue($object, 'baz'));
     }
 
+    public function testGetObjectFieldValueIsAccessorWithIsPrefix() : void
+    {
+        $object = new TestObject(1, 2, true);
+
+        self::assertTrue($this->visitor->getObjectFieldValue($object, 'isBaz'));
+    }
+
     public function testGetObjectFieldValueIsAccessorCamelCase() : void
     {
         $object = new TestObjectNotCamelCase(1);


### PR DESCRIPTION
This PR tries to fix an issue I am facing in my application that uses Doctrine2 ORM.

I have the following setup:
```php
class Platform {
    // ..

    /**
     * @ORM\OneToMany(targetEntity="PaymentMethod", mappedBy="platform")
     */
    private $paymentMethods;
}

class PaymentMethod {
    // ...

    /**
     * @ORM\Column(type="boolean")
     */
    private $isActive = true;
}
```

I'm trying to get all PaymentMethods from the Platform that are active:
```php
class Platform {
    // ..

    public function getActivePaymentMethods() : Collection
    {
        $criteria = Criteria::create()
            ->where(Criteria::expr()->eq('isActive', true));

        return $this->paymentMethods->matching($criteria);
    }
}
```

When I call `$platform->getActivePaymentMethods()` I get:
```
  [Symfony\Component\Debug\Exception\FatalThrowableError]
  Cannot access private property PaymentMethod::$isActive
```

I can fix this of course by changing my Criteria to `Criteria::expr()->eq('active', true)` but then I will get in troubles when it tries to run the expression on the PersistentCollection instead of the ArrayCollection.

This fix makes the getter a bit smarter. When you prefix the field with `is*` it doesn't re-apply `is` as an accessor. Instead of `isIsActive` it will just do `isActive`.

