### PR TITLE
Add prepend() to Collection interface

### DIFF
--- a/lib/Doctrine/Common/Collections/AbstractLazyCollection.php
+++ b/lib/Doctrine/Common/Collections/AbstractLazyCollection.php
@@ -40,6 +40,15 @@ abstract class AbstractLazyCollection implements Collection
     /**
      * {@inheritDoc}
      */
+    public function prepend($element)
+    {
+        $this->initialize();
+        return $this->collection->prepend($element);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function clear()
     {
         $this->initialize();

--- a/lib/Doctrine/Common/Collections/ArrayCollection.php
+++ b/lib/Doctrine/Common/Collections/ArrayCollection.php
@@ -12,6 +12,7 @@ use function array_map;
 use function array_reverse;
 use function array_search;
 use function array_slice;
+use function array_unshift;
 use function array_values;
 use function count;
 use function current;
@@ -22,7 +23,6 @@ use function next;
 use function reset;
 use function spl_object_hash;
 use function uasort;
-use function array_unshift;
 
 /**
  * An ArrayCollection is a Collection implementation that wraps a regular PHP array.

--- a/lib/Doctrine/Common/Collections/ArrayCollection.php
+++ b/lib/Doctrine/Common/Collections/ArrayCollection.php
@@ -22,6 +22,7 @@ use function next;
 use function reset;
 use function spl_object_hash;
 use function uasort;
+use function array_unshift;
 
 /**
  * An ArrayCollection is a Collection implementation that wraps a regular PHP array.

--- a/lib/Doctrine/Common/Collections/ArrayCollection.php
+++ b/lib/Doctrine/Common/Collections/ArrayCollection.php
@@ -280,6 +280,16 @@ class ArrayCollection implements Collection, Selectable
     /**
      * {@inheritDoc}
      */
+    public function prepend($element)
+    {
+        array_unshift($this->elements, $element);
+
+        return true;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function isEmpty()
     {
         return empty($this->elements);

--- a/lib/Doctrine/Common/Collections/Collection.php
+++ b/lib/Doctrine/Common/Collections/Collection.php
@@ -36,6 +36,15 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
     public function add($element);
 
     /**
+     * Adds an element at the begin of the collection.
+     *
+     * @param mixed $element The element to add.
+     *
+     * @return bool Always TRUE.
+     */
+    public function prepend($element);
+
+    /**
      * Clears the collection, removing all elements.
      *
      * @return void

--- a/tests/Doctrine/Tests/Common/Collections/BaseArrayCollectionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/BaseArrayCollectionTest.php
@@ -317,7 +317,7 @@ abstract class BaseArrayCollectionTest extends TestCase
         );
     }
 
-    public function testAdd(): void
+    public function testAdd() : void
     {
         $collection = $this->buildCollection([0]);
         $collection->add(1);
@@ -326,7 +326,7 @@ abstract class BaseArrayCollectionTest extends TestCase
         self::assertSame(1, $collection->last());
     }
 
-    public function testPrepend(): void
+    public function testPrepend() : void
     {
         $collection = $this->buildCollection([0]);
         $collection->prepend(1);

--- a/tests/Doctrine/Tests/Common/Collections/BaseArrayCollectionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/BaseArrayCollectionTest.php
@@ -316,4 +316,22 @@ abstract class BaseArrayCollectionTest extends TestCase
                 ->toArray()
         );
     }
+
+    public function testAdd(): void
+    {
+        $collection = $this->buildCollection([0]);
+        $collection->add(1);
+
+        self::assertTrue($collection->contains(1));
+        self::assertSame(1, $collection->last());
+    }
+
+    public function testPrepend(): void
+    {
+        $collection = $this->buildCollection([0]);
+        $collection->prepend(1);
+
+        self::assertTrue($collection->contains(1));
+        self::assertSame(1, $collection->first());
+    }
 }


### PR DESCRIPTION
New function ´prepend()´ has been added to Colelction interface.
Implementations have been added to ArrayCollection and AbstractLazyCollection.
Tests added.

