### PR TITLE
Preserve keys in ArrayCollection for Criteria firstresults/maxresults

### DIFF
--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -301,17 +301,17 @@ matching
 --------
 
 Selects all elements from a selectable that match the expression and
-returns a new collection containing these elements.
+returns a new collection containing these elements and preserved keys.
 
 .. code-block:: php
     use Doctrine\Common\Collections\Criteria;
     use Doctrine\Common\Collections\Expr\Comparison;
 
     $collection = new ArrayCollection([
-        [
+        'wage' => [
             'name' => 'jwage',
         ],
-        [
+        'roman' => [
             'name' => 'romanb',
         ],
     ]);
@@ -322,6 +322,6 @@ returns a new collection containing these elements.
 
     $criteria->where($expr);
 
-    $matched = $collection->matching($criteria); // ['jwage']
+    $matchingCollection = $collection->matching($criteria); // [ 'wage' => [ 'name' => 'jwage' ]]
 
 You can read more about expressions :ref:`here <expressions>`.

--- a/lib/Doctrine/Common/Collections/ArrayCollection.php
+++ b/lib/Doctrine/Common/Collections/ArrayCollection.php
@@ -403,7 +403,7 @@ class ArrayCollection implements Collection, Selectable
         $length = $criteria->getMaxResults();
 
         if ($offset || $length) {
-            $filtered = array_slice($filtered, (int) $offset, $length);
+            $filtered = array_slice($filtered, (int) $offset, $length, true);
         }
 
         return $this->createFrom($filtered);

--- a/lib/Doctrine/Common/Collections/Selectable.php
+++ b/lib/Doctrine/Common/Collections/Selectable.php
@@ -18,7 +18,7 @@ interface Selectable
 {
     /**
      * Selects all elements from a selectable that match the expression and
-     * returns a new collection containing these elements.
+     * returns a new collection containing these elements and preserved keys.
      *
      * @return Collection
      */

--- a/tests/Doctrine/Tests/Common/Collections/BaseArrayCollectionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/BaseArrayCollectionTest.php
@@ -292,6 +292,31 @@ abstract class BaseArrayCollectionTest extends TestCase
         );
     }
 
+    public function testMatchingWithSlicingPreserveKeys() : void
+    {
+
+        $collection = $this->buildCollection([
+            0 => 1,
+            1 => 2,
+            2 => 3,
+            3 => 4,
+        ]);
+
+        if (! $this->isSelectable($collection)) {
+            $this->markTestSkipped('Collection does not support Selectable interface');
+        }
+
+        self::assertSame(
+            [
+                1 => 2,
+                2 => 3,
+            ],
+            $collection
+                ->matching(new Criteria(null, null, 1, 2))
+                ->toArray()
+        );
+    }
+
     public function testMultiColumnSortAppliesAllSorts() : void
     {
         $collection = $this->buildCollection([

--- a/tests/Doctrine/Tests/Common/Collections/BaseArrayCollectionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/BaseArrayCollectionTest.php
@@ -292,29 +292,92 @@ abstract class BaseArrayCollectionTest extends TestCase
         );
     }
 
-    public function testMatchingWithSlicingPreserveKeys() : void
+    /**
+     * @param int[] $array
+     * @param int[] $slicedArray
+     *
+     * @dataProvider provideSlices
+     */
+    public function testMatchingWithSlicingPreserveKeys(array $array, array $slicedArray, ?int $firstResult, ?int $maxResult) : void
     {
-
-        $collection = $this->buildCollection([
-            0 => 1,
-            1 => 2,
-            2 => 3,
-            3 => 4,
-        ]);
+        $collection = $this->buildCollection($array);
 
         if (! $this->isSelectable($collection)) {
             $this->markTestSkipped('Collection does not support Selectable interface');
         }
 
         self::assertSame(
-            [
-                1 => 2,
-                2 => 3,
-            ],
+            $slicedArray,
             $collection
-                ->matching(new Criteria(null, null, 1, 2))
+                ->matching(new Criteria(null, null, $firstResult, $maxResult))
                 ->toArray()
         );
+    }
+
+    /**
+     * @return mixed[][]
+     */
+    public function provideSlices() : array
+    {
+        return [
+            'preserve numeric keys' => [
+                [
+                    0 => 1,
+                    1 => 2,
+                    2 => 3,
+                    3 => 4,
+                ],
+                [
+                    1 => 2,
+                    2 => 3,
+                ],
+                1,
+                2,
+            ],
+            'preserve string keys' => [
+                [
+                    'a' => 1,
+                    'b' => 2,
+                    'c' => 3,
+                    'd' => 4,
+                ],
+                [
+                    'b' => 2,
+                    'c' => 3,
+                ],
+                1,
+                2,
+            ],
+            'preserve keys on firstresult only' => [
+                [
+                    'a' => 1,
+                    'b' => 2,
+                    'c' => 3,
+                    'd' => 4,
+                ],
+                [
+                    'b' => 2,
+                    'c' => 3,
+                    'd' => 4,
+                ],
+                1,
+                null,
+            ],
+            'preserve keys on maxresult only' => [
+                [
+                    'a' => 1,
+                    'b' => 2,
+                    'c' => 3,
+                    'd' => 4,
+                ],
+                [
+                    'a' => 1,
+                    'b' => 2,
+                ],
+                null,
+                2,
+            ],
+        ];
     }
 
     public function testMultiColumnSortAppliesAllSorts() : void

--- a/tests/Doctrine/Tests/Common/Collections/CollectionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/CollectionTest.php
@@ -62,6 +62,6 @@ class CollectionTest extends BaseCollectionTest
         self::assertInstanceOf(Collection::class, $col);
         self::assertNotSame($col, $this->collection);
         self::assertEquals(1, count($col));
-        self::assertEquals('baz', $col[0]->foo);
+        self::assertEquals('baz', $col[1]->foo);
     }
 }


### PR DESCRIPTION
When a `Crieria` is used with a set firstresult or maxresult, the keys of the resulting ArrayCollection are not preserved.

Because keys are kept on `map` or `filter` too, I expect `matching`, like with the order criteria, to keep the keys with a criteria that slices a result.