### PR TITLE
Update Collection::filter docblock to add key parameter to closure

### DIFF
--- a/lib/Doctrine/Common/Collections/Collection.php
+++ b/lib/Doctrine/Common/Collections/Collection.php
@@ -221,7 +221,7 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      *
      * @return Collection A collection with the results of the filter operation.
      *
-     * @psalm-param Closure(T=):bool $p
+     * @psalm-param Closure(T=, TKey=):bool $p
      * @psalm-return Collection<TKey, T>
      */
     public function filter(Closure $p);


### PR DESCRIPTION
Since the key was added to the closure of `ArrayCollection::filter` in 1.6.0 I guess this needs to be updated.