### PR TITLE
Using array_splice instead of unset

### DIFF
--- a/lib/Doctrine/Common/Collections/ArrayCollection.php
+++ b/lib/Doctrine/Common/Collections/ArrayCollection.php
@@ -123,7 +123,7 @@ class ArrayCollection implements Collection, Selectable
         }
 
         $removed = $this->elements[$key];
-        unset($this->elements[$key]);
+        array_splice($this->elements, $key, 1);
 
         return $removed;
     }
@@ -139,7 +139,7 @@ class ArrayCollection implements Collection, Selectable
             return false;
         }
 
-        unset($this->elements[$key]);
+        array_splice($this->elements, $key, 1);
 
         return true;
     }


### PR DESCRIPTION
Using array_splice instead of unset to avoid missing index in the collection that cause issues with json_encode function.