### PR TITLE
Use @psalm-template annotation to avoid clashes

### DIFF
--- a/lib/Doctrine/Common/Collections/AbstractLazyCollection.php
+++ b/lib/Doctrine/Common/Collections/AbstractLazyCollection.php
@@ -7,8 +7,8 @@ use Closure;
 /**
  * Lazy collection that is backed by a concrete collection
  *
- * @template TKey of array-key
- * @template T
+ * @psalm-template TKey of array-key
+ * @psalm-template T
  * @template-implements Collection<TKey,T>
  */
 abstract class AbstractLazyCollection implements Collection

--- a/lib/Doctrine/Common/Collections/ArrayCollection.php
+++ b/lib/Doctrine/Common/Collections/ArrayCollection.php
@@ -32,8 +32,8 @@ use function uasort;
  * serialize a collection use {@link toArray()} and reconstruct the collection
  * manually.
  *
- * @template TKey of array-key
- * @template T
+ * @psalm-template TKey of array-key
+ * @psalm-template T
  * @template-implements Collection<TKey,T>
  * @template-implements Selectable<TKey,T>
  */

--- a/lib/Doctrine/Common/Collections/Collection.php
+++ b/lib/Doctrine/Common/Collections/Collection.php
@@ -24,8 +24,8 @@ use IteratorAggregate;
  * position unless you explicitly positioned it before. Prefer iteration with
  * external iterators.
  *
- * @template TKey of array-key
- * @template T
+ * @psalm-template TKey of array-key
+ * @psalm-template T
  * @template-extends IteratorAggregate<TKey, T>
  * @template-extends ArrayAccess<TKey|null, T>
  */
@@ -243,7 +243,7 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      *
      * @return Collection
      *
-     * @template U
+     * @psalm-template U
      * @psalm-param Closure(T=):U $func
      * @psalm-return Collection<TKey, U>
      */

--- a/lib/Doctrine/Common/Collections/Selectable.php
+++ b/lib/Doctrine/Common/Collections/Selectable.php
@@ -14,8 +14,8 @@ namespace Doctrine\Common\Collections;
  * this API can implement efficient database access without having to ask the
  * EntityManager or Repositories.
  *
- * @template TKey as array-key
- * @template T
+ * @psalm-template TKey as array-key
+ * @psalm-template T
  */
 interface Selectable
 {


### PR DESCRIPTION
Following reports that some users encountered issues with `@template` annotations, this PR replaces `@template` with the functionally-equivalent `@psalm-template`.