### PR TITLE
Apply Doctrine CS 2.1

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,20 +18,7 @@ branches.
 
 ## Coding Standard
 
-We use [doctrine coding standard](https://github.com/doctrine/coding-standard) which is PSR-1 and PSR-2:
-
-* https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-1-basic-coding-standard.md
-* https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md
-
-with some exceptions/differences:
-
-* Keep the nesting of control structures per method as small as possible
-* Align equals (=) signs
-* Add spaces between assignment, control and return statements
-* Prefer early exit over nesting conditions
-* Add spaces around a negation if condition ``if ( ! $cond)``
-* Add legal information at the beginning of each source file
-* Add ``@author`` [phpDoc](https://www.phpdoc.org/docs/latest/references/phpdoc/tags/author.html) comment at DockBlock of class/interface/trait that you create.
+We use the [Doctrine Coding Standard](https://github.com/doctrine/coding-standard).
 
 ## Unit-Tests
 

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^6.3",
-        "doctrine/coding-standard": "^1.0",
+        "doctrine/coding-standard": "~2.1.0",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/lib/Doctrine/Common/Collections/AbstractLazyCollection.php
+++ b/lib/Doctrine/Common/Collections/AbstractLazyCollection.php
@@ -6,9 +6,6 @@ use Closure;
 
 /**
  * Lazy collection that is backed by a concrete collection
- *
- * @author Michaël Gallego <mic.gallego@gmail.com>
- * @since  1.2
  */
 abstract class AbstractLazyCollection implements Collection
 {
@@ -306,12 +303,10 @@ abstract class AbstractLazyCollection implements Collection
 
     /**
      * Initialize the collection
-     *
-     * @return void
      */
     protected function initialize()
     {
-        if ( ! $this->initialized) {
+        if (! $this->initialized) {
             $this->doInitialize();
             $this->initialized = true;
         }

--- a/lib/Doctrine/Common/Collections/ArrayCollection.php
+++ b/lib/Doctrine/Common/Collections/ArrayCollection.php
@@ -5,6 +5,23 @@ namespace Doctrine\Common\Collections;
 use ArrayIterator;
 use Closure;
 use Doctrine\Common\Collections\Expr\ClosureExpressionVisitor;
+use function array_filter;
+use function array_key_exists;
+use function array_keys;
+use function array_map;
+use function array_reverse;
+use function array_search;
+use function array_slice;
+use function array_values;
+use function count;
+use function current;
+use function end;
+use function in_array;
+use function key;
+use function next;
+use function reset;
+use function spl_object_hash;
+use function uasort;
 
 /**
  * An ArrayCollection is a Collection implementation that wraps a regular PHP array.
@@ -13,11 +30,6 @@ use Doctrine\Common\Collections\Expr\ClosureExpressionVisitor;
  * and may break when we change the internals in the future. If you need to
  * serialize a collection use {@link toArray()} and reconstruct the collection
  * manually.
- *
- * @since  2.0
- * @author Guilherme Blanco <guilhermeblanco@hotmail.com>
- * @author Jonathan Wage <jonwage@gmail.com>
- * @author Roman Borschel <roman@code-factory.org>
  */
 class ArrayCollection implements Collection, Selectable
 {
@@ -106,7 +118,7 @@ class ArrayCollection implements Collection, Selectable
      */
     public function remove($key)
     {
-        if ( ! isset($this->elements[$key]) && ! array_key_exists($key, $this->elements)) {
+        if (! isset($this->elements[$key]) && ! array_key_exists($key, $this->elements)) {
             return null;
         }
 
@@ -159,7 +171,7 @@ class ArrayCollection implements Collection, Selectable
      */
     public function offsetSet($offset, $value)
     {
-        if ( ! isset($offset)) {
+        if (! isset($offset)) {
             $this->add($value);
             return;
         }
@@ -309,7 +321,7 @@ class ArrayCollection implements Collection, Selectable
     public function forAll(Closure $p)
     {
         foreach ($this->elements as $key => $element) {
-            if ( ! $p($key, $element)) {
+            if (! $p($key, $element)) {
                 return false;
             }
         }
@@ -375,10 +387,12 @@ class ArrayCollection implements Collection, Selectable
             $filtered = array_filter($filtered, $filter);
         }
 
-        if ($orderings = $criteria->getOrderings()) {
+        $orderings = $criteria->getOrderings();
+
+        if ($orderings) {
             $next = null;
             foreach (array_reverse($orderings) as $field => $ordering) {
-                $next = ClosureExpressionVisitor::sortByField($field, $ordering == Criteria::DESC ? -1 : 1, $next);
+                $next = ClosureExpressionVisitor::sortByField($field, $ordering === Criteria::DESC ? -1 : 1, $next);
             }
 
             uasort($filtered, $next);

--- a/lib/Doctrine/Common/Collections/Collection.php
+++ b/lib/Doctrine/Common/Collections/Collection.php
@@ -23,11 +23,6 @@ use IteratorAggregate;
  * You can not rely on the internal iterator of the collection being at a certain
  * position unless you explicitly positioned it before. Prefer iteration with
  * external iterators.
- *
- * @since  2.0
- * @author Guilherme Blanco <guilhermeblanco@hotmail.com>
- * @author Jonathan Wage <jonwage@gmail.com>
- * @author Roman Borschel <roman@code-factory.org>
  */
 interface Collection extends Countable, IteratorAggregate, ArrayAccess
 {
@@ -200,8 +195,6 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
     /**
      * Applies the given function to each element in the collection and returns
      * a new collection with the elements returned by the function.
-     *
-     * @param Closure $func
      *
      * @return Collection
      */

--- a/lib/Doctrine/Common/Collections/Criteria.php
+++ b/lib/Doctrine/Common/Collections/Criteria.php
@@ -2,26 +2,25 @@
 
 namespace Doctrine\Common\Collections;
 
-use Doctrine\Common\Collections\Expr\Expression;
 use Doctrine\Common\Collections\Expr\CompositeExpression;
+use Doctrine\Common\Collections\Expr\Expression;
+use function array_map;
+use function strtoupper;
 
 /**
  * Criteria for filtering Selectable collections.
- *
- * @author Benjamin Eberlei <kontakt@beberlei.de>
- * @since 2.3
  */
 class Criteria
 {
     /**
      * @var string
      */
-    const ASC = 'ASC';
+    public const ASC = 'ASC';
 
     /**
      * @var string
      */
-    const DESC = 'DESC';
+    public const DESC = 'DESC';
 
     /**
      * @var \Doctrine\Common\Collections\ExpressionBuilder|null
@@ -75,27 +74,24 @@ class Criteria
     /**
      * Construct a new Criteria.
      *
-     * @param Expression    $expression
      * @param string[]|null $orderings
      * @param int|null      $firstResult
      * @param int|null      $maxResults
      */
-    public function __construct(Expression $expression = null, array $orderings = null, $firstResult = null, $maxResults = null)
+    public function __construct(?Expression $expression = null, ?array $orderings = null, $firstResult = null, $maxResults = null)
     {
         $this->expression = $expression;
 
         $this->setFirstResult($firstResult);
         $this->setMaxResults($maxResults);
 
-        if (null !== $orderings) {
+        if ($orderings !== null) {
             $this->orderBy($orderings);
         }
     }
 
     /**
      * Sets the where expression to evaluate when this Criteria is searched for.
-     *
-     * @param Expression $expression
      *
      * @return Criteria
      */
@@ -109,8 +105,6 @@ class Criteria
     /**
      * Appends the where expression to evaluate when this Criteria is searched for
      * using an AND with previous expression.
-     *
-     * @param Expression $expression
      *
      * @return Criteria
      */
@@ -131,8 +125,6 @@ class Criteria
     /**
      * Appends the where expression to evaluate when this Criteria is searched for
      * using an OR with previous expression.
-     *
-     * @param Expression $expression
      *
      * @return Criteria
      */
@@ -213,7 +205,7 @@ class Criteria
      */
     public function setFirstResult($firstResult)
     {
-        $this->firstResult = null === $firstResult ? null : (int) $firstResult;
+        $this->firstResult = $firstResult === null ? null : (int) $firstResult;
 
         return $this;
     }
@@ -237,7 +229,7 @@ class Criteria
      */
     public function setMaxResults($maxResults)
     {
-        $this->maxResults = null === $maxResults ? null : (int) $maxResults;
+        $this->maxResults = $maxResults === null ? null : (int) $maxResults;
 
         return $this;
     }

--- a/lib/Doctrine/Common/Collections/Expr/ClosureExpressionVisitor.php
+++ b/lib/Doctrine/Common/Collections/Expr/ClosureExpressionVisitor.php
@@ -2,14 +2,21 @@
 
 namespace Doctrine\Common\Collections\Expr;
 
+use function in_array;
+use function is_array;
+use function iterator_to_array;
+use function method_exists;
+use function preg_replace_callback;
+use function strlen;
+use function strpos;
+use function strtoupper;
+use function substr;
+
 /**
  * Walks an expression graph and turns it into a PHP closure.
  *
  * This closure can be used with {@Collection#filter()} and is used internally
  * by {@ArrayCollection#select()}.
- *
- * @author Benjamin Eberlei <kontakt@beberlei.de>
- * @since  2.3
  */
 class ClosureExpressionVisitor extends ExpressionVisitor
 {
@@ -19,7 +26,7 @@ class ClosureExpressionVisitor extends ExpressionVisitor
      * method, __get, __call).
      *
      * @param object|array $object
-     * @param string $field
+     * @param string       $field
      *
      * @return mixed
      */
@@ -34,7 +41,7 @@ class ClosureExpressionVisitor extends ExpressionVisitor
         foreach ($accessors as $accessor) {
             $accessor .= $field;
 
-            if ( ! method_exists($object, $accessor)) {
+            if (! method_exists($object, $accessor)) {
                 continue;
             }
 
@@ -64,8 +71,7 @@ class ClosureExpressionVisitor extends ExpressionVisitor
         foreach ($accessors as $accessor) {
             $accessor .= $ccField;
 
-
-            if ( ! method_exists($object, $accessor)) {
+            if (! method_exists($object, $accessor)) {
                 continue;
             }
 
@@ -78,15 +84,14 @@ class ClosureExpressionVisitor extends ExpressionVisitor
     /**
      * Helper for sorting arrays of objects based on multiple fields + orientations.
      *
-     * @param string   $name
-     * @param int      $orientation
-     * @param \Closure $next
+     * @param string $name
+     * @param int    $orientation
      *
      * @return \Closure
      */
-    public static function sortByField($name, $orientation = 1, \Closure $next = null)
+    public static function sortByField($name, $orientation = 1, ?\Closure $next = null)
     {
-        if ( ! $next) {
+        if (! $next) {
             $next = function () : int {
                 return 0;
             };
@@ -155,13 +160,13 @@ class ClosureExpressionVisitor extends ExpressionVisitor
 
             case Comparison::CONTAINS:
                 return function ($object) use ($field, $value) {
-                    return false !== strpos(ClosureExpressionVisitor::getObjectFieldValue($object, $field), $value);
+                    return strpos(ClosureExpressionVisitor::getObjectFieldValue($object, $field), $value) !== false;
                 };
 
             case Comparison::MEMBER_OF:
                 return function ($object) use ($field, $value) : bool {
                     $fieldValues = ClosureExpressionVisitor::getObjectFieldValue($object, $field);
-                    if ( ! is_array($fieldValues)) {
+                    if (! is_array($fieldValues)) {
                         $fieldValues = iterator_to_array($fieldValues);
                     }
                     return in_array($value, $fieldValues, true);
@@ -169,7 +174,7 @@ class ClosureExpressionVisitor extends ExpressionVisitor
 
             case Comparison::STARTS_WITH:
                 return function ($object) use ($field, $value) : bool {
-                    return 0 === strpos(ClosureExpressionVisitor::getObjectFieldValue($object, $field), $value);
+                    return strpos(ClosureExpressionVisitor::getObjectFieldValue($object, $field), $value) === 0;
                 };
 
             case Comparison::ENDS_WITH:
@@ -177,9 +182,8 @@ class ClosureExpressionVisitor extends ExpressionVisitor
                     return $value === substr(ClosureExpressionVisitor::getObjectFieldValue($object, $field), -strlen($value));
                 };
 
-
             default:
-                throw new \RuntimeException("Unknown comparison operator: " . $comparison->getOperator());
+                throw new \RuntimeException('Unknown comparison operator: ' . $comparison->getOperator());
         }
     }
 
@@ -210,20 +214,18 @@ class ClosureExpressionVisitor extends ExpressionVisitor
                 return $this->orExpressions($expressionList);
 
             default:
-                throw new \RuntimeException("Unknown composite " . $expr->getType());
+                throw new \RuntimeException('Unknown composite ' . $expr->getType());
         }
     }
 
     /**
      * @param array $expressions
-     *
-     * @return callable
      */
     private function andExpressions(array $expressions) : callable
     {
         return function ($object) use ($expressions) : bool {
             foreach ($expressions as $expression) {
-                if ( ! $expression($object)) {
+                if (! $expression($object)) {
                     return false;
                 }
             }
@@ -234,8 +236,6 @@ class ClosureExpressionVisitor extends ExpressionVisitor
 
     /**
      * @param array $expressions
-     *
-     * @return callable
      */
     private function orExpressions(array $expressions) : callable
     {

--- a/lib/Doctrine/Common/Collections/Expr/Comparison.php
+++ b/lib/Doctrine/Common/Collections/Expr/Comparison.php
@@ -4,25 +4,22 @@ namespace Doctrine\Common\Collections\Expr;
 
 /**
  * Comparison of a field with a value by the given operator.
- *
- * @author Benjamin Eberlei <kontakt@beberlei.de>
- * @since  2.3
  */
 class Comparison implements Expression
 {
-    const EQ          = '=';
-    const NEQ         = '<>';
-    const LT          = '<';
-    const LTE         = '<=';
-    const GT          = '>';
-    const GTE         = '>=';
-    const IS          = '='; // no difference with EQ
-    const IN          = 'IN';
-    const NIN         = 'NIN';
-    const CONTAINS    = 'CONTAINS';
-    const MEMBER_OF   = 'MEMBER_OF';
-    const STARTS_WITH = 'STARTS_WITH';
-    const ENDS_WITH   = 'ENDS_WITH';
+    public const EQ          = '=';
+    public const NEQ         = '<>';
+    public const LT          = '<';
+    public const LTE         = '<=';
+    public const GT          = '>';
+    public const GTE         = '>=';
+    public const IS          = '='; // no difference with EQ
+    public const IN          = 'IN';
+    public const NIN         = 'NIN';
+    public const CONTAINS    = 'CONTAINS';
+    public const MEMBER_OF   = 'MEMBER_OF';
+    public const STARTS_WITH = 'STARTS_WITH';
+    public const ENDS_WITH   = 'ENDS_WITH';
 
     /**
      * @var string
@@ -46,7 +43,7 @@ class Comparison implements Expression
      */
     public function __construct($field, $operator, $value)
     {
-        if ( ! ($value instanceof Value)) {
+        if (! ($value instanceof Value)) {
             $value = new Value($value);
         }
 

--- a/lib/Doctrine/Common/Collections/Expr/CompositeExpression.php
+++ b/lib/Doctrine/Common/Collections/Expr/CompositeExpression.php
@@ -4,14 +4,11 @@ namespace Doctrine\Common\Collections\Expr;
 
 /**
  * Expression of Expressions combined by AND or OR operation.
- *
- * @author Benjamin Eberlei <kontakt@beberlei.de>
- * @since  2.3
  */
 class CompositeExpression implements Expression
 {
-    const TYPE_AND = 'AND';
-    const TYPE_OR  = 'OR';
+    public const TYPE_AND = 'AND';
+    public const TYPE_OR  = 'OR';
 
     /**
      * @var string
@@ -35,10 +32,10 @@ class CompositeExpression implements Expression
 
         foreach ($expressions as $expr) {
             if ($expr instanceof Value) {
-                throw new \RuntimeException("Values are not supported expressions as children of and/or expressions.");
+                throw new \RuntimeException('Values are not supported expressions as children of and/or expressions.');
             }
-            if ( ! ($expr instanceof Expression)) {
-                throw new \RuntimeException("No expression given to CompositeExpression.");
+            if (! ($expr instanceof Expression)) {
+                throw new \RuntimeException('No expression given to CompositeExpression.');
             }
 
             $this->expressions[] = $expr;

--- a/lib/Doctrine/Common/Collections/Expr/Expression.php
+++ b/lib/Doctrine/Common/Collections/Expr/Expression.php
@@ -4,14 +4,10 @@ namespace Doctrine\Common\Collections\Expr;
 
 /**
  * Expression for the {@link Selectable} interface.
- *
- * @author Benjamin Eberlei <kontakt@beberlei.de>
  */
 interface Expression
 {
     /**
-     * @param ExpressionVisitor $visitor
-     *
      * @return mixed
      */
     public function visit(ExpressionVisitor $visitor);

--- a/lib/Doctrine/Common/Collections/Expr/ExpressionVisitor.php
+++ b/lib/Doctrine/Common/Collections/Expr/ExpressionVisitor.php
@@ -2,18 +2,16 @@
 
 namespace Doctrine\Common\Collections\Expr;
 
+use function get_class;
+
 /**
  * An Expression visitor walks a graph of expressions and turns them into a
  * query for the underlying implementation.
- *
- * @author Benjamin Eberlei <kontakt@beberlei.de>
  */
 abstract class ExpressionVisitor
 {
     /**
      * Converts a comparison expression into the target query language output.
-     *
-     * @param Comparison $comparison
      *
      * @return mixed
      */
@@ -22,8 +20,6 @@ abstract class ExpressionVisitor
     /**
      * Converts a value expression into the target query language part.
      *
-     * @param Value $value
-     *
      * @return mixed
      */
     abstract public function walkValue(Value $value);
@@ -31,16 +27,12 @@ abstract class ExpressionVisitor
     /**
      * Converts a composite expression into the target query language output.
      *
-     * @param CompositeExpression $expr
-     *
      * @return mixed
      */
     abstract public function walkCompositeExpression(CompositeExpression $expr);
 
     /**
      * Dispatches walking an expression to the appropriate handler.
-     *
-     * @param Expression $expr
      *
      * @return mixed
      *
@@ -59,7 +51,7 @@ abstract class ExpressionVisitor
                 return $this->walkCompositeExpression($expr);
 
             default:
-                throw new \RuntimeException("Unknown Expression " . get_class($expr));
+                throw new \RuntimeException('Unknown Expression ' . get_class($expr));
         }
     }
 }

--- a/lib/Doctrine/Common/Collections/ExpressionBuilder.php
+++ b/lib/Doctrine/Common/Collections/ExpressionBuilder.php
@@ -5,6 +5,7 @@ namespace Doctrine\Common\Collections;
 use Doctrine\Common\Collections\Expr\Comparison;
 use Doctrine\Common\Collections\Expr\CompositeExpression;
 use Doctrine\Common\Collections\Expr\Value;
+use function func_get_args;
 
 /**
  * Builder for Expressions in the {@link Selectable} interface.
@@ -12,9 +13,6 @@ use Doctrine\Common\Collections\Expr\Value;
  * Important Notice for interoperable code: You have to use scalar
  * values only for comparisons, otherwise the behavior of the comparison
  * may be different between implementations (Array vs ORM vs ODM).
- *
- * @author Benjamin Eberlei <kontakt@beberlei.de>
- * @since  2.3
  */
 class ExpressionBuilder
 {

--- a/lib/Doctrine/Common/Collections/Selectable.php
+++ b/lib/Doctrine/Common/Collections/Selectable.php
@@ -13,17 +13,12 @@ namespace Doctrine\Common\Collections;
  * utilizing the query APIs, for example SQL in the ORM. Applications using
  * this API can implement efficient database access without having to ask the
  * EntityManager or Repositories.
- *
- * @author Benjamin Eberlei <kontakt@beberlei.de>
- * @since  2.3
  */
 interface Selectable
 {
     /**
      * Selects all elements from a selectable that match the expression and
      * returns a new collection containing these elements.
-     *
-     * @param Criteria $criteria
      *
      * @return Collection
      */

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -4,17 +4,34 @@
     <arg name="extensions" value="php"/>
     <arg name="parallel" value="80"/>
     <arg name="cache" value=".phpcs-cache"/>
-    <arg name="colors" />
+    <arg name="colors"/>
 
-    <!-- Ignore warnings and show progress of the run -->
-    <arg value="np"/>
+    <!-- Ignore warnings, show progress of the run and show sniff names -->
+    <arg value="nps"/>
 
     <file>lib</file>
     <file>tests</file>
 
-    <rule ref="Doctrine"/>
+    <rule ref="Doctrine">
+        <exclude name="SlevomatCodingStandard.TypeHints.DeclareStrictTypes"/>
+        <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingParameterTypeHint"/>
+        <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingReturnTypeHint"/>
+
+        <!-- Since Collections are built around mixed content, this has no value here -->
+        <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingTraversablePropertyTypeHintSpecification"/>
+        <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingTraversableParameterTypeHintSpecification"/>
+        <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingTraversableReturnTypeHintSpecification"/>
+    </rule>
 
     <rule ref="PSR1.Classes.ClassDeclaration.MultipleClasses">
-        <exclude-pattern>*/tests/*</exclude-pattern>
+        <exclude-pattern>tests/*</exclude-pattern>
+    </rule>
+
+    <rule ref="Squiz.Classes.ClassFileName.NoMatch">
+        <exclude-pattern>tests/*</exclude-pattern>
+    </rule>
+
+    <rule ref="SlevomatCodingStandard.Classes.UnusedPrivateElements.WriteOnlyProperty">
+        <exclude-pattern>tests/*</exclude-pattern>
     </rule>
 </ruleset>

--- a/tests/Doctrine/Tests/Common/Collections/AbstractLazyArrayCollectionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/AbstractLazyArrayCollectionTest.php
@@ -11,7 +11,7 @@ use Doctrine\Tests\LazyArrayCollection;
  *
  * @covers \Doctrine\Common\Collections\AbstractLazyCollection
  */
-class AbstractLazyCollectionTest extends BaseArrayCollectionTest
+class AbstractLazyArrayCollectionTest extends BaseArrayCollectionTest
 {
     protected function buildCollection(array $elements = []) : Collection
     {

--- a/tests/Doctrine/Tests/Common/Collections/AbstractLazyCollectionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/AbstractLazyCollectionTest.php
@@ -10,7 +10,7 @@ use Doctrine\Tests\LazyArrayCollection;
  *
  * @covers \Doctrine\Common\Collections\AbstractLazyCollection
  */
-class LazyCollectionTest extends BaseCollectionTest
+class AbstractLazyCollectionTest extends BaseCollectionTest
 {
     protected function setUp() : void
     {

--- a/tests/Doctrine/Tests/Common/Collections/BaseArrayCollectionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/BaseArrayCollectionTest.php
@@ -5,8 +5,18 @@ namespace Doctrine\Tests\Common\Collections;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\Common\Collections\Selectable;
+use PHPUnit\Framework\TestCase;
+use function array_keys;
+use function array_search;
+use function array_values;
+use function count;
+use function current;
+use function end;
+use function key;
+use function next;
+use function reset;
 
-abstract class BaseArrayCollectionTest extends \PHPUnit\Framework\TestCase
+abstract class BaseArrayCollectionTest extends TestCase
 {
     abstract protected function buildCollection(array $elements = []) : Collection;
 
@@ -69,7 +79,7 @@ abstract class BaseArrayCollectionTest extends \PHPUnit\Framework\TestCase
             $collectionNext = $collection->next();
             $arrayNext      = next($elements);
 
-            if ( ! $collectionNext || ! $arrayNext) {
+            if (! $collectionNext || ! $arrayNext) {
                 break;
             }
 
@@ -133,7 +143,7 @@ abstract class BaseArrayCollectionTest extends \PHPUnit\Framework\TestCase
 
         $iterations = 0;
         foreach ($collection->getIterator() as $key => $item) {
-            self::assertSame($elements[$key], $item, "Item {$key} not match");
+            self::assertSame($elements[$key], $item, 'Item ' . $key . ' not match');
             ++$iterations;
         }
 
@@ -225,11 +235,11 @@ abstract class BaseArrayCollectionTest extends \PHPUnit\Framework\TestCase
         $collection = $this->buildCollection($elements);
 
         self::assertTrue($collection->exists(function ($key, $element) {
-            return $key == 'A' && $element == 'a';
+            return $key === 'A' && $element === 'a';
         }), 'Element exists');
 
         self::assertFalse($collection->exists(function ($key, $element) {
-            return $key == 'non-existent' && $element == 'non-existent';
+            return $key === 'non-existent' && $element === 'non-existent';
         }), 'Element not exists');
     }
 
@@ -266,7 +276,7 @@ abstract class BaseArrayCollectionTest extends \PHPUnit\Framework\TestCase
             'object2' => $object2,
         ]);
 
-        if ( ! $this->isSelectable($collection)) {
+        if (! $this->isSelectable($collection)) {
             $this->markTestSkipped('Collection does not support Selectable interface');
         }
 
@@ -286,16 +296,16 @@ abstract class BaseArrayCollectionTest extends \PHPUnit\Framework\TestCase
         $collection = $this->buildCollection([
             ['foo' => 1, 'bar' => 2],
             ['foo' => 2, 'bar' => 4],
-            ['foo' => 2, 'bar' => 3]
+            ['foo' => 2, 'bar' => 3],
         ]);
 
         $expected = [
             1 => ['foo' => 2, 'bar' => 4],
             2 => ['foo' => 2, 'bar' => 3],
-            0 => ['foo' => 1, 'bar' => 2]
+            0 => ['foo' => 1, 'bar' => 2],
         ];
 
-        if ( ! $this->isSelectable($collection)) {
+        if (! $this->isSelectable($collection)) {
             $this->markTestSkipped('Collection does not support Selectable interface');
         }
 

--- a/tests/Doctrine/Tests/Common/Collections/BaseCollectionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/BaseCollectionTest.php
@@ -3,8 +3,13 @@
 namespace Doctrine\Tests\Common\Collections;
 
 use Doctrine\Common\Collections\Collection;
+use PHPUnit\Framework\TestCase;
+use function count;
+use function is_array;
+use function is_numeric;
+use function is_string;
 
-abstract class BaseCollectionTest extends \PHPUnit\Framework\TestCase
+abstract class BaseCollectionTest extends TestCase
 {
     /**
      * @var Collection
@@ -30,11 +35,11 @@ abstract class BaseCollectionTest extends \PHPUnit\Framework\TestCase
         $this->collection->add('one');
         $this->collection->add('two');
         $exists = $this->collection->exists(function ($k, $e) {
-            return $e == 'one';
+            return $e === 'one';
         });
         self::assertTrue($exists);
         $exists = $this->collection->exists(function ($k, $e) {
-            return $e == 'other';
+            return $e === 'other';
         });
         self::assertFalse($exists);
     }
@@ -144,7 +149,7 @@ abstract class BaseCollectionTest extends \PHPUnit\Framework\TestCase
         $this->collection[] = true;
         $this->collection[] = false;
         $partition          = $this->collection->partition(function ($k, $e) {
-            return $e == true;
+            return $e === true;
         });
         self::assertEquals($partition[0][0], true);
         self::assertEquals($partition[1][0], false);

--- a/tests/Doctrine/Tests/Common/Collections/ClosureExpressionVisitorTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/ClosureExpressionVisitorTest.php
@@ -4,11 +4,13 @@ namespace Doctrine\Tests\Common\Collections;
 
 use Doctrine\Common\Collections\Expr\ClosureExpressionVisitor;
 use Doctrine\Common\Collections\ExpressionBuilder;
+use PHPUnit\Framework\TestCase;
+use function usort;
 
 /**
  * @group DDC-1637
  */
-class ClosureExpressionVisitorTest extends \PHPUnit\Framework\TestCase
+class ClosureExpressionVisitorTest extends TestCase
 {
     /**
      * @var ClosureExpressionVisitor
@@ -78,7 +80,7 @@ class ClosureExpressionVisitorTest extends \PHPUnit\Framework\TestCase
 
     public function testWalkEqualsComparison() : void
     {
-        $closure = $this->visitor->walkComparison($this->builder->eq("foo", 1));
+        $closure = $this->visitor->walkComparison($this->builder->eq('foo', 1));
 
         self::assertTrue($closure(new TestObject(1)));
         self::assertFalse($closure(new TestObject(2)));
@@ -86,7 +88,7 @@ class ClosureExpressionVisitorTest extends \PHPUnit\Framework\TestCase
 
     public function testWalkNotEqualsComparison() : void
     {
-        $closure = $this->visitor->walkComparison($this->builder->neq("foo", 1));
+        $closure = $this->visitor->walkComparison($this->builder->neq('foo', 1));
 
         self::assertFalse($closure(new TestObject(1)));
         self::assertTrue($closure(new TestObject(2)));
@@ -94,7 +96,7 @@ class ClosureExpressionVisitorTest extends \PHPUnit\Framework\TestCase
 
     public function testWalkLessThanComparison() : void
     {
-        $closure = $this->visitor->walkComparison($this->builder->lt("foo", 1));
+        $closure = $this->visitor->walkComparison($this->builder->lt('foo', 1));
 
         self::assertFalse($closure(new TestObject(1)));
         self::assertTrue($closure(new TestObject(0)));
@@ -102,7 +104,7 @@ class ClosureExpressionVisitorTest extends \PHPUnit\Framework\TestCase
 
     public function testWalkLessThanEqualsComparison() : void
     {
-        $closure = $this->visitor->walkComparison($this->builder->lte("foo", 1));
+        $closure = $this->visitor->walkComparison($this->builder->lte('foo', 1));
 
         self::assertFalse($closure(new TestObject(2)));
         self::assertTrue($closure(new TestObject(1)));
@@ -111,7 +113,7 @@ class ClosureExpressionVisitorTest extends \PHPUnit\Framework\TestCase
 
     public function testWalkGreaterThanEqualsComparison() : void
     {
-        $closure = $this->visitor->walkComparison($this->builder->gte("foo", 1));
+        $closure = $this->visitor->walkComparison($this->builder->gte('foo', 1));
 
         self::assertTrue($closure(new TestObject(2)));
         self::assertTrue($closure(new TestObject(1)));
@@ -120,7 +122,7 @@ class ClosureExpressionVisitorTest extends \PHPUnit\Framework\TestCase
 
     public function testWalkGreaterThanComparison() : void
     {
-        $closure = $this->visitor->walkComparison($this->builder->gt("foo", 1));
+        $closure = $this->visitor->walkComparison($this->builder->gt('foo', 1));
 
         self::assertTrue($closure(new TestObject(2)));
         self::assertFalse($closure(new TestObject(1)));
@@ -129,7 +131,7 @@ class ClosureExpressionVisitorTest extends \PHPUnit\Framework\TestCase
 
     public function testWalkInComparison() : void
     {
-        $closure = $this->visitor->walkComparison($this->builder->in("foo", [1, 2, 3, '04']));
+        $closure = $this->visitor->walkComparison($this->builder->in('foo', [1, 2, 3, '04']));
 
         self::assertTrue($closure(new TestObject(2)));
         self::assertTrue($closure(new TestObject(1)));
@@ -140,7 +142,7 @@ class ClosureExpressionVisitorTest extends \PHPUnit\Framework\TestCase
 
     public function testWalkNotInComparison() : void
     {
-        $closure = $this->visitor->walkComparison($this->builder->notIn("foo", [1, 2, 3, '04']));
+        $closure = $this->visitor->walkComparison($this->builder->notIn('foo', [1, 2, 3, '04']));
 
         self::assertFalse($closure(new TestObject(1)));
         self::assertFalse($closure(new TestObject(2)));
@@ -159,12 +161,12 @@ class ClosureExpressionVisitorTest extends \PHPUnit\Framework\TestCase
 
     public function testWalkMemberOfComparisonWithObject() : void
     {
-        $closure = $this->visitor->walkComparison($this->builder->memberof("foo", 2));
+        $closure = $this->visitor->walkComparison($this->builder->memberof('foo', 2));
 
-        self::assertTrue($closure(new TestObject([1,2,3])));
+        self::assertTrue($closure(new TestObject([1, 2, 3])));
         self::assertTrue($closure(new TestObject([2])));
-        self::assertFalse($closure(new TestObject([1,3,5])));
-        self::assertFalse($closure(new TestObject(array(1,'02'))));
+        self::assertFalse($closure(new TestObject([1, 3, 5])));
+        self::assertFalse($closure(new TestObject([1, '02'])));
     }
 
     public function testWalkStartsWithComparison() : void
@@ -187,8 +189,8 @@ class ClosureExpressionVisitorTest extends \PHPUnit\Framework\TestCase
     {
         $closure = $this->visitor->walkCompositeExpression(
             $this->builder->andX(
-                $this->builder->eq("foo", 1),
-                $this->builder->eq("bar", 1)
+                $this->builder->eq('foo', 1),
+                $this->builder->eq('bar', 1)
             )
         );
 
@@ -202,8 +204,8 @@ class ClosureExpressionVisitorTest extends \PHPUnit\Framework\TestCase
     {
         $closure = $this->visitor->walkCompositeExpression(
             $this->builder->orX(
-                $this->builder->eq("foo", 1),
-                $this->builder->eq("bar", 1)
+                $this->builder->eq('foo', 1),
+                $this->builder->eq('bar', 1)
             )
         );
 
@@ -215,44 +217,44 @@ class ClosureExpressionVisitorTest extends \PHPUnit\Framework\TestCase
 
     public function testSortByFieldAscending() : void
     {
-        $objects = [new TestObject("b"), new TestObject("a"), new TestObject("c")];
-        $sort    = ClosureExpressionVisitor::sortByField("foo");
+        $objects = [new TestObject('b'), new TestObject('a'), new TestObject('c')];
+        $sort    = ClosureExpressionVisitor::sortByField('foo');
 
         usort($objects, $sort);
 
-        self::assertEquals("a", $objects[0]->getFoo());
-        self::assertEquals("b", $objects[1]->getFoo());
-        self::assertEquals("c", $objects[2]->getFoo());
+        self::assertEquals('a', $objects[0]->getFoo());
+        self::assertEquals('b', $objects[1]->getFoo());
+        self::assertEquals('c', $objects[2]->getFoo());
     }
 
     public function testSortByFieldDescending() : void
     {
-        $objects = [new TestObject("b"), new TestObject("a"), new TestObject("c")];
-        $sort    = ClosureExpressionVisitor::sortByField("foo", -1);
+        $objects = [new TestObject('b'), new TestObject('a'), new TestObject('c')];
+        $sort    = ClosureExpressionVisitor::sortByField('foo', -1);
 
         usort($objects, $sort);
 
-        self::assertEquals("c", $objects[0]->getFoo());
-        self::assertEquals("b", $objects[1]->getFoo());
-        self::assertEquals("a", $objects[2]->getFoo());
+        self::assertEquals('c', $objects[0]->getFoo());
+        self::assertEquals('b', $objects[1]->getFoo());
+        self::assertEquals('a', $objects[2]->getFoo());
     }
 
     public function testSortDelegate() : void
     {
-        $objects = [new TestObject("a", "c"), new TestObject("a", "b"), new TestObject("a", "a")];
-        $sort    = ClosureExpressionVisitor::sortByField("bar", 1);
-        $sort    = ClosureExpressionVisitor::sortByField("foo", 1, $sort);
+        $objects = [new TestObject('a', 'c'), new TestObject('a', 'b'), new TestObject('a', 'a')];
+        $sort    = ClosureExpressionVisitor::sortByField('bar', 1);
+        $sort    = ClosureExpressionVisitor::sortByField('foo', 1, $sort);
 
         usort($objects, $sort);
 
-        self::assertEquals("a", $objects[0]->getBar());
-        self::assertEquals("b", $objects[1]->getBar());
-        self::assertEquals("c", $objects[2]->getBar());
+        self::assertEquals('a', $objects[0]->getBar());
+        self::assertEquals('b', $objects[1]->getBar());
+        self::assertEquals('c', $objects[2]->getBar());
     }
 
     public function testArrayComparison() : void
     {
-        $closure = $this->visitor->walkComparison($this->builder->eq("foo", 42));
+        $closure = $this->visitor->walkComparison($this->builder->eq('foo', 42));
 
         self::assertTrue($closure(['foo' => 42]));
     }
@@ -260,9 +262,16 @@ class ClosureExpressionVisitorTest extends \PHPUnit\Framework\TestCase
 
 class TestObject
 {
+    /** @var mixed */
     private $foo;
+
+    /** @var mixed */
     private $bar;
+
+    /** @var mixed */
     private $baz;
+
+    /** @var mixed */
     private $qux;
 
     public function __construct($foo = null, $bar = null, $baz = null, $qux = null)
@@ -275,7 +284,7 @@ class TestObject
 
     public function __call(string $name, array $arguments)
     {
-        if ('getqux' === $name) {
+        if ($name === 'getqux') {
             return $this->qux;
         }
     }
@@ -298,6 +307,7 @@ class TestObject
 
 class TestObjectNotCamelCase
 {
+    /** @var int|null */
     private $foo_bar;
 
     public function __construct(?int $foo_bar)
@@ -313,10 +323,13 @@ class TestObjectNotCamelCase
 
 class TestObjectBothCamelCaseAndUnderscore
 {
+    /** @var int|null */
     private $foo_bar;
+
+    /** @var int|null */
     private $fooBar;
 
-    public function __construct(int $foo_bar = null, int $fooBar = null)
+    public function __construct(?int $foo_bar = null, ?int $fooBar = null)
     {
         $this->foo_bar = $foo_bar;
         $this->fooBar  = $fooBar;
@@ -330,10 +343,13 @@ class TestObjectBothCamelCaseAndUnderscore
 
 class TestObjectPublicCamelCaseAndPrivateUnderscore
 {
+    /** @var int|null */
     private $foo_bar;
+
+    /** @var int|null */
     public $fooBar;
 
-    public function __construct(int $foo_bar = null, int $fooBar = null)
+    public function __construct(?int $foo_bar = null, ?int $fooBar = null)
     {
         $this->foo_bar = $foo_bar;
         $this->fooBar  = $fooBar;
@@ -347,7 +363,9 @@ class TestObjectPublicCamelCaseAndPrivateUnderscore
 
 class TestObjectBothPublic
 {
+    /** @var mixed */
     public $foo_bar;
+    /** @var mixed */
     public $fooBar;
 
     public function __construct($foo_bar = null, $fooBar = null)

--- a/tests/Doctrine/Tests/Common/Collections/CollectionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/CollectionTest.php
@@ -5,6 +5,8 @@ namespace Doctrine\Tests\Common\Collections;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Collections\Criteria;
+use function count;
+use function is_string;
 
 class CollectionTest extends BaseCollectionTest
 {

--- a/tests/Doctrine/Tests/Common/Collections/CriteriaTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/CriteriaTest.php
@@ -6,8 +6,9 @@ use Doctrine\Common\Collections\Criteria;
 use Doctrine\Common\Collections\Expr\Comparison;
 use Doctrine\Common\Collections\Expr\CompositeExpression;
 use Doctrine\Common\Collections\ExpressionBuilder;
+use PHPUnit\Framework\TestCase;
 
-class CriteriaTest extends \PHPUnit\Framework\TestCase
+class CriteriaTest extends TestCase
 {
     public function testCreate() : void
     {
@@ -18,18 +19,18 @@ class CriteriaTest extends \PHPUnit\Framework\TestCase
 
     public function testConstructor() : void
     {
-        $expr     = new Comparison("field", "=", "value");
-        $criteria = new Criteria($expr, ["foo" => "ASC"], 10, 20);
+        $expr     = new Comparison('field', '=', 'value');
+        $criteria = new Criteria($expr, ['foo' => 'ASC'], 10, 20);
 
         self::assertSame($expr, $criteria->getWhereExpression());
-        self::assertEquals(["foo" => "ASC"], $criteria->getOrderings());
+        self::assertEquals(['foo' => 'ASC'], $criteria->getOrderings());
         self::assertEquals(10, $criteria->getFirstResult());
         self::assertEquals(20, $criteria->getMaxResults());
     }
 
     public function testWhere() : void
     {
-        $expr     = new Comparison("field", "=", "value");
+        $expr     = new Comparison('field', '=', 'value');
         $criteria = new Criteria();
 
         $criteria->where($expr);
@@ -39,7 +40,7 @@ class CriteriaTest extends \PHPUnit\Framework\TestCase
 
     public function testAndWhere() : void
     {
-        $expr     = new Comparison("field", "=", "value");
+        $expr     = new Comparison('field', '=', 'value');
         $criteria = new Criteria();
 
         $criteria->where($expr);
@@ -55,7 +56,7 @@ class CriteriaTest extends \PHPUnit\Framework\TestCase
 
     public function testAndWhereWithoutWhere() : void
     {
-        $expr     = new Comparison("field", "=", "value");
+        $expr     = new Comparison('field', '=', 'value');
         $criteria = new Criteria();
 
         $criteria->andWhere($expr);
@@ -65,7 +66,7 @@ class CriteriaTest extends \PHPUnit\Framework\TestCase
 
     public function testOrWhere() : void
     {
-        $expr     = new Comparison("field", "=", "value");
+        $expr     = new Comparison('field', '=', 'value');
         $criteria = new Criteria();
 
         $criteria->where($expr);
@@ -81,7 +82,7 @@ class CriteriaTest extends \PHPUnit\Framework\TestCase
 
     public function testOrWhereWithoutWhere() : void
     {
-        $expr     = new Comparison("field", "=", "value");
+        $expr     = new Comparison('field', '=', 'value');
         $criteria = new Criteria();
 
         $criteria->orWhere($expr);
@@ -92,9 +93,9 @@ class CriteriaTest extends \PHPUnit\Framework\TestCase
     public function testOrderings() : void
     {
         $criteria = Criteria::create()
-            ->orderBy(["foo" => "ASC"]);
+            ->orderBy(['foo' => 'ASC']);
 
-        self::assertEquals(["foo" => "ASC"], $criteria->getOrderings());
+        self::assertEquals(['foo' => 'ASC'], $criteria->getOrderings());
     }
 
     public function testExpr() : void

--- a/tests/Doctrine/Tests/Common/Collections/DerivedCollectionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/DerivedCollectionTest.php
@@ -4,11 +4,9 @@ namespace Doctrine\Tests\Common\Collections;
 
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\Tests\DerivedArrayCollection;
+use PHPUnit\Framework\TestCase;
 
-/**
- * @author Alexander Golovnya <snsanich@gmail.com>
- */
-class DerivedCollectionTest extends \PHPUnit\Framework\TestCase
+class DerivedCollectionTest extends TestCase
 {
     /**
      * Tests that methods that create a new instance can be called in a derived

--- a/tests/Doctrine/Tests/Common/Collections/Expr/CompositeExpressionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/Expr/CompositeExpressionTest.php
@@ -9,7 +9,6 @@ use Doctrine\Common\Collections\Expr\Value;
 use PHPUnit\Framework\TestCase as TestCase;
 
 /**
- * @author  Tobias Oberrauch <hello@tobiasoberrauch.com>
  * @covers  \Doctrine\Common\Collections\Expr\CompositeExpression
  */
 class CompositeExpressionTest extends TestCase
@@ -28,9 +27,7 @@ class CompositeExpressionTest extends TestCase
     public function testExceptions($expression) : void
     {
         $type        = CompositeExpression::TYPE_AND;
-        $expressions = [
-            $expression,
-        ];
+        $expressions = [$expression];
 
         $this->expectException(\RuntimeException::class);
         new CompositeExpression($type, $expressions);

--- a/tests/Doctrine/Tests/Common/Collections/Expr/ValueTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/Expr/ValueTest.php
@@ -7,7 +7,6 @@ use Doctrine\Common\Collections\Expr\Value;
 use PHPUnit\Framework\TestCase as TestCase;
 
 /**
- * @author  Tobias Oberrauch <hello@tobiasoberrauch.com>
  * @covers  \Doctrine\Common\Collections\Expr\Value
  */
 class ValueTest extends TestCase

--- a/tests/Doctrine/Tests/Common/Collections/ExpressionBuilderTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/ExpressionBuilderTest.php
@@ -2,14 +2,15 @@
 
 namespace Doctrine\Tests\Common\Collections;
 
-use Doctrine\Common\Collections\ExpressionBuilder;
 use Doctrine\Common\Collections\Expr\Comparison;
 use Doctrine\Common\Collections\Expr\CompositeExpression;
+use Doctrine\Common\Collections\ExpressionBuilder;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group DDC-1637
  */
-class ExpressionBuilderTest extends \PHPUnit\Framework\TestCase
+class ExpressionBuilderTest extends TestCase
 {
     /**
      * @var ExpressionBuilder
@@ -23,7 +24,7 @@ class ExpressionBuilderTest extends \PHPUnit\Framework\TestCase
 
     public function testAndX() : void
     {
-        $expr = $this->builder->andX($this->builder->eq("a", "b"));
+        $expr = $this->builder->andX($this->builder->eq('a', 'b'));
 
         self::assertInstanceOf(CompositeExpression::class, $expr);
         self::assertEquals(CompositeExpression::TYPE_AND, $expr->getType());
@@ -31,7 +32,7 @@ class ExpressionBuilderTest extends \PHPUnit\Framework\TestCase
 
     public function testOrX() : void
     {
-        $expr = $this->builder->orX($this->builder->eq("a", "b"));
+        $expr = $this->builder->orX($this->builder->eq('a', 'b'));
 
         self::assertInstanceOf(CompositeExpression::class, $expr);
         self::assertEquals(CompositeExpression::TYPE_OR, $expr->getType());
@@ -40,12 +41,12 @@ class ExpressionBuilderTest extends \PHPUnit\Framework\TestCase
     public function testInvalidAndXArgument() : void
     {
         $this->expectException(\RuntimeException::class);
-        $this->builder->andX("foo");
+        $this->builder->andX('foo');
     }
 
     public function testEq() : void
     {
-        $expr = $this->builder->eq("a", "b");
+        $expr = $this->builder->eq('a', 'b');
 
         self::assertInstanceOf(Comparison::class, $expr);
         self::assertEquals(Comparison::EQ, $expr->getOperator());
@@ -53,7 +54,7 @@ class ExpressionBuilderTest extends \PHPUnit\Framework\TestCase
 
     public function testNeq() : void
     {
-        $expr = $this->builder->neq("a", "b");
+        $expr = $this->builder->neq('a', 'b');
 
         self::assertInstanceOf(Comparison::class, $expr);
         self::assertEquals(Comparison::NEQ, $expr->getOperator());
@@ -61,7 +62,7 @@ class ExpressionBuilderTest extends \PHPUnit\Framework\TestCase
 
     public function testLt() : void
     {
-        $expr = $this->builder->lt("a", "b");
+        $expr = $this->builder->lt('a', 'b');
 
         self::assertInstanceOf(Comparison::class, $expr);
         self::assertEquals(Comparison::LT, $expr->getOperator());
@@ -69,7 +70,7 @@ class ExpressionBuilderTest extends \PHPUnit\Framework\TestCase
 
     public function testGt() : void
     {
-        $expr = $this->builder->gt("a", "b");
+        $expr = $this->builder->gt('a', 'b');
 
         self::assertInstanceOf(Comparison::class, $expr);
         self::assertEquals(Comparison::GT, $expr->getOperator());
@@ -77,7 +78,7 @@ class ExpressionBuilderTest extends \PHPUnit\Framework\TestCase
 
     public function testGte() : void
     {
-        $expr = $this->builder->gte("a", "b");
+        $expr = $this->builder->gte('a', 'b');
 
         self::assertInstanceOf(Comparison::class, $expr);
         self::assertEquals(Comparison::GTE, $expr->getOperator());
@@ -85,7 +86,7 @@ class ExpressionBuilderTest extends \PHPUnit\Framework\TestCase
 
     public function testLte() : void
     {
-        $expr = $this->builder->lte("a", "b");
+        $expr = $this->builder->lte('a', 'b');
 
         self::assertInstanceOf(Comparison::class, $expr);
         self::assertEquals(Comparison::LTE, $expr->getOperator());
@@ -93,7 +94,7 @@ class ExpressionBuilderTest extends \PHPUnit\Framework\TestCase
 
     public function testIn() : void
     {
-        $expr = $this->builder->in("a", ["b"]);
+        $expr = $this->builder->in('a', ['b']);
 
         self::assertInstanceOf(Comparison::class, $expr);
         self::assertEquals(Comparison::IN, $expr->getOperator());
@@ -101,7 +102,7 @@ class ExpressionBuilderTest extends \PHPUnit\Framework\TestCase
 
     public function testNotIn() : void
     {
-        $expr = $this->builder->notIn("a", ["b"]);
+        $expr = $this->builder->notIn('a', ['b']);
 
         self::assertInstanceOf(Comparison::class, $expr);
         self::assertEquals(Comparison::NIN, $expr->getOperator());
@@ -109,7 +110,7 @@ class ExpressionBuilderTest extends \PHPUnit\Framework\TestCase
 
     public function testIsNull() : void
     {
-        $expr = $this->builder->isNull("a");
+        $expr = $this->builder->isNull('a');
 
         self::assertInstanceOf(Comparison::class, $expr);
         self::assertEquals(Comparison::EQ, $expr->getOperator());
@@ -117,7 +118,7 @@ class ExpressionBuilderTest extends \PHPUnit\Framework\TestCase
 
     public function testContains() : void
     {
-        $expr = $this->builder->contains("a", "b");
+        $expr = $this->builder->contains('a', 'b');
 
         self::assertInstanceOf(Comparison::class, $expr);
         self::assertEquals(Comparison::CONTAINS, $expr->getOperator());
@@ -125,7 +126,7 @@ class ExpressionBuilderTest extends \PHPUnit\Framework\TestCase
 
     public function testMemberOf() : void
     {
-        $expr = $this->builder->memberOf("b", ["a"]);
+        $expr = $this->builder->memberOf('b', ['a']);
 
         self::assertInstanceOf(Comparison::class, $expr);
         self::assertEquals(Comparison::MEMBER_OF, $expr->getOperator());
@@ -133,7 +134,7 @@ class ExpressionBuilderTest extends \PHPUnit\Framework\TestCase
 
     public function testStartsWith() : void
     {
-        $expr = $this->builder->startsWith("a", "b");
+        $expr = $this->builder->startsWith('a', 'b');
 
         self::assertInstanceOf(Comparison::class, $expr);
         self::assertEquals(Comparison::STARTS_WITH, $expr->getOperator());
@@ -141,7 +142,7 @@ class ExpressionBuilderTest extends \PHPUnit\Framework\TestCase
 
     public function testEndsWith() : void
     {
-        $expr = $this->builder->endsWith("a", "b");
+        $expr = $this->builder->endsWith('a', 'b');
 
         self::assertInstanceOf(Comparison::class, $expr);
         self::assertEquals(Comparison::ENDS_WITH, $expr->getOperator());

--- a/tests/Doctrine/Tests/DerivedArrayCollection.php
+++ b/tests/Doctrine/Tests/DerivedArrayCollection.php
@@ -9,6 +9,7 @@ use Doctrine\Common\Collections\ArrayCollection;
  */
 final class DerivedArrayCollection extends ArrayCollection
 {
+    /** @var \stdClass */
     private $foo;
 
     public function __construct(\stdClass $foo, array $elements = [])


### PR DESCRIPTION
BC-breaking sniffs disabled. Also disabled checks for iterable types since Collections are built around mixed values.