### PR TITLE
Add extract method to the Collection

### DIFF
--- a/lib/Doctrine/Common/Collections/AbstractLazyCollection.php
+++ b/lib/Doctrine/Common/Collections/AbstractLazyCollection.php
@@ -313,6 +313,16 @@ abstract class AbstractLazyCollection implements Collection
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function extract(Closure $func)
+    {
+        $this->initialize();
+        return $this->collection->extract($func);
+    }
+
+
+    /**
      * Do the initialization logic
      *
      * @return void

--- a/lib/Doctrine/Common/Collections/ArrayCollection.php
+++ b/lib/Doctrine/Common/Collections/ArrayCollection.php
@@ -407,4 +407,25 @@ class ArrayCollection implements Collection, Selectable
 
         return $this->createFrom($filtered);
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function extract(Closure $func)
+    {
+        $extractedList = new ArrayCollection();
+
+        foreach ($this->elements as $element) {
+            $res = $func($element);
+            if ($res === null) {
+                continue;
+            }
+            if (! $extractedList->containsKey($res[0])) {
+                $extractedList[$res[0]] = new ArrayCollection();
+            }
+            $extractedList[$res[0]][] = $res[1];
+        }
+
+        return $extractedList;
+    }
 }

--- a/lib/Doctrine/Common/Collections/Collection.php
+++ b/lib/Doctrine/Common/Collections/Collection.php
@@ -236,4 +236,16 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      * @return array
      */
     public function slice($offset, $length = null);
+
+    /**
+     * Extract elements into a Collection of Collection.
+     *
+     * The predicate must return an array where the first element is the key of the collection and the second element
+     * is the value. If the predicate return null, the value of the predicate is ignored.
+     *
+     * @param Closure $func The predicate.
+     *
+     * @return Collection[]
+     */
+    public function extract(Closure $func);
 }

--- a/lib/Doctrine/Common/Collections/Collection.php
+++ b/lib/Doctrine/Common/Collections/Collection.php
@@ -245,7 +245,7 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      *
      * @param Closure $func The predicate.
      *
-     * @return Collection[]
+     * @return Collection[Collection]
      */
     public function extract(Closure $func);
 }

--- a/tests/Doctrine/Tests/Common/Collections/BaseCollectionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/BaseCollectionTest.php
@@ -223,7 +223,7 @@ abstract class BaseCollectionTest extends TestCase
         self::assertTrue($this->collection->containsKey('key'));
     }
 
-    public function testExtract(): void
+    public function testExtract() : void
     {
         $this->collection->add([0, 1]);
         $this->collection->add([0, 2]);
@@ -231,13 +231,13 @@ abstract class BaseCollectionTest extends TestCase
         $this->collection->add([1, 1]);
         $this->collection->add([2, 42]);
 
-        $res = $this->collection->extract(function($element){
+        $res      = $this->collection->extract(function ($element) {
             return [$element[0] + 1, $element[1]];
         });
         $expected = [
             1 => [1, 2, 3],
             2 => [1],
-            3 => [42]
+            3 => [42],
         ];
         foreach ($res as $i => $array) {
             self::assertEquals(count($expected[$i]), $array->count());

--- a/tests/Doctrine/Tests/Common/Collections/BaseCollectionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/BaseCollectionTest.php
@@ -222,4 +222,28 @@ abstract class BaseCollectionTest extends TestCase
         $this->collection->set('key', null);
         self::assertTrue($this->collection->containsKey('key'));
     }
+
+    public function testExtract(): void
+    {
+        $this->collection->add([0, 1]);
+        $this->collection->add([0, 2]);
+        $this->collection->add([0, 3]);
+        $this->collection->add([1, 1]);
+        $this->collection->add([2, 42]);
+
+        $res = $this->collection->extract(function($element){
+            return [$element[0] + 1, $element[1]];
+        });
+        $expected = [
+            1 => [1, 2, 3],
+            2 => [1],
+            3 => [42]
+        ];
+        foreach ($res as $i => $array) {
+            self::assertEquals(count($expected[$i]), $array->count());
+            foreach ($array as $j => $value) {
+                self::assertEquals($expected[$i][$j], $value);
+            }
+        }
+    }
 }


### PR DESCRIPTION
I created a method in ArrayCollection which is extract elements with a predicate. The differences with the map method is that my method return a key and the value to add to an associative array.