### PR TITLE
Enables automatic serialization with json_encode native function

### DIFF
--- a/lib/Doctrine/Common/Collections/AbstractLazyCollection.php
+++ b/lib/Doctrine/Common/Collections/AbstractLazyCollection.php
@@ -139,6 +139,14 @@ abstract class AbstractLazyCollection implements Collection
     /**
      * {@inheritDoc}
      */
+    public function jsonSerialize()
+    {
+        return $this->toArray();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function first()
     {
         $this->initialize();

--- a/lib/Doctrine/Common/Collections/ArrayCollection.php
+++ b/lib/Doctrine/Common/Collections/ArrayCollection.php
@@ -407,4 +407,12 @@ class ArrayCollection implements Collection, Selectable
 
         return $this->createFrom($filtered);
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function jsonSerialize()
+    {
+        return $this->toArray();
+    }
 }

--- a/lib/Doctrine/Common/Collections/Collection.php
+++ b/lib/Doctrine/Common/Collections/Collection.php
@@ -6,6 +6,7 @@ use ArrayAccess;
 use Closure;
 use Countable;
 use IteratorAggregate;
+use JsonSerializable;
 
 /**
  * The missing (SPL) Collection/Array/OrderedMap interface.
@@ -24,7 +25,7 @@ use IteratorAggregate;
  * position unless you explicitly positioned it before. Prefer iteration with
  * external iterators.
  */
-interface Collection extends Countable, IteratorAggregate, ArrayAccess
+interface Collection extends Countable, IteratorAggregate, ArrayAccess, JsonSerializable
 {
     /**
      * Adds an element at the end of the collection.
@@ -128,6 +129,13 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      * @return array
      */
     public function toArray();
+
+    /**
+     * Gets a native PHP array representation of the collection for the json encoder. Enables automatic serialization
+     *
+     * @return array
+     */
+    public function jsonSerialize();
 
     /**
      * Sets the internal iterator to the first element in the collection and returns this element.

--- a/lib/Doctrine/Common/Collections/Collection.php
+++ b/lib/Doctrine/Common/Collections/Collection.php
@@ -6,7 +6,6 @@ use ArrayAccess;
 use Closure;
 use Countable;
 use IteratorAggregate;
-use JsonSerializable;
 
 /**
  * The missing (SPL) Collection/Array/OrderedMap interface.
@@ -25,7 +24,7 @@ use JsonSerializable;
  * position unless you explicitly positioned it before. Prefer iteration with
  * external iterators.
  */
-interface Collection extends Countable, IteratorAggregate, ArrayAccess, JsonSerializable
+interface Collection extends Countable, IteratorAggregate, ArrayAccess
 {
     /**
      * Adds an element at the end of the collection.
@@ -129,13 +128,6 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess, JsonSeri
      * @return array
      */
     public function toArray();
-
-    /**
-     * Gets a native PHP array representation of the collection for the json encoder. Enables automatic serialization
-     *
-     * @return array
-     */
-    public function jsonSerialize();
 
     /**
      * Sets the internal iterator to the first element in the collection and returns this element.


### PR DESCRIPTION
with this feature, we can now use \json_encode with our Collections.

Before, \json_encode returns null. Now we receive a good response