### PR TITLE
Allow `ArrayCollection#filter()` to filter by key and also value

### DIFF
--- a/lib/Doctrine/Common/Collections/ArrayCollection.php
+++ b/lib/Doctrine/Common/Collections/ArrayCollection.php
@@ -5,6 +5,7 @@ namespace Doctrine\Common\Collections;
 use ArrayIterator;
 use Closure;
 use Doctrine\Common\Collections\Expr\ClosureExpressionVisitor;
+use const ARRAY_FILTER_USE_BOTH;
 use function array_filter;
 use function array_key_exists;
 use function array_keys;

--- a/lib/Doctrine/Common/Collections/ArrayCollection.php
+++ b/lib/Doctrine/Common/Collections/ArrayCollection.php
@@ -312,7 +312,7 @@ class ArrayCollection implements Collection, Selectable
      */
     public function filter(Closure $p)
     {
-        return $this->createFrom(array_filter($this->elements, $p));
+        return $this->createFrom(array_filter($this->elements, $p, ARRAY_FILTER_USE_BOTH));
     }
 
     /**

--- a/tests/Doctrine/Tests/Common/Collections/BaseCollectionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/BaseCollectionTest.php
@@ -58,6 +58,17 @@ abstract class BaseCollectionTest extends TestCase
         $this->collection->add(1);
         $this->collection->add('foo');
         $this->collection->add(3);
+        $res = $this->collection->filter(static function ($v) {
+            return is_numeric($v);
+        });
+        self::assertEquals([0 => 1, 2 => 3], $res->toArray());
+    }
+
+    public function testFilterByValueAndKey() : void
+    {
+        $this->collection->add(1);
+        $this->collection->add('foo');
+        $this->collection->add(3);
         $this->collection->add(4);
         $this->collection->add(5);
         $res = $this->collection->filter(static function ($v, $k) {

--- a/tests/Doctrine/Tests/Common/Collections/BaseCollectionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/BaseCollectionTest.php
@@ -58,10 +58,12 @@ abstract class BaseCollectionTest extends TestCase
         $this->collection->add(1);
         $this->collection->add('foo');
         $this->collection->add(3);
-        $res = $this->collection->filter(static function ($e) {
-            return is_numeric($e);
+        $this->collection->add(4);
+        $this->collection->add(5);
+        $res = $this->collection->filter(static function ($v, $k) {
+            return is_numeric($v) && $k % 2 === 0;
         });
-        self::assertEquals([0 => 1, 2 => 3], $res->toArray());
+        self::assertEquals([0 => 1, 2 => 3, 4 => 5], $res->toArray());
     }
 
     public function testFirstAndLast() : void

--- a/tests/Doctrine/Tests/Common/Collections/BaseCollectionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/BaseCollectionTest.php
@@ -74,7 +74,7 @@ abstract class BaseCollectionTest extends TestCase
         $res = $this->collection->filter(static function ($v, $k) {
             return is_numeric($v) && $k % 2 === 0;
         });
-        self::assertEquals([0 => 1, 2 => 3, 4 => 5], $res->toArray());
+        self::assertSame([0 => 1, 2 => 3, 4 => 5], $res->toArray());
     }
 
     public function testFirstAndLast() : void

--- a/tests/Doctrine/Tests/Common/Collections/BaseCollectionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/BaseCollectionTest.php
@@ -58,8 +58,8 @@ abstract class BaseCollectionTest extends TestCase
         $this->collection->add(1);
         $this->collection->add('foo');
         $this->collection->add(3);
-        $res = $this->collection->filter(static function ($v) {
-            return is_numeric($v);
+        $res = $this->collection->filter(static function ($e) {
+            return is_numeric($e);
         });
         self::assertEquals([0 => 1, 2 => 3], $res->toArray());
     }


### PR DESCRIPTION
Uses ARRAY_FILTER_USE_BOTH in the underlying array_filter function. Does
not cause BC Break.

Any examples where how to run benchmarks against this?

https://github.com/doctrine/collections/issues/165