### PR TITLE
Generify collections using Psalm

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,7 +1,7 @@
 build:
     environment:
         php:
-            version: 7.1.0
+            version: 7.1.3
 
 tools:
     external_code_coverage:

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,3 +47,8 @@ jobs:
       env: STATIC_ANALYSIS
       install: travis_retry composer install --prefer-dist
       script: vendor/bin/phpstan analyse -l 3 lib
+
+    - stage: Code Quality
+      env: STATIC_ANALYSIS
+      install: travis_retry composer install --prefer-dist
+      script: vendor/bin/psalm

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,9 @@
         {"name": "Jonathan Wage", "email": "jonwage@gmail.com"},
         {"name": "Johannes Schmitt", "email": "schmittjoh@gmail.com"}
     ],
+    "suggest": {
+        "vimeo/psalm": "Psalm allows you to enforce template types for your collections."
+    },
     "require": {
         "php": "^7.1.3"
     },

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         {"name": "Johannes Schmitt", "email": "schmittjoh@gmail.com"}
     ],
     "require": {
-        "php": "^7.1"
+        "php": "^7.1.3"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.0",

--- a/composer.json
+++ b/composer.json
@@ -17,9 +17,6 @@
         {"name": "Jonathan Wage", "email": "jonwage@gmail.com"},
         {"name": "Johannes Schmitt", "email": "schmittjoh@gmail.com"}
     ],
-    "suggest": {
-        "vimeo/psalm": "Psalm allows you to enforce template types for your collections."
-    },
     "require": {
         "php": "^7.1.3"
     },

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "phpunit/phpunit": "^7.0",
         "doctrine/coding-standard": "^6.0",
         "phpstan/phpstan-shim": "^0.9.2",
-        "vimeo/psalm": "^3.1"
+        "vimeo/psalm": "^3.2"
     },
     "autoload": {
         "psr-4": { "Doctrine\\Common\\Collections\\": "lib/Doctrine/Common/Collections" }

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "phpunit/phpunit": "^7.0",
         "doctrine/coding-standard": "^6.0",
         "phpstan/phpstan-shim": "^0.9.2",
-        "vimeo/psalm": "^3.2"
+        "vimeo/psalm": "^3.2.2"
     },
     "autoload": {
         "psr-4": { "Doctrine\\Common\\Collections\\": "lib/Doctrine/Common/Collections" }

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
     "require-dev": {
         "phpunit/phpunit": "^7.0",
         "doctrine/coding-standard": "^6.0",
-        "phpstan/phpstan-shim": "^0.9.2"
+        "phpstan/phpstan-shim": "^0.9.2",
+        "vimeo/psalm": "^3.1"
     },
     "autoload": {
         "psr-4": { "Doctrine\\Common\\Collections\\": "lib/Doctrine/Common/Collections" }

--- a/composer.lock
+++ b/composer.lock
@@ -4,9 +4,188 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3110654c561f87d0733ed1cc2af09006",
+    "content-hash": "7014339bd22658dfdc6a95cff353a5e2",
     "packages": [],
     "packages-dev": [
+        {
+            "name": "amphp/amp",
+            "version": "v2.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/amp.git",
+                "reference": "7075ef7d74dbd32626bfd31c976b23055c3ade6a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/amp/zipball/7075ef7d74dbd32626bfd31c976b23055c3ade6a",
+                "reference": "7075ef7d74dbd32626bfd31c976b23055c3ade6a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7"
+            },
+            "require-dev": {
+                "amphp/phpunit-util": "^1",
+                "friendsofphp/php-cs-fixer": "^2.3",
+                "phpstan/phpstan": "^0.8.5",
+                "phpunit/phpunit": "^6.0.9",
+                "react/promise": "^2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Amp\\": "lib"
+                },
+                "files": [
+                    "lib/functions.php",
+                    "lib/Internal/functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bob Weinand",
+                    "email": "bobwei9@hotmail.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                },
+                {
+                    "name": "Daniel Lowrey",
+                    "email": "rdlowrey@php.net"
+                },
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                }
+            ],
+            "description": "A non-blocking concurrency framework for PHP applications.",
+            "homepage": "http://amphp.org/amp",
+            "keywords": [
+                "async",
+                "asynchronous",
+                "awaitable",
+                "concurrency",
+                "event",
+                "event-loop",
+                "future",
+                "non-blocking",
+                "promise"
+            ],
+            "time": "2018-12-11T10:31:37+00:00"
+        },
+        {
+            "name": "amphp/byte-stream",
+            "version": "v1.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/byte-stream.git",
+                "reference": "6bbfcb6f47e92577e739586ba0c87e867be70a23"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/byte-stream/zipball/6bbfcb6f47e92577e739586ba0c87e867be70a23",
+                "reference": "6bbfcb6f47e92577e739586ba0c87e867be70a23",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^2"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "dev-master",
+                "amphp/phpunit-util": "^1",
+                "friendsofphp/php-cs-fixer": "^2.3",
+                "infection/infection": "^0.9.3",
+                "phpunit/phpunit": "^6"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Amp\\ByteStream\\": "lib"
+                },
+                "files": [
+                    "lib/functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                },
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                }
+            ],
+            "description": "A stream abstraction to make working with non-blocking I/O simple.",
+            "homepage": "http://amphp.org/byte-stream",
+            "keywords": [
+                "amp",
+                "amphp",
+                "async",
+                "io",
+                "non-blocking",
+                "stream"
+            ],
+            "time": "2018-12-27T18:08:06+00:00"
+        },
+        {
+            "name": "composer/xdebug-handler",
+            "version": "1.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/xdebug-handler.git",
+                "reference": "d17708133b6c276d6e42ef887a877866b909d892"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/d17708133b6c276d6e42ef887a877866b909d892",
+                "reference": "d17708133b6c276d6e42ef887a877866b909d892",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.2 || ^7.0",
+                "psr/log": "^1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Composer\\XdebugHandler\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "John Stevenson",
+                    "email": "john-stevenson@blueyonder.co.uk"
+                }
+            ],
+            "description": "Restarts a process without xdebug.",
+            "keywords": [
+                "Xdebug",
+                "performance"
+            ],
+            "time": "2019-01-28T20:25:53+00:00"
+        },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
             "version": "v0.5.0",
@@ -189,6 +368,150 @@
             "time": "2017-07-22T11:58:36+00:00"
         },
         {
+            "name": "felixfbecker/advanced-json-rpc",
+            "version": "v3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/felixfbecker/php-advanced-json-rpc.git",
+                "reference": "241c470695366e7b83672be04ea0e64d8085a551"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/felixfbecker/php-advanced-json-rpc/zipball/241c470695366e7b83672be04ea0e64d8085a551",
+                "reference": "241c470695366e7b83672be04ea0e64d8085a551",
+                "shasum": ""
+            },
+            "require": {
+                "netresearch/jsonmapper": "^1.0",
+                "php": ">=7.0",
+                "phpdocumentor/reflection-docblock": "^4.0.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "AdvancedJsonRpc\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "ISC"
+            ],
+            "authors": [
+                {
+                    "name": "Felix Becker",
+                    "email": "felix.b@outlook.com"
+                }
+            ],
+            "description": "A more advanced JSONRPC implementation",
+            "time": "2018-09-10T08:58:41+00:00"
+        },
+        {
+            "name": "felixfbecker/language-server-protocol",
+            "version": "v1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/felixfbecker/php-language-server-protocol.git",
+                "reference": "1bdd1bcc95428edf85ec04c7b558d0886c07280f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/felixfbecker/php-language-server-protocol/zipball/1bdd1bcc95428edf85ec04c7b558d0886c07280f",
+                "reference": "1bdd1bcc95428edf85ec04c7b558d0886c07280f",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "*",
+                "phpunit/phpunit": "^6.3",
+                "squizlabs/php_codesniffer": "^3.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "LanguageServerProtocol\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "ISC"
+            ],
+            "authors": [
+                {
+                    "name": "Felix Becker",
+                    "email": "felix.b@outlook.com"
+                }
+            ],
+            "description": "PHP classes for the Language Server Protocol",
+            "keywords": [
+                "language",
+                "microsoft",
+                "php",
+                "server"
+            ],
+            "time": "2018-09-25T11:42:25+00:00"
+        },
+        {
+            "name": "muglug/package-versions-56",
+            "version": "1.2.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/muglug/PackageVersions.git",
+                "reference": "a67bed26deaaf9269a348e53063bc8d4dcc60ffd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/muglug/PackageVersions/zipball/a67bed26deaaf9269a348e53063bc8d4dcc60ffd",
+                "reference": "a67bed26deaaf9269a348e53063bc8d4dcc60ffd",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0",
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "composer/composer": "^1.3",
+                "ext-zip": "*",
+                "phpunit/phpunit": "^5.7.5"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Muglug\\PackageVersions\\Installer",
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Muglug\\PackageVersions\\": "src/PackageVersions"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com"
+                },
+                {
+                    "name": "Abdul Malik Ikhsan",
+                    "email": "samsonasik@gmail.com"
+                },
+                {
+                    "name": "Matt Brown",
+                    "email": "github@muglug.com"
+                }
+            ],
+            "description": "A backport of ocramius/package-versions that supports php ^5.6. Composer plugin that provides efficient querying for installed package versions (no runtime IO)",
+            "time": "2018-03-26T03:22:13+00:00"
+        },
+        {
             "name": "myclabs/deep-copy",
             "version": "1.7.0",
             "source": {
@@ -232,6 +555,148 @@
                 "object graph"
             ],
             "time": "2017-10-19T19:58:43+00:00"
+        },
+        {
+            "name": "netresearch/jsonmapper",
+            "version": "v1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cweiske/jsonmapper.git",
+                "reference": "3868fe1128ce1169228acdb623359dca74db5ef3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cweiske/jsonmapper/zipball/3868fe1128ce1169228acdb623359dca74db5ef3",
+                "reference": "3868fe1128ce1169228acdb623359dca74db5ef3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.8.35 || ~5.7 || ~6.4",
+                "squizlabs/php_codesniffer": "~1.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "JsonMapper": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "OSL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Weiske",
+                    "email": "cweiske@cweiske.de",
+                    "homepage": "http://github.com/cweiske/jsonmapper/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Map nested JSON structures onto PHP classes",
+            "time": "2017-11-28T21:30:01+00:00"
+        },
+        {
+            "name": "nikic/php-parser",
+            "version": "v4.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "5221f49a608808c1e4d436df32884cbc1b821ac0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/5221f49a608808c1e4d436df32884cbc1b821ac0",
+                "reference": "5221f49a608808c1e4d436df32884cbc1b821ac0",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.5 || ^7.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "time": "2019-02-16T20:54:15+00:00"
+        },
+        {
+            "name": "openlss/lib-array2xml",
+            "version": "0.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nullivex/lib-array2xml.git",
+                "reference": "c8b5998a342d7861f2e921403f44e0a2f3ef2be0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nullivex/lib-array2xml/zipball/c8b5998a342d7861f2e921403f44e0a2f3ef2be0",
+                "reference": "c8b5998a342d7861f2e921403f44e0a2f3ef2be0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "LSS": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Bryan Tong",
+                    "email": "contact@nullivex.com",
+                    "homepage": "http://bryantong.com"
+                },
+                {
+                    "name": "Tony Butler",
+                    "email": "spudz76@gmail.com",
+                    "homepage": "http://openlss.org"
+                }
+            ],
+            "description": "Array2XML conversion library credit to lalit.org",
+            "homepage": "http://openlss.org",
+            "keywords": [
+                "array",
+                "array conversion",
+                "xml",
+                "xml conversion"
+            ],
+            "time": "2016-11-10T19:10:18+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -334,6 +799,57 @@
             ],
             "description": "Library for handling version information and constraints",
             "time": "2017-03-05T17:38:23+00:00"
+        },
+        {
+            "name": "php-cs-fixer/diff",
+            "version": "v1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHP-CS-Fixer/diff.git",
+                "reference": "78bb099e9c16361126c86ce82ec4405ebab8e756"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/diff/zipball/78bb099e9c16361126c86ce82ec4405ebab8e756",
+                "reference": "78bb099e9c16361126c86ce82ec4405ebab8e756",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.7.23 || ^6.4.3",
+                "symfony/process": "^3.3"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "SpacePossum"
+                }
+            ],
+            "description": "sebastian/diff v2 backport support for PHP5.6",
+            "homepage": "https://github.com/PHP-CS-Fixer",
+            "keywords": [
+                "diff"
+            ],
+            "time": "2018-02-15T16:58:55+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -486,6 +1002,67 @@
                 }
             ],
             "time": "2017-07-14T14:27:02+00:00"
+        },
+        {
+            "name": "phpmyadmin/sql-parser",
+            "version": "v4.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpmyadmin/sql-parser.git",
+                "reference": "0eb16ef5e3acacbc792be336754e42d98791a33f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpmyadmin/sql-parser/zipball/0eb16ef5e3acacbc792be336754e42d98791a33f",
+                "reference": "0eb16ef5e3acacbc792be336754e42d98791a33f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0",
+                "symfony/polyfill-mbstring": "^1.3"
+            },
+            "conflict": {
+                "phpmyadmin/motranslator": "<3.0"
+            },
+            "require-dev": {
+                "phpunit/php-code-coverage": "*",
+                "phpunit/phpunit": "~4.8 || ~5.7 || ~6.5",
+                "sami/sami": "^4.0"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance",
+                "phpmyadmin/motranslator": "Translate messages to your favorite locale"
+            },
+            "bin": [
+                "bin/highlight-query",
+                "bin/lint-query"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PhpMyAdmin\\SqlParser\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "The phpMyAdmin Team",
+                    "email": "developers@phpmyadmin.net",
+                    "homepage": "https://www.phpmyadmin.net/team/"
+                }
+            ],
+            "description": "A validating SQL lexer and parser with a focus on MySQL dialect.",
+            "homepage": "https://github.com/phpmyadmin/sql-parser",
+            "keywords": [
+                "analysis",
+                "lexer",
+                "parser",
+                "sql"
+            ],
+            "time": "2019-01-05T13:46:38+00:00"
         },
         {
             "name": "phpspec/prophecy",
@@ -1017,6 +1594,53 @@
                 "xunit"
             ],
             "time": "2018-02-15T05:27:38+00:00"
+        },
+        {
+            "name": "psr/log",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "6c001f1daafa3a3ac1d8ff69ee4db8e799a654dd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/6c001f1daafa3a3ac1d8ff69ee4db8e799a654dd",
+                "reference": "6c001f1daafa3a3ac1d8ff69ee4db8e799a654dd",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "Psr/Log/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "time": "2018-11-20T15:27:04+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -1673,6 +2297,205 @@
             "time": "2018-12-19T23:57:18+00:00"
         },
         {
+            "name": "symfony/console",
+            "version": "v4.2.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/console.git",
+                "reference": "9dc2299a016497f9ee620be94524e6c0af0280a9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/console/zipball/9dc2299a016497f9ee620be94524e6c0af0280a9",
+                "reference": "9dc2299a016497f9ee620be94524e6c0af0280a9",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3",
+                "symfony/contracts": "^1.0",
+                "symfony/polyfill-mbstring": "~1.0"
+            },
+            "conflict": {
+                "symfony/dependency-injection": "<3.4",
+                "symfony/process": "<3.3"
+            },
+            "provide": {
+                "psr/log-implementation": "1.0"
+            },
+            "require-dev": {
+                "psr/log": "~1.0",
+                "symfony/config": "~3.4|~4.0",
+                "symfony/dependency-injection": "~3.4|~4.0",
+                "symfony/event-dispatcher": "~3.4|~4.0",
+                "symfony/lock": "~3.4|~4.0",
+                "symfony/process": "~3.4|~4.0"
+            },
+            "suggest": {
+                "psr/log": "For using the console logger",
+                "symfony/event-dispatcher": "",
+                "symfony/lock": "",
+                "symfony/process": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Console\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Console Component",
+            "homepage": "https://symfony.com",
+            "time": "2019-02-23T15:17:42+00:00"
+        },
+        {
+            "name": "symfony/contracts",
+            "version": "v1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/contracts.git",
+                "reference": "1aa7ab2429c3d594dd70689604b5cf7421254cdf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/contracts/zipball/1aa7ab2429c3d594dd70689604b5cf7421254cdf",
+                "reference": "1aa7ab2429c3d594dd70689604b5cf7421254cdf",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3"
+            },
+            "require-dev": {
+                "psr/cache": "^1.0",
+                "psr/container": "^1.0"
+            },
+            "suggest": {
+                "psr/cache": "When using the Cache contracts",
+                "psr/container": "When using the Service contracts",
+                "symfony/cache-contracts-implementation": "",
+                "symfony/service-contracts-implementation": "",
+                "symfony/translation-contracts-implementation": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\": ""
+                },
+                "exclude-from-classmap": [
+                    "**/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A set of abstractions extracted out of the Symfony components",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "time": "2018-12-05T08:06:11+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "c79c051f5b3a46be09205c73b80b346e4153e494"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/c79c051f5b3a46be09205c73b80b346e4153e494",
+                "reference": "c79c051f5b3a46be09205c73b80b346e4153e494",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.9-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2018-09-21T13:07:52+00:00"
+        },
+        {
             "name": "theseer/tokenizer",
             "version": "1.1.0",
             "source": {
@@ -1711,6 +2534,86 @@
             ],
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
             "time": "2017-04-07T12:08:54+00:00"
+        },
+        {
+            "name": "vimeo/psalm",
+            "version": "3.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/vimeo/psalm.git",
+                "reference": "6efa978680b891ef4e4ca5718323073d809cea01"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/6efa978680b891ef4e4ca5718323073d809cea01",
+                "reference": "6efa978680b891ef4e4ca5718323073d809cea01",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^2.1",
+                "amphp/byte-stream": "^1.5",
+                "composer/xdebug-handler": "^1.1",
+                "felixfbecker/advanced-json-rpc": "^3.0.3",
+                "felixfbecker/language-server-protocol": "^1.2",
+                "muglug/package-versions-56": "1.2.4",
+                "netresearch/jsonmapper": "^1.0",
+                "nikic/php-parser": "^4.0.2 || ^4.1",
+                "openlss/lib-array2xml": "^0.0.10||^0.5.1",
+                "php": "^7.0",
+                "php-cs-fixer/diff": "^1.2",
+                "phpmyadmin/sql-parser": "^4.0",
+                "symfony/console": "^3.0||^4.0",
+                "webmozart/glob": "^4.1",
+                "webmozart/path-util": "^2.3"
+            },
+            "provide": {
+                "psalm/psalm": "self.version"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.2",
+                "phpunit/phpunit": "^6.0 || ^7.0",
+                "psalm/plugin-phpunit": "^0.5.1",
+                "squizlabs/php_codesniffer": "^3.0"
+            },
+            "suggest": {
+                "ext-igbinary": "^2.0.5"
+            },
+            "bin": [
+                "psalm",
+                "psalter",
+                "psalm-language-server",
+                "psalm-plugin"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev",
+                    "dev-2.x": "2.x-dev",
+                    "dev-1.x": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psalm\\Plugin\\": "src/Psalm/Plugin",
+                    "Psalm\\": "src/Psalm"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Matthew Brown"
+                }
+            ],
+            "description": "A static analysis tool for finding errors in PHP applications",
+            "keywords": [
+                "code",
+                "inspection",
+                "php"
+            ],
+            "time": "2019-03-12T12:55:38+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -1761,6 +2664,99 @@
                 "validate"
             ],
             "time": "2018-01-29T19:49:41+00:00"
+        },
+        {
+            "name": "webmozart/glob",
+            "version": "4.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozart/glob.git",
+                "reference": "3cbf63d4973cf9d780b93d2da8eec7e4a9e63bbe"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozart/glob/zipball/3cbf63d4973cf9d780b93d2da8eec7e4a9e63bbe",
+                "reference": "3cbf63d4973cf9d780b93d2da8eec7e4a9e63bbe",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.3|^7.0",
+                "webmozart/path-util": "^2.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.6",
+                "sebastian/version": "^1.0.1",
+                "symfony/filesystem": "^2.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\Glob\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "A PHP implementation of Ant's glob.",
+            "time": "2015-12-29T11:14:33+00:00"
+        },
+        {
+            "name": "webmozart/path-util",
+            "version": "2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozart/path-util.git",
+                "reference": "d939f7edc24c9a1bb9c0dee5cb05d8e859490725"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozart/path-util/zipball/d939f7edc24c9a1bb9c0dee5cb05d8e859490725",
+                "reference": "d939f7edc24c9a1bb9c0dee5cb05d8e859490725",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "webmozart/assert": "~1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.6",
+                "sebastian/version": "^1.0.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\PathUtil\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "A robust cross-platform utility for normalizing, comparing and modifying file paths.",
+            "time": "2015-12-17T08:42:14+00:00"
         }
     ],
     "aliases": [],

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7014339bd22658dfdc6a95cff353a5e2",
+    "content-hash": "663068946b0b278bdafdd8bb777bb4c2",
     "packages": [],
     "packages-dev": [
         {
@@ -1593,6 +1593,7 @@
                 "mock",
                 "xunit"
             ],
+            "abandoned": true,
             "time": "2018-02-15T05:27:38+00:00"
         },
         {
@@ -2537,16 +2538,16 @@
         },
         {
             "name": "vimeo/psalm",
-            "version": "3.1.3",
+            "version": "3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "6efa978680b891ef4e4ca5718323073d809cea01"
+                "reference": "3704e75049703e861cda4585b66d49e3eb6810bd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/6efa978680b891ef4e4ca5718323073d809cea01",
-                "reference": "6efa978680b891ef4e4ca5718323073d809cea01",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/3704e75049703e861cda4585b66d49e3eb6810bd",
+                "reference": "3704e75049703e861cda4585b66d49e3eb6810bd",
                 "shasum": ""
             },
             "require": {
@@ -2613,7 +2614,7 @@
                 "inspection",
                 "php"
             ],
-            "time": "2019-03-12T12:55:38+00:00"
+            "time": "2019-03-14T14:23:26+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -2765,7 +2766,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.1"
+        "php": "^7.1.3"
     },
     "platform-dev": []
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e0e1fd6f2f470ccb15ba29bab769a4be",
+    "content-hash": "9089934b1d5718afcff78cb110ec244a",
     "packages": [],
     "packages-dev": [
         {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "663068946b0b278bdafdd8bb777bb4c2",
+    "content-hash": "e0e1fd6f2f470ccb15ba29bab769a4be",
     "packages": [],
     "packages-dev": [
         {
@@ -2438,6 +2438,64 @@
             "time": "2018-12-05T08:06:11+00:00"
         },
         {
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "e3d826245268269cd66f8326bd8bc066687b4a19"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/e3d826245268269cd66f8326bd8bc066687b4a19",
+                "reference": "e3d826245268269cd66f8326bd8bc066687b4a19",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.9-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                },
+                {
+                    "name": "Gert de Pagter",
+                    "email": "backendtea@gmail.com"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "time": "2018-08-06T14:22:27+00:00"
+        },
+        {
             "name": "symfony/polyfill-mbstring",
             "version": "v1.10.0",
             "source": {
@@ -2538,16 +2596,16 @@
         },
         {
             "name": "vimeo/psalm",
-            "version": "3.2",
+            "version": "3.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "3704e75049703e861cda4585b66d49e3eb6810bd"
+                "reference": "f0ddc6f3bc35ba7ecb99232903907a1d5ec1c8e8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/3704e75049703e861cda4585b66d49e3eb6810bd",
-                "reference": "3704e75049703e861cda4585b66d49e3eb6810bd",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/f0ddc6f3bc35ba7ecb99232903907a1d5ec1c8e8",
+                "reference": "f0ddc6f3bc35ba7ecb99232903907a1d5ec1c8e8",
                 "shasum": ""
             },
             "require": {
@@ -2614,24 +2672,25 @@
                 "inspection",
                 "php"
             ],
-            "time": "2019-03-14T14:23:26+00:00"
+            "time": "2019-03-17T22:14:30+00:00"
         },
         {
             "name": "webmozart/assert",
-            "version": "1.3.0",
+            "version": "1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozart/assert.git",
-                "reference": "0df1908962e7a3071564e857d86874dad1ef204a"
+                "reference": "83e253c8e0be5b0257b881e1827274667c5c17a9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/0df1908962e7a3071564e857d86874dad1ef204a",
-                "reference": "0df1908962e7a3071564e857d86874dad1ef204a",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/83e253c8e0be5b0257b881e1827274667c5c17a9",
+                "reference": "83e253c8e0be5b0257b881e1827274667c5c17a9",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0"
+                "php": "^5.3.3 || ^7.0",
+                "symfony/polyfill-ctype": "^1.8"
             },
             "require-dev": {
                 "phpunit/phpunit": "^4.6",
@@ -2664,7 +2723,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2018-01-29T19:49:41+00:00"
+            "time": "2018-12-25T11:19:39+00:00"
         },
         {
             "name": "webmozart/glob",

--- a/lib/Doctrine/Common/Collections/AbstractLazyCollection.php
+++ b/lib/Doctrine/Common/Collections/AbstractLazyCollection.php
@@ -8,6 +8,7 @@ use Closure;
  * Lazy collection that is backed by a concrete collection
  *
  * @template T
+ * @template-extends Collection<T>
  */
 abstract class AbstractLazyCollection implements Collection
 {

--- a/lib/Doctrine/Common/Collections/AbstractLazyCollection.php
+++ b/lib/Doctrine/Common/Collections/AbstractLazyCollection.php
@@ -8,7 +8,7 @@ use Closure;
  * Lazy collection that is backed by a concrete collection
  *
  * @template T
- * @template-extends Collection<T>
+ * @template-implements Collection<T>
  */
 abstract class AbstractLazyCollection implements Collection
 {

--- a/lib/Doctrine/Common/Collections/AbstractLazyCollection.php
+++ b/lib/Doctrine/Common/Collections/AbstractLazyCollection.php
@@ -7,8 +7,8 @@ use Closure;
 /**
  * Lazy collection that is backed by a concrete collection
  *
+ * @template TKey of array-key
  * @template T
- * @template TKey
  * @template-implements Collection<TKey,T>
  */
 abstract class AbstractLazyCollection implements Collection

--- a/lib/Doctrine/Common/Collections/AbstractLazyCollection.php
+++ b/lib/Doctrine/Common/Collections/AbstractLazyCollection.php
@@ -6,12 +6,15 @@ use Closure;
 
 /**
  * Lazy collection that is backed by a concrete collection
+ *
+ * @template T
  */
 abstract class AbstractLazyCollection implements Collection
 {
     /**
      * The backed collection to use
      *
+     * @psalm-var Collection<T>
      * @var Collection
      */
     protected $collection;
@@ -327,6 +330,8 @@ abstract class AbstractLazyCollection implements Collection
 
     /**
      * Initialize the collection
+     *
+     * @return void
      */
     protected function initialize()
     {

--- a/lib/Doctrine/Common/Collections/AbstractLazyCollection.php
+++ b/lib/Doctrine/Common/Collections/AbstractLazyCollection.php
@@ -8,14 +8,15 @@ use Closure;
  * Lazy collection that is backed by a concrete collection
  *
  * @template T
- * @template-implements Collection<T>
+ * @template TKey
+ * @template-implements Collection<TKey,T>
  */
 abstract class AbstractLazyCollection implements Collection
 {
     /**
      * The backed collection to use
      *
-     * @psalm-var Collection<T>
+     * @psalm-var Collection<TKey,T>
      * @var Collection
      */
     protected $collection;

--- a/lib/Doctrine/Common/Collections/ArrayCollection.php
+++ b/lib/Doctrine/Common/Collections/ArrayCollection.php
@@ -31,12 +31,15 @@ use function uasort;
  * and may break when we change the internals in the future. If you need to
  * serialize a collection use {@link toArray()} and reconstruct the collection
  * manually.
+ *
+ * @template T
  */
 class ArrayCollection implements Collection, Selectable
 {
     /**
      * An array containing the entries of this collection.
      *
+     * @psalm-var T[]
      * @var array
      */
     private $elements;
@@ -45,6 +48,8 @@ class ArrayCollection implements Collection, Selectable
      * Initializes a new ArrayCollection.
      *
      * @param array $elements
+     *
+     * @psalm-param T[]
      */
     public function __construct(array $elements = [])
     {
@@ -60,6 +65,9 @@ class ArrayCollection implements Collection, Selectable
      * @param array $elements Elements.
      *
      * @return static
+     *
+     * @psalm-param T[]
+     * @psalm-return ArrayCollection<T>
      */
     protected function createFrom(array $elements)
     {
@@ -301,6 +309,9 @@ class ArrayCollection implements Collection, Selectable
      * {@inheritDoc}
      *
      * @return static
+     *
+     * @template U
+     * @psalm-return ArrayCollection<U>
      */
     public function map(Closure $func)
     {
@@ -311,6 +322,9 @@ class ArrayCollection implements Collection, Selectable
      * {@inheritDoc}
      *
      * @return static
+     *
+     * @template U
+     * @psalm-return ArrayCollection<U>
      */
     public function filter(Closure $p)
     {
@@ -397,7 +411,9 @@ class ArrayCollection implements Collection, Selectable
                 $next = ClosureExpressionVisitor::sortByField($field, $ordering === Criteria::DESC ? -1 : 1, $next);
             }
 
-            uasort($filtered, $next);
+            if ($next) {
+                uasort($filtered, $next);
+            }
         }
 
         $offset = $criteria->getFirstResult();

--- a/lib/Doctrine/Common/Collections/ArrayCollection.php
+++ b/lib/Doctrine/Common/Collections/ArrayCollection.php
@@ -33,6 +33,8 @@ use function uasort;
  * manually.
  *
  * @template T
+ * @template-implements Collection<T>
+ * @template-implements Selectable<T>
  */
 class ArrayCollection implements Collection, Selectable
 {
@@ -49,11 +51,31 @@ class ArrayCollection implements Collection, Selectable
      *
      * @param array $elements
      *
-     * @psalm-param T[]
+     * @psalm-param array<T> $elements
      */
     public function __construct(array $elements = [])
     {
         $this->elements = $elements;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @psalm-return array<T>
+     */
+    public function toArray()
+    {
+        return $this->elements;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @psalm-return T
+     */
+    public function first()
+    {
+        return reset($this->elements);
     }
 
     /**
@@ -66,7 +88,7 @@ class ArrayCollection implements Collection, Selectable
      *
      * @return static
      *
-     * @psalm-param T[]
+     * @psalm-param array<T> $elements
      * @psalm-return ArrayCollection<T>
      */
     protected function createFrom(array $elements)
@@ -76,22 +98,8 @@ class ArrayCollection implements Collection, Selectable
 
     /**
      * {@inheritDoc}
-     */
-    public function toArray()
-    {
-        return $this->elements;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function first()
-    {
-        return reset($this->elements);
-    }
-
-    /**
-     * {@inheritDoc}
+     *
+     * @psalm-return T
      */
     public function last()
     {
@@ -108,6 +116,8 @@ class ArrayCollection implements Collection, Selectable
 
     /**
      * {@inheritDoc}
+     *
+     * @psalm-return T
      */
     public function next()
     {
@@ -116,6 +126,8 @@ class ArrayCollection implements Collection, Selectable
 
     /**
      * {@inheritDoc}
+     *
+     * @psalm-return T
      */
     public function current()
     {
@@ -124,6 +136,8 @@ class ArrayCollection implements Collection, Selectable
 
     /**
      * {@inheritDoc}
+     *
+     * @psalm-return T|null
      */
     public function remove($key)
     {
@@ -139,6 +153,8 @@ class ArrayCollection implements Collection, Selectable
 
     /**
      * {@inheritDoc}
+     *
+     * @psalm-param T $element
      */
     public function removeElement($element)
     {
@@ -167,6 +183,8 @@ class ArrayCollection implements Collection, Selectable
      * Required by interface ArrayAccess.
      *
      * {@inheritDoc}
+     *
+     * @psalm-return T|null
      */
     public function offsetGet($offset)
     {
@@ -177,6 +195,8 @@ class ArrayCollection implements Collection, Selectable
      * Required by interface ArrayAccess.
      *
      * {@inheritDoc}
+     *
+     * @psalm-param T $value
      */
     public function offsetSet($offset, $value)
     {
@@ -209,6 +229,8 @@ class ArrayCollection implements Collection, Selectable
 
     /**
      * {@inheritDoc}
+     *
+     * @psalm-param T $element
      */
     public function contains($element)
     {
@@ -217,6 +239,8 @@ class ArrayCollection implements Collection, Selectable
 
     /**
      * {@inheritDoc}
+     *
+     * @psalm-param Closure(int|string, T):bool $p
      */
     public function exists(Closure $p)
     {
@@ -231,6 +255,8 @@ class ArrayCollection implements Collection, Selectable
 
     /**
      * {@inheritDoc}
+     *
+     * @psalm-param T $element
      */
     public function indexOf($element)
     {
@@ -239,6 +265,8 @@ class ArrayCollection implements Collection, Selectable
 
     /**
      * {@inheritDoc}
+     *
+     * @psalm-return T|null
      */
     public function get($key)
     {
@@ -255,6 +283,8 @@ class ArrayCollection implements Collection, Selectable
 
     /**
      * {@inheritDoc}
+     *
+     * @psalm-return array<T>
      */
     public function getValues()
     {
@@ -271,6 +301,8 @@ class ArrayCollection implements Collection, Selectable
 
     /**
      * {@inheritDoc}
+     *
+     * @psalm-param T $value
      */
     public function set($key, $value)
     {
@@ -279,6 +311,8 @@ class ArrayCollection implements Collection, Selectable
 
     /**
      * {@inheritDoc}
+     *
+     * @psalm-param T $element
      */
     public function add($element)
     {
@@ -299,6 +333,8 @@ class ArrayCollection implements Collection, Selectable
      * Required by interface IteratorAggregate.
      *
      * {@inheritDoc}
+     *
+     * @psalm-return ArrayIterator<int|string, T>
      */
     public function getIterator()
     {
@@ -311,7 +347,8 @@ class ArrayCollection implements Collection, Selectable
      * @return static
      *
      * @template U
-     * @psalm-return ArrayCollection<U>
+     * @psalm-param Closure(T):U $func
+     * @psalm-return Collection<U>
      */
     public function map(Closure $func)
     {
@@ -323,8 +360,8 @@ class ArrayCollection implements Collection, Selectable
      *
      * @return static
      *
-     * @template U
-     * @psalm-return ArrayCollection<U>
+     * @psalm-param Closure(T):bool $p
+     * @psalm-return Collection<T>
      */
     public function filter(Closure $p)
     {
@@ -333,6 +370,8 @@ class ArrayCollection implements Collection, Selectable
 
     /**
      * {@inheritDoc}
+     *
+     * @psalm-param Closure(int|string, T):bool $p
      */
     public function forAll(Closure $p)
     {
@@ -347,6 +386,9 @@ class ArrayCollection implements Collection, Selectable
 
     /**
      * {@inheritDoc}
+     *
+     * @psalm-param Closure(int|string, T):bool $p
+     * @psalm-return Collection<T>[]
      */
     public function partition(Closure $p)
     {
@@ -383,6 +425,8 @@ class ArrayCollection implements Collection, Selectable
 
     /**
      * {@inheritDoc}
+     *
+     * @psalm-return array<T>
      */
     public function slice($offset, $length = null)
     {
@@ -391,6 +435,8 @@ class ArrayCollection implements Collection, Selectable
 
     /**
      * {@inheritDoc}
+     *
+     * @psalm-return Collection<T>
      */
     public function matching(Criteria $criteria)
     {

--- a/lib/Doctrine/Common/Collections/ArrayCollection.php
+++ b/lib/Doctrine/Common/Collections/ArrayCollection.php
@@ -410,9 +410,7 @@ class ArrayCollection implements Collection, Selectable
                 $next = ClosureExpressionVisitor::sortByField($field, $ordering === Criteria::DESC ? -1 : 1, $next);
             }
 
-            if ($next) {
-                uasort($filtered, $next);
-            }
+            uasort($filtered, $next);
         }
 
         $offset = $criteria->getFirstResult();

--- a/lib/Doctrine/Common/Collections/ArrayCollection.php
+++ b/lib/Doctrine/Common/Collections/ArrayCollection.php
@@ -32,6 +32,7 @@ use function uasort;
  * serialize a collection use {@link toArray()} and reconstruct the collection
  * manually.
  *
+ * @template TKey of string|int
  * @template T
  * @template-implements Collection<T>
  * @template-implements Selectable<T>
@@ -60,8 +61,6 @@ class ArrayCollection implements Collection, Selectable
 
     /**
      * {@inheritDoc}
-     *
-     * @psalm-return array<T>
      */
     public function toArray()
     {
@@ -70,8 +69,6 @@ class ArrayCollection implements Collection, Selectable
 
     /**
      * {@inheritDoc}
-     *
-     * @psalm-return T
      */
     public function first()
     {
@@ -98,8 +95,6 @@ class ArrayCollection implements Collection, Selectable
 
     /**
      * {@inheritDoc}
-     *
-     * @psalm-return T
      */
     public function last()
     {
@@ -116,8 +111,6 @@ class ArrayCollection implements Collection, Selectable
 
     /**
      * {@inheritDoc}
-     *
-     * @psalm-return T
      */
     public function next()
     {
@@ -126,8 +119,6 @@ class ArrayCollection implements Collection, Selectable
 
     /**
      * {@inheritDoc}
-     *
-     * @psalm-return T
      */
     public function current()
     {
@@ -136,8 +127,6 @@ class ArrayCollection implements Collection, Selectable
 
     /**
      * {@inheritDoc}
-     *
-     * @psalm-return T|null
      */
     public function remove($key)
     {
@@ -153,8 +142,6 @@ class ArrayCollection implements Collection, Selectable
 
     /**
      * {@inheritDoc}
-     *
-     * @psalm-param T $element
      */
     public function removeElement($element)
     {
@@ -183,8 +170,6 @@ class ArrayCollection implements Collection, Selectable
      * Required by interface ArrayAccess.
      *
      * {@inheritDoc}
-     *
-     * @psalm-return T|null
      */
     public function offsetGet($offset)
     {
@@ -195,8 +180,6 @@ class ArrayCollection implements Collection, Selectable
      * Required by interface ArrayAccess.
      *
      * {@inheritDoc}
-     *
-     * @psalm-param T $value
      */
     public function offsetSet($offset, $value)
     {
@@ -229,8 +212,6 @@ class ArrayCollection implements Collection, Selectable
 
     /**
      * {@inheritDoc}
-     *
-     * @psalm-param T $element
      */
     public function contains($element)
     {
@@ -239,8 +220,6 @@ class ArrayCollection implements Collection, Selectable
 
     /**
      * {@inheritDoc}
-     *
-     * @psalm-param Closure(int|string, T):bool $p
      */
     public function exists(Closure $p)
     {
@@ -255,8 +234,6 @@ class ArrayCollection implements Collection, Selectable
 
     /**
      * {@inheritDoc}
-     *
-     * @psalm-param T $element
      */
     public function indexOf($element)
     {
@@ -265,8 +242,6 @@ class ArrayCollection implements Collection, Selectable
 
     /**
      * {@inheritDoc}
-     *
-     * @psalm-return T|null
      */
     public function get($key)
     {
@@ -283,8 +258,6 @@ class ArrayCollection implements Collection, Selectable
 
     /**
      * {@inheritDoc}
-     *
-     * @psalm-return array<T>
      */
     public function getValues()
     {
@@ -301,8 +274,6 @@ class ArrayCollection implements Collection, Selectable
 
     /**
      * {@inheritDoc}
-     *
-     * @psalm-param T $value
      */
     public function set($key, $value)
     {
@@ -311,8 +282,6 @@ class ArrayCollection implements Collection, Selectable
 
     /**
      * {@inheritDoc}
-     *
-     * @psalm-param T $element
      */
     public function add($element)
     {
@@ -333,8 +302,6 @@ class ArrayCollection implements Collection, Selectable
      * Required by interface IteratorAggregate.
      *
      * {@inheritDoc}
-     *
-     * @psalm-return ArrayIterator<int|string, T>
      */
     public function getIterator()
     {
@@ -345,10 +312,6 @@ class ArrayCollection implements Collection, Selectable
      * {@inheritDoc}
      *
      * @return static
-     *
-     * @template U
-     * @psalm-param Closure(T):U $func
-     * @psalm-return Collection<U>
      */
     public function map(Closure $func)
     {
@@ -360,8 +323,7 @@ class ArrayCollection implements Collection, Selectable
      *
      * @return static
      *
-     * @psalm-param Closure(T):bool $p
-     * @psalm-return Collection<T>
+     * @psalm-return ArrayCollection<T>
      */
     public function filter(Closure $p)
     {
@@ -370,8 +332,6 @@ class ArrayCollection implements Collection, Selectable
 
     /**
      * {@inheritDoc}
-     *
-     * @psalm-param Closure(int|string, T):bool $p
      */
     public function forAll(Closure $p)
     {
@@ -386,9 +346,6 @@ class ArrayCollection implements Collection, Selectable
 
     /**
      * {@inheritDoc}
-     *
-     * @psalm-param Closure(int|string, T):bool $p
-     * @psalm-return array{0: Collection<T>, 1: Collection<T>}
      */
     public function partition(Closure $p)
     {
@@ -425,8 +382,6 @@ class ArrayCollection implements Collection, Selectable
 
     /**
      * {@inheritDoc}
-     *
-     * @psalm-return array<T>
      */
     public function slice($offset, $length = null)
     {
@@ -435,8 +390,6 @@ class ArrayCollection implements Collection, Selectable
 
     /**
      * {@inheritDoc}
-     *
-     * @psalm-return Collection<T>
      */
     public function matching(Criteria $criteria)
     {

--- a/lib/Doctrine/Common/Collections/ArrayCollection.php
+++ b/lib/Doctrine/Common/Collections/ArrayCollection.php
@@ -388,7 +388,7 @@ class ArrayCollection implements Collection, Selectable
      * {@inheritDoc}
      *
      * @psalm-param Closure(int|string, T):bool $p
-     * @psalm-return Collection<T>[]
+     * @psalm-return array{0: Collection<T>, 1: Collection<T>}
      */
     public function partition(Closure $p)
     {

--- a/lib/Doctrine/Common/Collections/ArrayCollection.php
+++ b/lib/Doctrine/Common/Collections/ArrayCollection.php
@@ -32,7 +32,7 @@ use function uasort;
  * serialize a collection use {@link toArray()} and reconstruct the collection
  * manually.
  *
- * @template TKey of string|int
+ * @template TKey of array-key
  * @template T
  * @template-implements Collection<TKey,T>
  * @template-implements Selectable<TKey,T>

--- a/lib/Doctrine/Common/Collections/ArrayCollection.php
+++ b/lib/Doctrine/Common/Collections/ArrayCollection.php
@@ -34,15 +34,15 @@ use function uasort;
  *
  * @template TKey of string|int
  * @template T
- * @template-implements Collection<T>
- * @template-implements Selectable<T>
+ * @template-implements Collection<TKey,T>
+ * @template-implements Selectable<TKey,T>
  */
 class ArrayCollection implements Collection, Selectable
 {
     /**
      * An array containing the entries of this collection.
      *
-     * @psalm-var T[]
+     * @psalm-var array<TKey,T>
      * @var array
      */
     private $elements;
@@ -52,7 +52,7 @@ class ArrayCollection implements Collection, Selectable
      *
      * @param array $elements
      *
-     * @psalm-param array<T> $elements
+     * @psalm-param array<TKey,T> $elements
      */
     public function __construct(array $elements = [])
     {
@@ -85,8 +85,8 @@ class ArrayCollection implements Collection, Selectable
      *
      * @return static
      *
-     * @psalm-param array<T> $elements
-     * @psalm-return ArrayCollection<T>
+     * @psalm-param array<TKey,T> $elements
+     * @psalm-return ArrayCollection<TKey,T>
      */
     protected function createFrom(array $elements)
     {
@@ -323,7 +323,7 @@ class ArrayCollection implements Collection, Selectable
      *
      * @return static
      *
-     * @psalm-return ArrayCollection<T>
+     * @psalm-return ArrayCollection<TKey,T>
      */
     public function filter(Closure $p)
     {

--- a/lib/Doctrine/Common/Collections/Collection.php
+++ b/lib/Doctrine/Common/Collections/Collection.php
@@ -23,6 +23,8 @@ use IteratorAggregate;
  * You can not rely on the internal iterator of the collection being at a certain
  * position unless you explicitly positioned it before. Prefer iteration with
  * external iterators.
+ *
+ * @template T
  */
 interface Collection extends Countable, IteratorAggregate, ArrayAccess
 {
@@ -32,6 +34,8 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      * @param mixed $element The element to add.
      *
      * @return bool Always TRUE.
+     *
+     * @psalm-param T $element
      */
     public function add($element);
 
@@ -49,6 +53,8 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      * @param mixed $element The element to search for.
      *
      * @return bool TRUE if the collection contains the element, FALSE otherwise.
+     *
+     * @psalm-param T $element
      */
     public function contains($element);
 
@@ -65,6 +71,8 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      * @param string|int $key The key/index of the element to remove.
      *
      * @return mixed The removed element or NULL, if the collection did not contain the element.
+     *
+     * @psalm-return T|null
      */
     public function remove($key);
 
@@ -74,6 +82,8 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      * @param mixed $element The element to remove.
      *
      * @return bool TRUE if this collection contained the specified element, FALSE otherwise.
+     *
+     * @psalm-param T $element
      */
     public function removeElement($element);
 
@@ -93,13 +103,15 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      * @param string|int $key The key/index of the element to retrieve.
      *
      * @return mixed
+     *
+     * @psalm-return T|null
      */
     public function get($key);
 
     /**
      * Gets all keys/indices of the collection.
      *
-     * @return array The keys/indices of the collection, in the order of the corresponding
+     * @return int[]|string[] The keys/indices of the collection, in the order of the corresponding
      *               elements in the collection.
      */
     public function getKeys();
@@ -109,6 +121,8 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      *
      * @return array The values of all elements in the collection, in the order they
      *               appear in the collection.
+     *
+     * @psalm-return T[]
      */
     public function getValues();
 
@@ -119,6 +133,8 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      * @param mixed      $value The element to set.
      *
      * @return void
+     *
+     * @psalm-param T $value
      */
     public function set($key, $value);
 
@@ -126,6 +142,8 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      * Gets a native PHP array representation of the collection.
      *
      * @return array
+     *
+     * @psalm-return T[]
      */
     public function toArray();
 
@@ -133,6 +151,8 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      * Sets the internal iterator to the first element in the collection and returns this element.
      *
      * @return mixed
+     *
+     * @psalm-return T
      */
     public function first();
 
@@ -140,6 +160,8 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      * Sets the internal iterator to the last element in the collection and returns this element.
      *
      * @return mixed
+     *
+     * @psalm-return T
      */
     public function last();
 
@@ -154,6 +176,8 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      * Gets the element of the collection at the current iterator position.
      *
      * @return mixed
+     *
+     * @psalm-return T
      */
     public function current();
 
@@ -161,6 +185,8 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      * Moves the internal iterator position to the next element and returns this element.
      *
      * @return mixed
+     *
+     * @psalm-return T
      */
     public function next();
 
@@ -170,6 +196,8 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      * @param Closure $p The predicate.
      *
      * @return bool TRUE if the predicate is TRUE for at least one element, FALSE otherwise.
+     *
+     * @psalm-param Closure(int|string, T):bool $p
      */
     public function exists(Closure $p);
 
@@ -180,6 +208,9 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      * @param Closure $p The predicate used for filtering.
      *
      * @return Collection A collection with the results of the filter operation.
+     *
+     * @psalm-param Closure(T):bool $p
+     * @psalm-return Collection<T>
      */
     public function filter(Closure $p);
 
@@ -189,6 +220,8 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      * @param Closure $p The predicate.
      *
      * @return bool TRUE, if the predicate yields TRUE for all elements, FALSE otherwise.
+     *
+     * @psalm-param Closure(int|string, T):bool $p
      */
     public function forAll(Closure $p);
 
@@ -197,6 +230,10 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      * a new collection with the elements returned by the function.
      *
      * @return Collection
+     *
+     * @template U
+     * @psalm-param Closure(T):U $func
+     * @psalm-return Collection<U>
      */
     public function map(Closure $func);
 
@@ -209,6 +246,9 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      * @return Collection[] An array with two elements. The first element contains the collection
      *                      of elements where the predicate returned TRUE, the second element
      *                      contains the collection of elements where the predicate returned FALSE.
+     *
+     * @psalm-param Closure(int|string, T):bool $p
+     * @psalm-return Collection<T>[]
      */
     public function partition(Closure $p);
 
@@ -220,6 +260,8 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      * @param mixed $element The element to search for.
      *
      * @return int|string|bool The key/index of the element or FALSE if the element was not found.
+     *
+     * @psalm-param T $element
      */
     public function indexOf($element);
 
@@ -234,6 +276,8 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      * @param int|null $length The maximum number of elements to return, or null for no limit.
      *
      * @return array
+     *
+     * @psalm-return T[]
      */
     public function slice($offset, $length = null);
 }

--- a/lib/Doctrine/Common/Collections/Collection.php
+++ b/lib/Doctrine/Common/Collections/Collection.php
@@ -25,6 +25,8 @@ use IteratorAggregate;
  * external iterators.
  *
  * @template T
+ * @template-extends IteratorAggregate<int|string, T>
+ * @template-extends ArrayAccess<int|string, T>
  */
 interface Collection extends Countable, IteratorAggregate, ArrayAccess
 {
@@ -122,7 +124,7 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      * @return array The values of all elements in the collection, in the order they
      *               appear in the collection.
      *
-     * @psalm-return T[]
+     * @psalm-return array<T>
      */
     public function getValues();
 
@@ -143,7 +145,7 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      *
      * @return array
      *
-     * @psalm-return T[]
+     * @psalm-return array<T>
      */
     public function toArray();
 
@@ -277,7 +279,7 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      *
      * @return array
      *
-     * @psalm-return T[]
+     * @psalm-return array<T>
      */
     public function slice($offset, $length = null);
 }

--- a/lib/Doctrine/Common/Collections/Collection.php
+++ b/lib/Doctrine/Common/Collections/Collection.php
@@ -24,9 +24,10 @@ use IteratorAggregate;
  * position unless you explicitly positioned it before. Prefer iteration with
  * external iterators.
  *
+ * @template TKey of array-key
  * @template T
- * @template-extends IteratorAggregate<int|string, T>
- * @template-extends ArrayAccess<int|string|null, T>
+ * @template-extends IteratorAggregate<TKey, T>
+ * @template-extends ArrayAccess<TKey|null, T>
  */
 interface Collection extends Countable, IteratorAggregate, ArrayAccess
 {
@@ -38,6 +39,7 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      * @return bool Always TRUE.
      *
      * @psalm-param T $element
+     * @psalm-return true
      */
     public function add($element);
 
@@ -74,6 +76,7 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      *
      * @return mixed The removed element or NULL, if the collection did not contain the element.
      *
+     * @psalm-param TKey $key
      * @psalm-return T|null
      */
     public function remove($key);
@@ -96,6 +99,8 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      *
      * @return bool TRUE if the collection contains an element with the specified key/index,
      *              FALSE otherwise.
+     *
+     * @psalm-param TKey $key
      */
     public function containsKey($key);
 
@@ -106,6 +111,7 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      *
      * @return mixed
      *
+     * @psalm-param TKey $key
      * @psalm-return T|null
      */
     public function get($key);
@@ -115,6 +121,8 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      *
      * @return int[]|string[] The keys/indices of the collection, in the order of the corresponding
      *               elements in the collection.
+     *
+     * @psalm-return TKey[]
      */
     public function getKeys();
 
@@ -136,6 +144,7 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      *
      * @return void
      *
+     * @psalm-param TKey $key
      * @psalm-param T $value
      */
     public function set($key, $value);
@@ -145,7 +154,7 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      *
      * @return array
      *
-     * @psalm-return array<array-key,T>
+     * @psalm-return array<TKey,T>
      */
     public function toArray();
 
@@ -171,6 +180,8 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      * Gets the key/index of the element at the current iterator position.
      *
      * @return int|string
+     *
+     * @psalm-return TKey
      */
     public function key();
 
@@ -199,7 +210,7 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      *
      * @return bool TRUE if the predicate is TRUE for at least one element, FALSE otherwise.
      *
-     * @psalm-param Closure(int|string, T):bool $p
+     * @psalm-param Closure(TKey, T):bool $p
      */
     public function exists(Closure $p);
 
@@ -212,7 +223,7 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      * @return Collection A collection with the results of the filter operation.
      *
      * @psalm-param Closure(T):bool $p
-     * @psalm-return Collection<T>
+     * @psalm-return Collection<TKey, T>
      */
     public function filter(Closure $p);
 
@@ -223,7 +234,7 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      *
      * @return bool TRUE, if the predicate yields TRUE for all elements, FALSE otherwise.
      *
-     * @psalm-param Closure(int|string, T):bool $p
+     * @psalm-param Closure(TKey, T):bool $p
      */
     public function forAll(Closure $p);
 
@@ -235,7 +246,7 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      *
      * @template U
      * @psalm-param Closure(T):U $func
-     * @psalm-return Collection<U>
+     * @psalm-return Collection<array-key, U>
      */
     public function map(Closure $func);
 
@@ -249,8 +260,8 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      *                      of elements where the predicate returned TRUE, the second element
      *                      contains the collection of elements where the predicate returned FALSE.
      *
-     * @psalm-param Closure(int|string, T):bool $p
-     * @psalm-return array{0: Collection<T>, 1: Collection<T>}
+     * @psalm-param Closure(TKey, T):bool $p
+     * @psalm-return array{0: Collection<TKey, T>, 1: Collection<TKey, T>}
      */
     public function partition(Closure $p);
 
@@ -264,7 +275,7 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      * @return int|string|bool The key/index of the element or FALSE if the element was not found.
      *
      * @psalm-param T $element
-     * @psalm-return int|string|false
+     * @psalm-return TKey|false
      */
     public function indexOf($element);
 
@@ -280,7 +291,7 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      *
      * @return array
      *
-     * @psalm-return array<array-key,T>
+     * @psalm-return array<TKey,T>
      */
     public function slice($offset, $length = null);
 }

--- a/lib/Doctrine/Common/Collections/Collection.php
+++ b/lib/Doctrine/Common/Collections/Collection.php
@@ -250,7 +250,7 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      *                      contains the collection of elements where the predicate returned FALSE.
      *
      * @psalm-param Closure(int|string, T):bool $p
-     * @psalm-return Collection<T>[]
+     * @psalm-return array{0: Collection<T>, 1: Collection<T>}
      */
     public function partition(Closure $p);
 

--- a/lib/Doctrine/Common/Collections/Collection.php
+++ b/lib/Doctrine/Common/Collections/Collection.php
@@ -26,7 +26,7 @@ use IteratorAggregate;
  *
  * @template T
  * @template-extends IteratorAggregate<int|string, T>
- * @template-extends ArrayAccess<int|string, T>
+ * @template-extends ArrayAccess<int|string|null, T>
  */
 interface Collection extends Countable, IteratorAggregate, ArrayAccess
 {
@@ -124,7 +124,7 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      * @return array The values of all elements in the collection, in the order they
      *               appear in the collection.
      *
-     * @psalm-return array<T>
+     * @psalm-return array<array-key,T>
      */
     public function getValues();
 
@@ -145,7 +145,7 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      *
      * @return array
      *
-     * @psalm-return array<T>
+     * @psalm-return array<array-key,T>
      */
     public function toArray();
 
@@ -154,7 +154,7 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      *
      * @return mixed
      *
-     * @psalm-return T
+     * @psalm-return T|false
      */
     public function first();
 
@@ -163,7 +163,7 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      *
      * @return mixed
      *
-     * @psalm-return T
+     * @psalm-return T|false
      */
     public function last();
 
@@ -179,7 +179,7 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      *
      * @return mixed
      *
-     * @psalm-return T
+     * @psalm-return T|false
      */
     public function current();
 
@@ -188,7 +188,7 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      *
      * @return mixed
      *
-     * @psalm-return T
+     * @psalm-return T|false
      */
     public function next();
 
@@ -264,6 +264,7 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      * @return int|string|bool The key/index of the element or FALSE if the element was not found.
      *
      * @psalm-param T $element
+     * @psalm-return int|string|false
      */
     public function indexOf($element);
 
@@ -279,7 +280,7 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      *
      * @return array
      *
-     * @psalm-return array<T>
+     * @psalm-return array<array-key,T>
      */
     public function slice($offset, $length = null);
 }

--- a/lib/Doctrine/Common/Collections/Collection.php
+++ b/lib/Doctrine/Common/Collections/Collection.php
@@ -36,10 +36,9 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      *
      * @param mixed $element The element to add.
      *
-     * @return bool Always TRUE.
+     * @return true Always TRUE.
      *
      * @psalm-param T $element
-     * @psalm-return true
      */
     public function add($element);
 

--- a/lib/Doctrine/Common/Collections/Collection.php
+++ b/lib/Doctrine/Common/Collections/Collection.php
@@ -261,7 +261,7 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      *                      of elements where the predicate returned TRUE, the second element
      *                      contains the collection of elements where the predicate returned FALSE.
      *
-     * @psalm-param Closure(TKey, T):bool $p
+     * @psalm-param Closure(TKey=, T=):bool $p
      * @psalm-return array{0: Collection<TKey, T>, 1: Collection<TKey, T>}
      */
     public function partition(Closure $p);

--- a/lib/Doctrine/Common/Collections/Collection.php
+++ b/lib/Doctrine/Common/Collections/Collection.php
@@ -40,6 +40,7 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      *
      * @psalm-param T $element
      * @psalm-return true
+     * @psalm-return true
      */
     public function add($element);
 
@@ -132,7 +133,7 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      * @return array The values of all elements in the collection, in the order they
      *               appear in the collection.
      *
-     * @psalm-return array<array-key,T>
+     * @psalm-return T[]
      */
     public function getValues();
 
@@ -246,7 +247,7 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      *
      * @template U
      * @psalm-param Closure(T):U $func
-     * @psalm-return Collection<array-key, U>
+     * @psalm-return Collection<TKey, U>
      */
     public function map(Closure $func);
 

--- a/lib/Doctrine/Common/Collections/Collection.php
+++ b/lib/Doctrine/Common/Collections/Collection.php
@@ -40,7 +40,6 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      *
      * @psalm-param T $element
      * @psalm-return true
-     * @psalm-return true
      */
     public function add($element);
 

--- a/lib/Doctrine/Common/Collections/Collection.php
+++ b/lib/Doctrine/Common/Collections/Collection.php
@@ -211,7 +211,7 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      *
      * @return bool TRUE if the predicate is TRUE for at least one element, FALSE otherwise.
      *
-     * @psalm-param Closure(TKey, T):bool $p
+     * @psalm-param Closure(TKey=, T=):bool $p
      */
     public function exists(Closure $p);
 
@@ -223,7 +223,7 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      *
      * @return Collection A collection with the results of the filter operation.
      *
-     * @psalm-param Closure(T):bool $p
+     * @psalm-param Closure(T=):bool $p
      * @psalm-return Collection<TKey, T>
      */
     public function filter(Closure $p);
@@ -235,7 +235,7 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      *
      * @return bool TRUE, if the predicate yields TRUE for all elements, FALSE otherwise.
      *
-     * @psalm-param Closure(TKey, T):bool $p
+     * @psalm-param Closure(TKey=, T=):bool $p
      */
     public function forAll(Closure $p);
 
@@ -246,7 +246,7 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      * @return Collection
      *
      * @template U
-     * @psalm-param Closure(T):U $func
+     * @psalm-param Closure(T=):U $func
      * @psalm-return Collection<TKey, U>
      */
     public function map(Closure $func);

--- a/lib/Doctrine/Common/Collections/Criteria.php
+++ b/lib/Doctrine/Common/Collections/Criteria.php
@@ -61,6 +61,8 @@ class Criteria
      * @param string[]|null $orderings
      * @param int|null      $firstResult
      * @param int|null      $maxResults
+     *
+     * @return void
      */
     public function __construct(?Expression $expression = null, ?array $orderings = null, $firstResult = null, $maxResults = null)
     {

--- a/lib/Doctrine/Common/Collections/Criteria.php
+++ b/lib/Doctrine/Common/Collections/Criteria.php
@@ -61,8 +61,6 @@ class Criteria
      * @param string[]|null $orderings
      * @param int|null      $firstResult
      * @param int|null      $maxResults
-     *
-     * @return void
      */
     public function __construct(?Expression $expression = null, ?array $orderings = null, $firstResult = null, $maxResults = null)
     {

--- a/lib/Doctrine/Common/Collections/Selectable.php
+++ b/lib/Doctrine/Common/Collections/Selectable.php
@@ -13,6 +13,8 @@ namespace Doctrine\Common\Collections;
  * utilizing the query APIs, for example SQL in the ORM. Applications using
  * this API can implement efficient database access without having to ask the
  * EntityManager or Repositories.
+ *
+ * @template T
  */
 interface Selectable
 {
@@ -21,6 +23,8 @@ interface Selectable
      * returns a new collection containing these elements.
      *
      * @return Collection
+     *
+     * @psalm-return Collection<T>
      */
     public function matching(Criteria $criteria);
 }

--- a/lib/Doctrine/Common/Collections/Selectable.php
+++ b/lib/Doctrine/Common/Collections/Selectable.php
@@ -14,8 +14,8 @@ namespace Doctrine\Common\Collections;
  * this API can implement efficient database access without having to ask the
  * EntityManager or Repositories.
  *
+ * @template TKey as array-key
  * @template T
- * @template TKey
  */
 interface Selectable
 {

--- a/lib/Doctrine/Common/Collections/Selectable.php
+++ b/lib/Doctrine/Common/Collections/Selectable.php
@@ -15,6 +15,7 @@ namespace Doctrine\Common\Collections;
  * EntityManager or Repositories.
  *
  * @template T
+ * @template TKey
  */
 interface Selectable
 {
@@ -24,7 +25,7 @@ interface Selectable
      *
      * @return Collection
      *
-     * @psalm-return Collection<T>
+     * @psalm-return Collection<TKey,T>
      */
     public function matching(Criteria $criteria);
 }

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -3,7 +3,7 @@
     totallyTyped="false"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
-    xsi:schemaLocation="https://getpsalm.org/schema/config file:///Users/nschoellhorn/PhpstormProjects/collections/vendor/vimeo/psalm/config.xsd"
+    xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
 >
     <projectFiles>
         <directory name="lib" />

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -1,0 +1,53 @@
+<?xml version="1.0"?>
+<psalm
+    totallyTyped="false"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://getpsalm.org/schema/config"
+    xsi:schemaLocation="https://getpsalm.org/schema/config file:///Users/nschoellhorn/PhpstormProjects/collections/vendor/vimeo/psalm/config.xsd"
+>
+    <projectFiles>
+        <directory name="lib" />
+        <ignoreFiles>
+            <directory name="vendor" />
+        </ignoreFiles>
+    </projectFiles>
+
+    <issueHandlers>
+        <LessSpecificReturnType errorLevel="info" />
+
+        <!-- level 3 issues - slightly lazy code writing, but provably low false-negatives -->
+
+        <DeprecatedMethod errorLevel="info" />
+        <DeprecatedProperty errorLevel="info" />
+        <DeprecatedClass errorLevel="info" />
+        <DeprecatedConstant errorLevel="info" />
+        <DeprecatedInterface errorLevel="info" />
+        <DeprecatedTrait errorLevel="info" />
+
+        <InternalMethod errorLevel="info" />
+        <InternalProperty errorLevel="info" />
+        <InternalClass errorLevel="info" />
+
+        <MissingClosureReturnType errorLevel="info" />
+        <MissingReturnType errorLevel="info" />
+        <MissingPropertyType errorLevel="info" />
+        <InvalidDocblock errorLevel="info" />
+        <MisplacedRequiredParam errorLevel="info" />
+
+        <PropertyNotSetInConstructor errorLevel="info" />
+        <MissingConstructor errorLevel="info" />
+        <MissingClosureParamType errorLevel="info" />
+        <MissingParamType errorLevel="info" />
+
+        <RedundantCondition errorLevel="info" />
+
+        <DocblockTypeContradiction errorLevel="info" />
+        <RedundantConditionGivenDocblockType errorLevel="info" />
+
+        <UnresolvableInclude errorLevel="info" />
+
+        <RawObjectIteration errorLevel="info" />
+
+        <InvalidStringClass errorLevel="info" />
+    </issueHandlers>
+</psalm>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -9,6 +9,7 @@
         <directory name="lib" />
         <ignoreFiles>
             <directory name="vendor" />
+            <directory name="lib/Doctrine/Common/Collections/Expr"/>
         </ignoreFiles>
     </projectFiles>
 


### PR DESCRIPTION
I've talked to @Ocramius and we find that generics/template types would make a very good addition to this library. Since PHP doesn't come with that feature natively, I have decided to implement it using Psalm and [Psalm's template annotations](https://psalm.dev/docs/templated_annotations/).  

**How is that useful?**
A lot of people already use static analysis to reduce the risk of introducing bugs in your application. Psalm is one of the most popular tools out there to do that. By adding the annotations to Psalm and using the correct `@psalm-var` annotations when using the collections in projects, Psalm makes sure that you only put values of the right type in your collection automatically, since it also scans the `vendor` directory.  
I have created a very minimal proof of concept project over at [nschoellhorn/psalm-collections-test](https://github.com/nschoellhorn/psalm-collections-test). You can clone that, install the dependencies and run `./vendor/bin/psalm` to check it out.