### PR TITLE
Enable strict comparison for arrays of scalar values

### DIFF
--- a/lib/Doctrine/Common/Collections/Expr/ClosureExpressionVisitor.php
+++ b/lib/Doctrine/Common/Collections/Expr/ClosureExpressionVisitor.php
@@ -7,6 +7,7 @@ use Closure;
 use RuntimeException;
 use function in_array;
 use function is_array;
+use function is_scalar;
 use function iterator_to_array;
 use function method_exists;
 use function preg_replace_callback;

--- a/lib/Doctrine/Common/Collections/Expr/ClosureExpressionVisitor.php
+++ b/lib/Doctrine/Common/Collections/Expr/ClosureExpressionVisitor.php
@@ -153,12 +153,16 @@ class ClosureExpressionVisitor extends ExpressionVisitor
 
             case Comparison::IN:
                 return static function ($object) use ($field, $value) : bool {
-                    return in_array(ClosureExpressionVisitor::getObjectFieldValue($object, $field), $value, true);
+                    $fieldValue = ClosureExpressionVisitor::getObjectFieldValue($object, $field);
+
+                    return in_array($fieldValue, $value, is_scalar($fieldValue));
                 };
 
             case Comparison::NIN:
                 return static function ($object) use ($field, $value) : bool {
-                    return ! in_array(ClosureExpressionVisitor::getObjectFieldValue($object, $field), $value, true);
+                    $fieldValue = ClosureExpressionVisitor::getObjectFieldValue($object, $field);
+
+                    return ! in_array($fieldValue, $value, is_scalar($fieldValue));
                 };
 
             case Comparison::CONTAINS:

--- a/tests/Doctrine/Tests/Common/Collections/ClosureExpressionVisitorTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/ClosureExpressionVisitorTest.php
@@ -136,6 +136,17 @@ class ClosureExpressionVisitorTest extends TestCase
         self::assertTrue($closure(new TestObject('04')));
     }
 
+    public function testWalkInComparisonObjects() : void
+    {
+        $closure = $this->visitor->walkComparison($this->builder->in('foo', [new TestObject(1), new TestObject(2)]));
+
+        self::assertTrue($closure(new TestObject(new TestObject(2))));
+        self::assertTrue($closure(new TestObject(new TestObject(1))));
+        self::assertFalse($closure(new TestObject(new TestObject(0))));
+        self::assertFalse($closure(new TestObject(4)));
+        self::assertFalse($closure(new TestObject('04')));
+    }
+
     public function testWalkNotInComparison() : void
     {
         $closure = $this->visitor->walkComparison($this->builder->notIn('foo', [1, 2, 3, '04']));
@@ -145,6 +156,17 @@ class ClosureExpressionVisitorTest extends TestCase
         self::assertTrue($closure(new TestObject(0)));
         self::assertTrue($closure(new TestObject(4)));
         self::assertFalse($closure(new TestObject('04')));
+    }
+
+    public function testWalkNotInComparisonObjects() : void
+    {
+        $closure = $this->visitor->walkComparison($this->builder->notIn('foo', [new TestObject(1), new TestObject(2)]));
+
+        self::assertFalse($closure(new TestObject(new TestObject(1))));
+        self::assertFalse($closure(new TestObject(new TestObject(1))));
+        self::assertTrue($closure(new TestObject(new TestObject(0))));
+        self::assertTrue($closure(new TestObject(4)));
+        self::assertTrue($closure(new TestObject('04')));
     }
 
     public function testWalkContainsComparison() : void


### PR DESCRIPTION
With the change in v1.5.0 that enabled strict `in_array` checks, if an array of objects is passed, it is strictly checked instead of doing a more passive check on the values. This enables the ability to pass an array objects (i.e. Discriminated entities) to be used in filtering an array without the objects being the exact same object in memory.

This PR is in response to #113 