### PR TITLE
[2.0] Strict types, native parameter & return types 

### DIFF
--- a/.doctrine-project.json
+++ b/.doctrine-project.json
@@ -5,7 +5,7 @@
 	"docsSlug": "doctrine-collections",
 	"versions": [
 		{
-			"name": "master",
+			"name": "2.0",
 			"branchName": "master",
 			"slug": "latest",
 			"upcoming": true

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,7 +1,7 @@
 build:
     environment:
         php:
-            version: 7.1.3
+            version: 7.2
 
 tools:
     external_code_coverage:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ cache:
     - $HOME/.composer/cache
 
 php:
-  - 7.1
   - 7.2
   - 7.3
   - 7.4snapshot
@@ -47,7 +46,7 @@ jobs:
     - stage: Code Quality
       env: STATIC_ANALYSIS
       install: travis_retry composer install --prefer-dist
-      script: vendor/bin/phpstan analyse -l 3 lib
+      script: vendor/bin/phpstan analyse
 
     - stage: Code Quality
       env: STATIC_ANALYSIS

--- a/UPGRADING-2.0.md
+++ b/UPGRADING-2.0.md
@@ -1,0 +1,61 @@
+Upgrading from 1.x to 2.0
+=========================
+
+
+## BC breaking changes
+
+Native parameter and return types were added.
+As a consequence, some signatures were changed and will have to be adjusted in sub-classes.
+
+
+Note that in order to keep compatibility with both 1.x and 2.x versions, extending code would have to omit the added parameter types and add the return types. This would only work in PHP 7.2+ which is the first version featuring [parameter widening](https://wiki.php.net/rfc/parameter-no-type-variance).
+
+
+You can find a list of major changes to public API below.
+
+#### Doctrine\Common\Collections\Collection
+
+|             before             |                  after                         |
+|-------------------------------:|:-----------------------------------------------|
+| add($element)                  | add($element): bool                            |
+| clear()                        | clear(): void                                  |
+| contains($element)             | contains($element): bool                       |
+| isEmpty()                      | isEmpty(): bool                                |
+| removeElement($element)        | removeElement($element): bool                  |
+| containsKey($key)              | containsKey($key): bool                        |
+| getKeys()                      | getKeys(): array                               |
+| getValues()                    | getValues(): array                             |
+| set($key, $value)              | set($key, $value): void                        |
+| toArray()                      | toArray(): array                               |
+| exists(Closure $p)             | exists(Closure $p): bool                       |
+| filter(Closure $p)             | filter(Closure $p): self                       |
+| forAll(Closure $p)             | forAll(Closure $p): bool                       |
+| map(Closure $func)             | map(Closure $func): self                       |
+| partition(Closure $p)          | partition(Closure $p): array                   |
+| slice($offset, $length = null) | slice(int $offset, ?int $length = null): array |
+| count()                        | count(): int                                   |
+| getIterator()                  | getIterator(): \Traversable                    |
+| offsetSet($offset, $value)     | offsetSet($offset, $value): void               |
+| offsetUnset($offset)           | offsetUnset($offset): void                     |
+| offsetExists($offset)          | offsetExists($offset): bool                    |
+
+#### Doctrine\Common\Collections\AbstractLazyCollection
+
+|      before     |         after         |
+|----------------:|:----------------------|
+| isInitialized() | isInitialized(): bool |
+| initialize()    | initialize(): void    |
+| doInitialize()  | doInitialize(): void  |
+
+#### Doctrine\Common\Collections\ArrayCollection
+
+|            before           |               after               |
+|----------------------------:|:----------------------------------|
+| createFrom(array $elements) | createFrom(array $elements): self |
+| __toString()                | __toString(): string              |
+
+#### Doctrine\Common\Collections\Selectable
+
+|             before           |                   after                  |
+|-----------------------------:|:-----------------------------------------|
+| matching(Criteria $criteria) | matching(Criteria $criteria): Collection |

--- a/UPGRADING-2.0.md
+++ b/UPGRADING-2.0.md
@@ -1,15 +1,12 @@
 Upgrading from 1.x to 2.0
 =========================
 
-
 ## BC breaking changes
 
 Native parameter and return types were added.
 As a consequence, some signatures were changed and will have to be adjusted in sub-classes.
 
-
 Note that in order to keep compatibility with both 1.x and 2.x versions, extending code would have to omit the added parameter types and add the return types. This would only work in PHP 7.2+ which is the first version featuring [parameter widening](https://wiki.php.net/rfc/parameter-no-type-variance).
-
 
 You can find a list of major changes to public API below.
 

--- a/composer.json
+++ b/composer.json
@@ -21,12 +21,12 @@
         "php": "^7.2"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.0",
         "doctrine/coding-standard": "^6.0",
+        "infection/infection": "^0.12.2",
         "phpstan/phpstan": "^0.11",
         "phpstan/phpstan-phpunit": "^0.11",
-        "vimeo/psalm": "^3.2.2",
-        "infection/infection": "^0.12.2"
+        "phpunit/phpunit": "^7.0",
+        "vimeo/psalm": "^3.2.2"
     },
     "config": {
         "sort-packages": true

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.6.x-dev"
+            "dev-master": "2.0.x-dev"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -18,14 +18,18 @@
         {"name": "Johannes Schmitt", "email": "schmittjoh@gmail.com"}
     ],
     "require": {
-        "php": "^7.1.3"
+        "php": "^7.2"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.0",
         "doctrine/coding-standard": "^6.0",
-        "phpstan/phpstan-shim": "^0.9.2",
+        "phpstan/phpstan": "^0.11",
+        "phpstan/phpstan-phpunit": "^0.11",
         "vimeo/psalm": "^3.2.2",
         "infection/infection": "^0.12.2"
+    },
+    "config": {
+        "sort-packages": true
     },
     "autoload": {
         "psr-4": { "Doctrine\\Common\\Collections\\": "lib/Doctrine/Common/Collections" }

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "f5b1dbb10a4bc7e152057f0ace9044e7",
+    "content-hash": "6d3364c688ed0047437ce00428d6f9cc",
     "packages": [],
     "packages-dev": [
         {
@@ -371,27 +371,29 @@
         },
         {
             "name": "doctrine/instantiator",
-            "version": "1.1.0",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda"
+                "reference": "a2c590166b2133a4633738648b6b064edae0814a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda",
-                "reference": "185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/a2c590166b2133a4633738648b6b064edae0814a",
+                "reference": "a2c590166b2133a4633738648b6b064edae0814a",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1"
             },
             "require-dev": {
-                "athletic/athletic": "~0.1.8",
+                "doctrine/coding-standard": "^6.0",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpunit/phpunit": "^6.2.3",
-                "squizlabs/php_codesniffer": "^3.0.2"
+                "phpbench/phpbench": "^0.13",
+                "phpstan/phpstan-phpunit": "^0.11",
+                "phpstan/phpstan-shim": "^0.11",
+                "phpunit/phpunit": "^7.0"
             },
             "type": "library",
             "extra": {
@@ -416,12 +418,12 @@
                 }
             ],
             "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
-            "homepage": "https://github.com/doctrine/instantiator",
+            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
             "keywords": [
                 "constructor",
                 "instantiate"
             ],
-            "time": "2017-07-22T11:58:36+00:00"
+            "time": "2019-03-17T17:37:11+00:00"
         },
         {
             "name": "felixfbecker/advanced-json-rpc",
@@ -601,6 +603,57 @@
             "time": "2019-02-10T18:24:30+00:00"
         },
         {
+            "name": "jean85/pretty-package-versions",
+            "version": "1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Jean85/pretty-package-versions.git",
+                "reference": "75c7effcf3f77501d0e0caa75111aff4daa0dd48"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Jean85/pretty-package-versions/zipball/75c7effcf3f77501d0e0caa75111aff4daa0dd48",
+                "reference": "75c7effcf3f77501d0e0caa75111aff4daa0dd48",
+                "shasum": ""
+            },
+            "require": {
+                "ocramius/package-versions": "^1.2.0",
+                "php": "^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Jean85\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Alessandro Lai",
+                    "email": "alessandro.lai85@gmail.com"
+                }
+            ],
+            "description": "A wrapper for ocramius/package-versions to get pretty versions strings",
+            "keywords": [
+                "composer",
+                "package",
+                "release",
+                "versions"
+            ],
+            "time": "2018-06-13T13:22:40+00:00"
+        },
+        {
             "name": "justinrainbow/json-schema",
             "version": "5.2.8",
             "source": {
@@ -724,25 +777,28 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.7.0",
+            "version": "1.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e"
+                "reference": "e6828efaba2c9b79f4499dae1d66ef8bfa7b2b72"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e",
-                "reference": "3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/e6828efaba2c9b79f4499dae1d66ef8bfa7b2b72",
+                "reference": "e6828efaba2c9b79f4499dae1d66ef8bfa7b2b72",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0"
+                "php": "^7.1"
+            },
+            "replace": {
+                "myclabs/deep-copy": "self.version"
             },
             "require-dev": {
                 "doctrine/collections": "^1.0",
                 "doctrine/common": "^2.6",
-                "phpunit/phpunit": "^4.1"
+                "phpunit/phpunit": "^7.1"
             },
             "type": "library",
             "autoload": {
@@ -765,7 +821,7 @@
                 "object",
                 "object graph"
             ],
-            "time": "2017-10-19T19:58:43+00:00"
+            "time": "2019-04-07T13:18:21+00:00"
         },
         {
             "name": "netresearch/jsonmapper",
@@ -808,6 +864,529 @@
             ],
             "description": "Map nested JSON structures onto PHP classes",
             "time": "2017-11-28T21:30:01+00:00"
+        },
+        {
+            "name": "nette/bootstrap",
+            "version": "v3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nette/bootstrap.git",
+                "reference": "e1075af05c211915e03e0c86542f3ba5433df4a3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nette/bootstrap/zipball/e1075af05c211915e03e0c86542f3ba5433df4a3",
+                "reference": "e1075af05c211915e03e0c86542f3ba5433df4a3",
+                "shasum": ""
+            },
+            "require": {
+                "nette/di": "^3.0",
+                "nette/utils": "^3.0",
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "latte/latte": "^2.2",
+                "nette/application": "^3.0",
+                "nette/caching": "^3.0",
+                "nette/database": "^3.0",
+                "nette/forms": "^3.0",
+                "nette/http": "^3.0",
+                "nette/mail": "^3.0",
+                "nette/robot-loader": "^3.0",
+                "nette/safe-stream": "^2.2",
+                "nette/security": "^3.0",
+                "nette/tester": "^2.0",
+                "tracy/tracy": "^2.6"
+            },
+            "suggest": {
+                "nette/robot-loader": "to use Configurator::createRobotLoader()",
+                "tracy/tracy": "to use Configurator::enableTracy()"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause",
+                "GPL-2.0",
+                "GPL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "David Grudl",
+                    "homepage": "https://davidgrudl.com"
+                },
+                {
+                    "name": "Nette Community",
+                    "homepage": "https://nette.org/contributors"
+                }
+            ],
+            "description": "🅱 Nette Bootstrap: the simple way to configure and bootstrap your Nette application.",
+            "homepage": "https://nette.org",
+            "keywords": [
+                "bootstrapping",
+                "configurator",
+                "nette"
+            ],
+            "time": "2019-03-26T12:59:07+00:00"
+        },
+        {
+            "name": "nette/di",
+            "version": "v3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nette/di.git",
+                "reference": "19d83539245aaacb59470828919182411061841f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nette/di/zipball/19d83539245aaacb59470828919182411061841f",
+                "reference": "19d83539245aaacb59470828919182411061841f",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "nette/neon": "^3.0",
+                "nette/php-generator": "^3.2.2",
+                "nette/robot-loader": "^3.2",
+                "nette/schema": "^1.0",
+                "nette/utils": "^3.0",
+                "php": ">=7.1"
+            },
+            "conflict": {
+                "nette/bootstrap": "<3.0"
+            },
+            "require-dev": {
+                "nette/tester": "^2.2",
+                "tracy/tracy": "^2.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ],
+                "files": [
+                    "src/compatibility.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause",
+                "GPL-2.0",
+                "GPL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "David Grudl",
+                    "homepage": "https://davidgrudl.com"
+                },
+                {
+                    "name": "Nette Community",
+                    "homepage": "https://nette.org/contributors"
+                }
+            ],
+            "description": "💎 Nette Dependency Injection Container: Flexible, compiled and full-featured DIC with perfectly usable autowiring and support for all new PHP 7.1 features.",
+            "homepage": "https://nette.org",
+            "keywords": [
+                "compiled",
+                "di",
+                "dic",
+                "factory",
+                "ioc",
+                "nette",
+                "static"
+            ],
+            "time": "2019-04-03T19:35:46+00:00"
+        },
+        {
+            "name": "nette/finder",
+            "version": "v2.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nette/finder.git",
+                "reference": "6be1b83ea68ac558aff189d640abe242e0306fe2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nette/finder/zipball/6be1b83ea68ac558aff189d640abe242e0306fe2",
+                "reference": "6be1b83ea68ac558aff189d640abe242e0306fe2",
+                "shasum": ""
+            },
+            "require": {
+                "nette/utils": "^2.4 || ~3.0.0",
+                "php": ">=7.1"
+            },
+            "conflict": {
+                "nette/nette": "<2.2"
+            },
+            "require-dev": {
+                "nette/tester": "^2.0",
+                "tracy/tracy": "^2.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.5-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause",
+                "GPL-2.0",
+                "GPL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "David Grudl",
+                    "homepage": "https://davidgrudl.com"
+                },
+                {
+                    "name": "Nette Community",
+                    "homepage": "https://nette.org/contributors"
+                }
+            ],
+            "description": "? Nette Finder: find files and directories with an intuitive API.",
+            "homepage": "https://nette.org",
+            "keywords": [
+                "filesystem",
+                "glob",
+                "iterator",
+                "nette"
+            ],
+            "time": "2019-02-28T18:13:25+00:00"
+        },
+        {
+            "name": "nette/neon",
+            "version": "v3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nette/neon.git",
+                "reference": "cbff32059cbdd8720deccf9e9eace6ee516f02eb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nette/neon/zipball/cbff32059cbdd8720deccf9e9eace6ee516f02eb",
+                "reference": "cbff32059cbdd8720deccf9e9eace6ee516f02eb",
+                "shasum": ""
+            },
+            "require": {
+                "ext-iconv": "*",
+                "ext-json": "*",
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "nette/tester": "^2.0",
+                "tracy/tracy": "^2.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause",
+                "GPL-2.0",
+                "GPL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "David Grudl",
+                    "homepage": "https://davidgrudl.com"
+                },
+                {
+                    "name": "Nette Community",
+                    "homepage": "https://nette.org/contributors"
+                }
+            ],
+            "description": "? Nette NEON: encodes and decodes NEON file format.",
+            "homepage": "http://ne-on.org",
+            "keywords": [
+                "export",
+                "import",
+                "neon",
+                "nette",
+                "yaml"
+            ],
+            "time": "2019-02-05T21:30:40+00:00"
+        },
+        {
+            "name": "nette/php-generator",
+            "version": "v3.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nette/php-generator.git",
+                "reference": "acff8b136fad84b860a626d133e791f95781f9f5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nette/php-generator/zipball/acff8b136fad84b860a626d133e791f95781f9f5",
+                "reference": "acff8b136fad84b860a626d133e791f95781f9f5",
+                "shasum": ""
+            },
+            "require": {
+                "nette/utils": "^2.4.2 || ~3.0.0",
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "nette/tester": "^2.0",
+                "tracy/tracy": "^2.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.2-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause",
+                "GPL-2.0",
+                "GPL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "David Grudl",
+                    "homepage": "https://davidgrudl.com"
+                },
+                {
+                    "name": "Nette Community",
+                    "homepage": "https://nette.org/contributors"
+                }
+            ],
+            "description": "🐘 Nette PHP Generator: generates neat PHP code for you. Supports new PHP 7.3 features.",
+            "homepage": "https://nette.org",
+            "keywords": [
+                "code",
+                "nette",
+                "php",
+                "scaffolding"
+            ],
+            "time": "2019-03-15T03:41:13+00:00"
+        },
+        {
+            "name": "nette/robot-loader",
+            "version": "v3.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nette/robot-loader.git",
+                "reference": "0712a0e39ae7956d6a94c0ab6ad41aa842544b5c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nette/robot-loader/zipball/0712a0e39ae7956d6a94c0ab6ad41aa842544b5c",
+                "reference": "0712a0e39ae7956d6a94c0ab6ad41aa842544b5c",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "nette/finder": "^2.5",
+                "nette/utils": "^3.0",
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "nette/tester": "^2.0",
+                "tracy/tracy": "^2.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.2-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause",
+                "GPL-2.0",
+                "GPL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "David Grudl",
+                    "homepage": "https://davidgrudl.com"
+                },
+                {
+                    "name": "Nette Community",
+                    "homepage": "https://nette.org/contributors"
+                }
+            ],
+            "description": "? Nette RobotLoader: high performance and comfortable autoloader that will search and autoload classes within your application.",
+            "homepage": "https://nette.org",
+            "keywords": [
+                "autoload",
+                "class",
+                "interface",
+                "nette",
+                "trait"
+            ],
+            "time": "2019-03-08T21:57:24+00:00"
+        },
+        {
+            "name": "nette/schema",
+            "version": "v1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nette/schema.git",
+                "reference": "6241d8d4da39e825dd6cb5bfbe4242912f4d7e4d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nette/schema/zipball/6241d8d4da39e825dd6cb5bfbe4242912f4d7e4d",
+                "reference": "6241d8d4da39e825dd6cb5bfbe4242912f4d7e4d",
+                "shasum": ""
+            },
+            "require": {
+                "nette/utils": "^3.0.1",
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "nette/tester": "^2.2",
+                "tracy/tracy": "^2.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause",
+                "GPL-2.0",
+                "GPL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "David Grudl",
+                    "homepage": "https://davidgrudl.com"
+                },
+                {
+                    "name": "Nette Community",
+                    "homepage": "https://nette.org/contributors"
+                }
+            ],
+            "description": "📐 Nette Schema: validating data structures against a given Schema.",
+            "homepage": "https://nette.org",
+            "keywords": [
+                "config",
+                "nette"
+            ],
+            "time": "2019-04-03T15:53:25+00:00"
+        },
+        {
+            "name": "nette/utils",
+            "version": "v3.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nette/utils.git",
+                "reference": "bd961f49b211997202bda1d0fbc410905be370d4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nette/utils/zipball/bd961f49b211997202bda1d0fbc410905be370d4",
+                "reference": "bd961f49b211997202bda1d0fbc410905be370d4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "nette/tester": "~2.0",
+                "tracy/tracy": "^2.3"
+            },
+            "suggest": {
+                "ext-gd": "to use Image",
+                "ext-iconv": "to use Strings::webalize() and toAscii()",
+                "ext-intl": "to use Strings::webalize(), toAscii(), normalize() and compare()",
+                "ext-json": "to use Nette\\Utils\\Json",
+                "ext-mbstring": "to use Strings::lower() etc...",
+                "ext-xml": "to use Strings::length() etc. when mbstring is not available"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause",
+                "GPL-2.0",
+                "GPL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "David Grudl",
+                    "homepage": "https://davidgrudl.com"
+                },
+                {
+                    "name": "Nette Community",
+                    "homepage": "https://nette.org/contributors"
+                }
+            ],
+            "description": "🛠 Nette Utils: lightweight utilities for string & array manipulation, image handling, safe JSON encoding/decoding, validation, slug or strong password generating etc.",
+            "homepage": "https://nette.org",
+            "keywords": [
+                "array",
+                "core",
+                "datetime",
+                "images",
+                "json",
+                "nette",
+                "paginator",
+                "password",
+                "slugify",
+                "string",
+                "unicode",
+                "utf-8",
+                "utility",
+                "validation"
+            ],
+            "time": "2019-03-22T01:00:30+00:00"
         },
         {
             "name": "nikic/php-parser",
@@ -1082,22 +1661,22 @@
         },
         {
             "name": "phar-io/manifest",
-            "version": "1.0.1",
+            "version": "1.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/manifest.git",
-                "reference": "2df402786ab5368a0169091f61a7c1e0eb6852d0"
+                "reference": "7761fcacf03b4d4f16e7ccb606d4879ca431fcf4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/manifest/zipball/2df402786ab5368a0169091f61a7c1e0eb6852d0",
-                "reference": "2df402786ab5368a0169091f61a7c1e0eb6852d0",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/7761fcacf03b4d4f16e7ccb606d4879ca431fcf4",
+                "reference": "7761fcacf03b4d4f16e7ccb606d4879ca431fcf4",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-phar": "*",
-                "phar-io/version": "^1.0.1",
+                "phar-io/version": "^2.0",
                 "php": "^5.6 || ^7.0"
             },
             "type": "library",
@@ -1133,20 +1712,20 @@
                 }
             ],
             "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
-            "time": "2017-03-05T18:14:27+00:00"
+            "time": "2018-07-08T19:23:20+00:00"
         },
         {
             "name": "phar-io/version",
-            "version": "1.0.1",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/version.git",
-                "reference": "a70c0ced4be299a63d32fa96d9281d03e94041df"
+                "reference": "45a2ec53a73c70ce41d55cedef9063630abaf1b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/version/zipball/a70c0ced4be299a63d32fa96d9281d03e94041df",
-                "reference": "a70c0ced4be299a63d32fa96d9281d03e94041df",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/45a2ec53a73c70ce41d55cedef9063630abaf1b6",
+                "reference": "45a2ec53a73c70ce41d55cedef9063630abaf1b6",
                 "shasum": ""
             },
             "require": {
@@ -1180,7 +1759,7 @@
                 }
             ],
             "description": "Library for handling version information and constraints",
-            "time": "2017-03-05T17:38:23+00:00"
+            "time": "2018-07-08T19:19:57+00:00"
         },
         {
             "name": "php-cs-fixer/diff",
@@ -1448,33 +2027,33 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.7.5",
+            "version": "1.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "dfd6be44111a7c41c2e884a336cc4f461b3b2401"
+                "reference": "4ba436b55987b4bf311cb7c6ba82aa528aac0a06"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/dfd6be44111a7c41c2e884a336cc4f461b3b2401",
-                "reference": "dfd6be44111a7c41c2e884a336cc4f461b3b2401",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/4ba436b55987b4bf311cb7c6ba82aa528aac0a06",
+                "reference": "4ba436b55987b4bf311cb7c6ba82aa528aac0a06",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
                 "php": "^5.3|^7.0",
                 "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0",
-                "sebastian/comparator": "^1.1|^2.0",
+                "sebastian/comparator": "^1.1|^2.0|^3.0",
                 "sebastian/recursion-context": "^1.0|^2.0|^3.0"
             },
             "require-dev": {
                 "phpspec/phpspec": "^2.5|^3.2",
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5"
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5 || ^7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.7.x-dev"
+                    "dev-master": "1.8.x-dev"
                 }
             },
             "autoload": {
@@ -1507,32 +2086,33 @@
                 "spy",
                 "stub"
             ],
-            "time": "2018-02-19T10:16:54+00:00"
+            "time": "2018-08-05T17:53:17+00:00"
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "0.3.1",
+            "version": "0.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "2cc49f47c69b023eaf05b48e6529389893b13d74"
+                "reference": "472d3161d289f652713a5e353532fa4592663a57"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/2cc49f47c69b023eaf05b48e6529389893b13d74",
-                "reference": "2cc49f47c69b023eaf05b48e6529389893b13d74",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/472d3161d289f652713a5e353532fa4592663a57",
+                "reference": "472d3161d289f652713a5e353532fa4592663a57",
                 "shasum": ""
             },
             "require": {
                 "php": "~7.1"
             },
             "require-dev": {
-                "consistence/coding-standard": "^2.0.0",
+                "consistence/coding-standard": "^3.5",
                 "jakub-onderka/php-parallel-lint": "^0.9.2",
                 "phing/phing": "^2.16.0",
                 "phpstan/phpstan": "^0.10",
                 "phpunit/phpunit": "^6.3",
-                "slevomat/coding-standard": "^3.3.0",
+                "slevomat/coding-standard": "^4.7.2",
+                "squizlabs/php_codesniffer": "^3.3.2",
                 "symfony/process": "^3.4 || ^4.0"
             },
             "type": "library",
@@ -1553,68 +2133,155 @@
                 "MIT"
             ],
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
-            "time": "2019-01-14T12:26:23+00:00"
+            "time": "2019-04-23T20:26:19+00:00"
         },
         {
-            "name": "phpstan/phpstan-shim",
-            "version": "0.9.2",
+            "name": "phpstan/phpstan",
+            "version": "0.11.5",
             "source": {
                 "type": "git",
-                "url": "https://github.com/phpstan/phpstan-shim.git",
-                "reference": "e4720fb2916be05de02869780072253e7e0e8a75"
+                "url": "https://github.com/phpstan/phpstan.git",
+                "reference": "24ce5a566a798b81343138ed5d41d6877554cf9a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan-shim/zipball/e4720fb2916be05de02869780072253e7e0e8a75",
-                "reference": "e4720fb2916be05de02869780072253e7e0e8a75",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/24ce5a566a798b81343138ed5d41d6877554cf9a",
+                "reference": "24ce5a566a798b81343138ed5d41d6877554cf9a",
                 "shasum": ""
             },
             "require": {
-                "php": "~7.0"
+                "composer/xdebug-handler": "^1.3.0",
+                "jean85/pretty-package-versions": "^1.0.3",
+                "nette/bootstrap": "^2.4 || ^3.0",
+                "nette/di": "^2.4.7 || ^3.0",
+                "nette/robot-loader": "^3.0.1",
+                "nette/utils": "^2.4.5 || ^3.0",
+                "nikic/php-parser": "^4.0.2",
+                "php": "~7.1",
+                "phpstan/phpdoc-parser": "^0.3",
+                "symfony/console": "~3.2 || ~4.0",
+                "symfony/finder": "~3.2 || ~4.0"
             },
-            "replace": {
-                "phpstan/phpstan": "self.version"
+            "conflict": {
+                "symfony/console": "3.4.16 || 4.1.5"
+            },
+            "require-dev": {
+                "brianium/paratest": "^2.0",
+                "consistence/coding-standard": "^3.5",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
+                "ext-intl": "*",
+                "ext-mysqli": "*",
+                "ext-soap": "*",
+                "ext-zip": "*",
+                "jakub-onderka/php-parallel-lint": "^1.0",
+                "localheinz/composer-normalize": "^1.1.0",
+                "phing/phing": "^2.16.0",
+                "phpstan/phpstan-deprecation-rules": "^0.11",
+                "phpstan/phpstan-php-parser": "^0.11",
+                "phpstan/phpstan-phpunit": "^0.11",
+                "phpstan/phpstan-strict-rules": "^0.11",
+                "phpunit/phpunit": "^7.0",
+                "slevomat/coding-standard": "^4.7.2",
+                "squizlabs/php_codesniffer": "^3.3.2"
             },
             "bin": [
-                "phpstan",
-                "phpstan.phar"
+                "bin/phpstan"
             ],
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "0.9-dev"
+                    "dev-master": "0.11-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\": [
+                        "src/",
+                        "build/PHPStan"
+                    ]
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
-            "description": "PHPStan Phar distribution",
-            "time": "2018-01-28T14:29:27+00:00"
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "time": "2019-03-25T16:40:09+00:00"
         },
         {
-            "name": "phpunit/php-code-coverage",
-            "version": "6.0.1",
+            "name": "phpstan/phpstan-phpunit",
+            "version": "0.11",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "f8ca4b604baf23dab89d87773c28cc07405189ba"
+                "url": "https://github.com/phpstan/phpstan-phpunit.git",
+                "reference": "70c22d44b96a21a4952fc13021a5a63cc83f5c81"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/f8ca4b604baf23dab89d87773c28cc07405189ba",
-                "reference": "f8ca4b604baf23dab89d87773c28cc07405189ba",
+                "url": "https://api.github.com/repos/phpstan/phpstan-phpunit/zipball/70c22d44b96a21a4952fc13021a5a63cc83f5c81",
+                "reference": "70c22d44b96a21a4952fc13021a5a63cc83f5c81",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.0",
+                "php": "~7.1",
+                "phpstan/phpdoc-parser": "^0.3",
+                "phpstan/phpstan": "^0.11"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<7.0"
+            },
+            "require-dev": {
+                "consistence/coding-standard": "^3.0.1",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
+                "jakub-onderka/php-parallel-lint": "^1.0",
+                "phing/phing": "^2.16.0",
+                "phpstan/phpstan-strict-rules": "^0.11",
+                "phpunit/phpunit": "^7.0",
+                "satooshi/php-coveralls": "^1.0",
+                "slevomat/coding-standard": "^4.5.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.11-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPUnit extensions and rules for PHPStan",
+            "time": "2018-12-22T14:05:04+00:00"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "6.1.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "807e6013b00af69b6c5d9ceb4282d0393dbb9d8d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/807e6013b00af69b6c5d9ceb4282d0393dbb9d8d",
+                "reference": "807e6013b00af69b6c5d9ceb4282d0393dbb9d8d",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-xmlwriter": "*",
                 "php": "^7.1",
-                "phpunit/php-file-iterator": "^1.4.2",
+                "phpunit/php-file-iterator": "^2.0",
                 "phpunit/php-text-template": "^1.2.1",
                 "phpunit/php-token-stream": "^3.0",
                 "sebastian/code-unit-reverse-lookup": "^1.0.1",
-                "sebastian/environment": "^3.0",
+                "sebastian/environment": "^3.1 || ^4.0",
                 "sebastian/version": "^2.0.1",
                 "theseer/tokenizer": "^1.1"
             },
@@ -1627,7 +2294,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "6.0-dev"
+                    "dev-master": "6.1-dev"
                 }
             },
             "autoload": {
@@ -1653,29 +2320,32 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2018-02-02T07:01:41+00:00"
+            "time": "2018-10-31T16:06:48+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "1.4.5",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4"
+                "reference": "050bedf145a257b1ff02746c31894800e5122946"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/730b01bc3e867237eaac355e06a36b85dd93a8b4",
-                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/050bedf145a257b1ff02746c31894800e5122946",
+                "reference": "050bedf145a257b1ff02746c31894800e5122946",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -1690,7 +2360,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -1700,7 +2370,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2017-11-27T13:52:08+00:00"
+            "time": "2018-09-13T20:33:42+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -1745,16 +2415,16 @@
         },
         {
             "name": "phpunit/php-timer",
-            "version": "2.0.0",
+            "version": "2.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "8b8454ea6958c3dee38453d3bd571e023108c91f"
+                "reference": "8b389aebe1b8b0578430bda0c7c95a829608e059"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/8b8454ea6958c3dee38453d3bd571e023108c91f",
-                "reference": "8b8454ea6958c3dee38453d3bd571e023108c91f",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/8b389aebe1b8b0578430bda0c7c95a829608e059",
+                "reference": "8b389aebe1b8b0578430bda0c7c95a829608e059",
                 "shasum": ""
             },
             "require": {
@@ -1766,7 +2436,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-master": "2.1-dev"
                 }
             },
             "autoload": {
@@ -1790,20 +2460,20 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2018-02-01T13:07:23+00:00"
+            "time": "2019-02-20T10:12:59+00:00"
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "3.0.0",
+            "version": "3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "21ad88bbba7c3d93530d93994e0a33cd45f02ace"
+                "reference": "c99e3be9d3e85f60646f152f9002d46ed7770d18"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/21ad88bbba7c3d93530d93994e0a33cd45f02ace",
-                "reference": "21ad88bbba7c3d93530d93994e0a33cd45f02ace",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/c99e3be9d3e85f60646f152f9002d46ed7770d18",
+                "reference": "c99e3be9d3e85f60646f152f9002d46ed7770d18",
                 "shasum": ""
             },
             "require": {
@@ -1839,51 +2509,55 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2018-02-01T13:16:43+00:00"
+            "time": "2018-10-30T05:52:18+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "7.0.2",
+            "version": "7.5.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "e2f8aa21bc54b6ba218bdd4f9e0dac1e9bc3b4e9"
+                "reference": "134669cf0eeac3f79bc7f0c793efbc158bffc160"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/e2f8aa21bc54b6ba218bdd4f9e0dac1e9bc3b4e9",
-                "reference": "e2f8aa21bc54b6ba218bdd4f9e0dac1e9bc3b4e9",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/134669cf0eeac3f79bc7f0c793efbc158bffc160",
+                "reference": "134669cf0eeac3f79bc7f0c793efbc158bffc160",
                 "shasum": ""
             },
             "require": {
+                "doctrine/instantiator": "^1.1",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
                 "ext-xml": "*",
-                "myclabs/deep-copy": "^1.6.1",
-                "phar-io/manifest": "^1.0.1",
-                "phar-io/version": "^1.0",
+                "myclabs/deep-copy": "^1.7",
+                "phar-io/manifest": "^1.0.2",
+                "phar-io/version": "^2.0",
                 "php": "^7.1",
                 "phpspec/prophecy": "^1.7",
-                "phpunit/php-code-coverage": "^6.0",
-                "phpunit/php-file-iterator": "^1.4.3",
+                "phpunit/php-code-coverage": "^6.0.7",
+                "phpunit/php-file-iterator": "^2.0.1",
                 "phpunit/php-text-template": "^1.2.1",
-                "phpunit/php-timer": "^2.0",
-                "phpunit/phpunit-mock-objects": "^6.0",
-                "sebastian/comparator": "^2.1",
+                "phpunit/php-timer": "^2.1",
+                "sebastian/comparator": "^3.0",
                 "sebastian/diff": "^3.0",
-                "sebastian/environment": "^3.1",
+                "sebastian/environment": "^4.0",
                 "sebastian/exporter": "^3.1",
                 "sebastian/global-state": "^2.0",
                 "sebastian/object-enumerator": "^3.0.3",
-                "sebastian/resource-operations": "^1.0",
+                "sebastian/resource-operations": "^2.0",
                 "sebastian/version": "^2.0.1"
+            },
+            "conflict": {
+                "phpunit/phpunit-mock-objects": "*"
             },
             "require-dev": {
                 "ext-pdo": "*"
             },
             "suggest": {
+                "ext-soap": "*",
                 "ext-xdebug": "*",
                 "phpunit/php-invoker": "^2.0"
             },
@@ -1893,7 +2567,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "7.0-dev"
+                    "dev-master": "7.5-dev"
                 }
             },
             "autoload": {
@@ -1919,64 +2593,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2018-02-26T07:03:12+00:00"
-        },
-        {
-            "name": "phpunit/phpunit-mock-objects",
-            "version": "6.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "e3249dedc2d99259ccae6affbc2684eac37c2e53"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/e3249dedc2d99259ccae6affbc2684eac37c2e53",
-                "reference": "e3249dedc2d99259ccae6affbc2684eac37c2e53",
-                "shasum": ""
-            },
-            "require": {
-                "doctrine/instantiator": "^1.0.5",
-                "php": "^7.1",
-                "phpunit/php-text-template": "^1.2.1",
-                "sebastian/exporter": "^3.1"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^7.0"
-            },
-            "suggest": {
-                "ext-soap": "*"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "6.0.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Mock Object library for PHPUnit",
-            "homepage": "https://github.com/sebastianbergmann/phpunit-mock-objects/",
-            "keywords": [
-                "mock",
-                "xunit"
-            ],
-            "abandoned": true,
-            "time": "2018-02-15T05:27:38+00:00"
+            "time": "2019-04-19T15:50:46+00:00"
         },
         {
             "name": "pimple/pimple",
@@ -2171,30 +2788,30 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "2.1.3",
+            "version": "3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "34369daee48eafb2651bea869b4b15d75ccc35f9"
+                "reference": "5de4fc177adf9bce8df98d8d141a7559d7ccf6da"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/34369daee48eafb2651bea869b4b15d75ccc35f9",
-                "reference": "34369daee48eafb2651bea869b4b15d75ccc35f9",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/5de4fc177adf9bce8df98d8d141a7559d7ccf6da",
+                "reference": "5de4fc177adf9bce8df98d8d141a7559d7ccf6da",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0",
-                "sebastian/diff": "^2.0 || ^3.0",
+                "php": "^7.1",
+                "sebastian/diff": "^3.0",
                 "sebastian/exporter": "^3.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.4"
+                "phpunit/phpunit": "^7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.1.x-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -2231,27 +2848,27 @@
                 "compare",
                 "equality"
             ],
-            "time": "2018-02-01T13:46:46+00:00"
+            "time": "2018-07-12T15:12:46+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "3.0.0",
+            "version": "3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "e09160918c66281713f1c324c1f4c4c3037ba1e8"
+                "reference": "720fcc7e9b5cf384ea68d9d930d480907a0c1a29"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/e09160918c66281713f1c324c1f4c4c3037ba1e8",
-                "reference": "e09160918c66281713f1c324c1f4c4c3037ba1e8",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/720fcc7e9b5cf384ea68d9d930d480907a0c1a29",
+                "reference": "720fcc7e9b5cf384ea68d9d930d480907a0c1a29",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^7.0",
+                "phpunit/phpunit": "^7.5 || ^8.0",
                 "symfony/process": "^2 || ^3.3 || ^4"
             },
             "type": "library",
@@ -2287,32 +2904,35 @@
                 "unidiff",
                 "unified diff"
             ],
-            "time": "2018-02-01T13:45:15+00:00"
+            "time": "2019-02-04T06:01:07+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "3.1.0",
+            "version": "4.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "cd0871b3975fb7fc44d11314fd1ee20925fce4f5"
+                "reference": "6fda8ce1974b62b14935adc02a9ed38252eca656"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/cd0871b3975fb7fc44d11314fd1ee20925fce4f5",
-                "reference": "cd0871b3975fb7fc44d11314fd1ee20925fce4f5",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/6fda8ce1974b62b14935adc02a9ed38252eca656",
+                "reference": "6fda8ce1974b62b14935adc02a9ed38252eca656",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0"
+                "php": "^7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.1"
+                "phpunit/phpunit": "^7.5"
+            },
+            "suggest": {
+                "ext-posix": "*"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1.x-dev"
+                    "dev-master": "4.1-dev"
                 }
             },
             "autoload": {
@@ -2337,7 +2957,7 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2017-07-01T08:51:00+00:00"
+            "time": "2019-02-01T05:27:49+00:00"
         },
         {
             "name": "sebastian/exporter",
@@ -2604,25 +3224,25 @@
         },
         {
             "name": "sebastian/resource-operations",
-            "version": "1.0.0",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/resource-operations.git",
-                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52"
+                "reference": "4d7a795d35b889bf80a0cc04e08d77cedfa917a9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
-                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/4d7a795d35b889bf80a0cc04e08d77cedfa917a9",
+                "reference": "4d7a795d35b889bf80a0cc04e08d77cedfa917a9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.6.0"
+                "php": "^7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -2642,7 +3262,7 @@
             ],
             "description": "Provides a list of PHP built-in functions that operate on resources",
             "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
-            "time": "2015-07-28T20:34:47+00:00"
+            "time": "2018-10-04T04:07:39+00:00"
         },
         {
             "name": "sebastian/version",
@@ -2689,30 +3309,30 @@
         },
         {
             "name": "slevomat/coding-standard",
-            "version": "5.0.2",
+            "version": "5.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/slevomat/coding-standard.git",
-                "reference": "223f02b6193fe47b7b483bfa5bf75693535482dd"
+                "reference": "287ac3347c47918c0bf5e10335e36197ea10894c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/223f02b6193fe47b7b483bfa5bf75693535482dd",
-                "reference": "223f02b6193fe47b7b483bfa5bf75693535482dd",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/287ac3347c47918c0bf5e10335e36197ea10894c",
+                "reference": "287ac3347c47918c0bf5e10335e36197ea10894c",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1",
                 "phpstan/phpdoc-parser": "^0.3.1",
-                "squizlabs/php_codesniffer": "^3.4.0"
+                "squizlabs/php_codesniffer": "^3.4.1"
             },
             "require-dev": {
                 "jakub-onderka/php-parallel-lint": "1.0.0",
                 "phing/phing": "2.16.1",
-                "phpstan/phpstan": "0.11.1",
+                "phpstan/phpstan": "0.11.4",
                 "phpstan/phpstan-phpunit": "0.11",
                 "phpstan/phpstan-strict-rules": "0.11",
-                "phpunit/phpunit": "8.0.0"
+                "phpunit/phpunit": "8.0.5"
             },
             "type": "phpcodesniffer-standard",
             "autoload": {
@@ -2725,20 +3345,20 @@
                 "MIT"
             ],
             "description": "Slevomat Coding Standard for PHP_CodeSniffer complements Consistence Coding Standard by providing sniffs with additional checks.",
-            "time": "2019-03-12T20:26:36+00:00"
+            "time": "2019-03-22T19:10:53+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.4.0",
+            "version": "3.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "379deb987e26c7cd103a7b387aea178baec96e48"
+                "reference": "b8a7362af1cc1aadb5bd36c3defc4dda2cf5f0a8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/379deb987e26c7cd103a7b387aea178baec96e48",
-                "reference": "379deb987e26c7cd103a7b387aea178baec96e48",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/b8a7362af1cc1aadb5bd36c3defc4dda2cf5f0a8",
+                "reference": "b8a7362af1cc1aadb5bd36c3defc4dda2cf5f0a8",
                 "shasum": ""
             },
             "require": {
@@ -2771,25 +3391,25 @@
                 }
             ],
             "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
-            "homepage": "http://www.squizlabs.com/php-codesniffer",
+            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
             "keywords": [
                 "phpcs",
                 "standards"
             ],
-            "time": "2018-12-19T23:57:18+00:00"
+            "time": "2019-04-10T23:49:02+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v4.2.4",
+            "version": "v4.2.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "9dc2299a016497f9ee620be94524e6c0af0280a9"
+                "reference": "e2840bb38bddad7a0feaf85931e38fdcffdb2f81"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/9dc2299a016497f9ee620be94524e6c0af0280a9",
-                "reference": "9dc2299a016497f9ee620be94524e6c0af0280a9",
+                "url": "https://api.github.com/repos/symfony/console/zipball/e2840bb38bddad7a0feaf85931e38fdcffdb2f81",
+                "reference": "e2840bb38bddad7a0feaf85931e38fdcffdb2f81",
                 "shasum": ""
             },
             "require": {
@@ -2848,7 +3468,7 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2019-02-23T15:17:42+00:00"
+            "time": "2019-04-08T14:23:48+00:00"
         },
         {
             "name": "symfony/contracts",
@@ -2920,7 +3540,7 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v4.2.4",
+            "version": "v4.2.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
@@ -2970,16 +3590,16 @@
         },
         {
             "name": "symfony/finder",
-            "version": "v4.2.4",
+            "version": "v4.2.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "267b7002c1b70ea80db0833c3afe05f0fbde580a"
+                "reference": "e45135658bd6c14b61850bf131c4f09a55133f69"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/267b7002c1b70ea80db0833c3afe05f0fbde580a",
-                "reference": "267b7002c1b70ea80db0833c3afe05f0fbde580a",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/e45135658bd6c14b61850bf131c4f09a55133f69",
+                "reference": "e45135658bd6c14b61850bf131c4f09a55133f69",
                 "shasum": ""
             },
             "require": {
@@ -3015,20 +3635,20 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2019-02-23T15:42:05+00:00"
+            "time": "2019-04-06T13:51:08+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.10.0",
+            "version": "v1.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "e3d826245268269cd66f8326bd8bc066687b4a19"
+                "reference": "82ebae02209c21113908c229e9883c419720738a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/e3d826245268269cd66f8326bd8bc066687b4a19",
-                "reference": "e3d826245268269cd66f8326bd8bc066687b4a19",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/82ebae02209c21113908c229e9883c419720738a",
+                "reference": "82ebae02209c21113908c229e9883c419720738a",
                 "shasum": ""
             },
             "require": {
@@ -3040,7 +3660,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.9-dev"
+                    "dev-master": "1.11-dev"
                 }
             },
             "autoload": {
@@ -3062,7 +3682,7 @@
                 },
                 {
                     "name": "Gert de Pagter",
-                    "email": "backendtea@gmail.com"
+                    "email": "BackEndTea@gmail.com"
                 }
             ],
             "description": "Symfony polyfill for ctype functions",
@@ -3073,20 +3693,20 @@
                 "polyfill",
                 "portable"
             ],
-            "time": "2018-08-06T14:22:27+00:00"
+            "time": "2019-02-06T07:57:58+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.10.0",
+            "version": "v1.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "c79c051f5b3a46be09205c73b80b346e4153e494"
+                "reference": "fe5e94c604826c35a32fa832f35bd036b6799609"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/c79c051f5b3a46be09205c73b80b346e4153e494",
-                "reference": "c79c051f5b3a46be09205c73b80b346e4153e494",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/fe5e94c604826c35a32fa832f35bd036b6799609",
+                "reference": "fe5e94c604826c35a32fa832f35bd036b6799609",
                 "shasum": ""
             },
             "require": {
@@ -3098,7 +3718,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.9-dev"
+                    "dev-master": "1.11-dev"
                 }
             },
             "autoload": {
@@ -3132,20 +3752,20 @@
                 "portable",
                 "shim"
             ],
-            "time": "2018-09-21T13:07:52+00:00"
+            "time": "2019-02-06T07:57:58+00:00"
         },
         {
             "name": "symfony/process",
-            "version": "v4.2.4",
+            "version": "v4.2.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "6c05edb11fbeff9e2b324b4270ecb17911a8b7ad"
+                "reference": "8cf39fb4ccff793340c258ee7760fd40bfe745fe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/6c05edb11fbeff9e2b324b4270ecb17911a8b7ad",
-                "reference": "6c05edb11fbeff9e2b324b4270ecb17911a8b7ad",
+                "url": "https://api.github.com/repos/symfony/process/zipball/8cf39fb4ccff793340c258ee7760fd40bfe745fe",
+                "reference": "8cf39fb4ccff793340c258ee7760fd40bfe745fe",
                 "shasum": ""
             },
             "require": {
@@ -3181,20 +3801,20 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2019-01-24T22:05:03+00:00"
+            "time": "2019-04-10T16:20:36+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v4.2.4",
+            "version": "v4.2.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "761fa560a937fd7686e5274ff89dcfa87a5047df"
+                "reference": "6712daf03ee25b53abb14e7e8e0ede1a770efdb1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/761fa560a937fd7686e5274ff89dcfa87a5047df",
-                "reference": "761fa560a937fd7686e5274ff89dcfa87a5047df",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/6712daf03ee25b53abb14e7e8e0ede1a770efdb1",
+                "reference": "6712daf03ee25b53abb14e7e8e0ede1a770efdb1",
                 "shasum": ""
             },
             "require": {
@@ -3240,20 +3860,20 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2019-02-23T15:17:42+00:00"
+            "time": "2019-03-30T15:58:42+00:00"
         },
         {
             "name": "theseer/tokenizer",
-            "version": "1.1.0",
+            "version": "1.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "cb2f008f3f05af2893a87208fe6a6c4985483f8b"
+                "reference": "1c42705be2b6c1de5904f8afacef5895cab44bf8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/cb2f008f3f05af2893a87208fe6a6c4985483f8b",
-                "reference": "cb2f008f3f05af2893a87208fe6a6c4985483f8b",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/1c42705be2b6c1de5904f8afacef5895cab44bf8",
+                "reference": "1c42705be2b6c1de5904f8afacef5895cab44bf8",
                 "shasum": ""
             },
             "require": {
@@ -3280,20 +3900,20 @@
                 }
             ],
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
-            "time": "2017-04-07T12:08:54+00:00"
+            "time": "2019-04-04T09:56:43+00:00"
         },
         {
             "name": "vimeo/psalm",
-            "version": "3.2.2",
+            "version": "3.2.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "f0ddc6f3bc35ba7ecb99232903907a1d5ec1c8e8"
+                "reference": "473c8cb83209de1b66a1487400c0ea47a2ee65cc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/f0ddc6f3bc35ba7ecb99232903907a1d5ec1c8e8",
-                "reference": "f0ddc6f3bc35ba7ecb99232903907a1d5ec1c8e8",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/473c8cb83209de1b66a1487400c0ea47a2ee65cc",
+                "reference": "473c8cb83209de1b66a1487400c0ea47a2ee65cc",
                 "shasum": ""
             },
             "require": {
@@ -3309,7 +3929,7 @@
                 "php": "^7.0",
                 "php-cs-fixer/diff": "^1.2",
                 "phpmyadmin/sql-parser": "^4.0",
-                "symfony/console": "^3.0||^4.0",
+                "symfony/console": "^3.3||^4.0",
                 "webmozart/glob": "^4.1",
                 "webmozart/path-util": "^2.3"
             },
@@ -3320,7 +3940,7 @@
                 "bamarni/composer-bin-plugin": "^1.2",
                 "phpunit/phpunit": "^6.0 || ^7.0",
                 "psalm/plugin-phpunit": "^0.5.1",
-                "squizlabs/php_codesniffer": "^3.0"
+                "squizlabs/php_codesniffer": "3.4.0"
             },
             "suggest": {
                 "ext-igbinary": "^2.0.5"
@@ -3360,7 +3980,7 @@
                 "inspection",
                 "php"
             ],
-            "time": "2019-03-17T22:14:30+00:00"
+            "time": "2019-04-22T17:18:19+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -3513,7 +4133,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.1.3"
+        "php": "^7.2"
     },
     "platform-dev": []
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "6d3364c688ed0047437ce00428d6f9cc",
+    "content-hash": "58cc74a6b2039aaaa4079a4287774aa6",
     "packages": [],
     "packages-dev": [
         {
@@ -2908,16 +2908,16 @@
         },
         {
             "name": "sebastian/environment",
-            "version": "4.1.0",
+            "version": "4.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "6fda8ce1974b62b14935adc02a9ed38252eca656"
+                "reference": "3095910f0f0fb155ac4021fc51a4a7a39ac04e8a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/6fda8ce1974b62b14935adc02a9ed38252eca656",
-                "reference": "6fda8ce1974b62b14935adc02a9ed38252eca656",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/3095910f0f0fb155ac4021fc51a4a7a39ac04e8a",
+                "reference": "3095910f0f0fb155ac4021fc51a4a7a39ac04e8a",
                 "shasum": ""
             },
             "require": {
@@ -2932,7 +2932,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.1-dev"
+                    "dev-master": "4.2-dev"
                 }
             },
             "autoload": {
@@ -2957,7 +2957,7 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2019-02-01T05:27:49+00:00"
+            "time": "2019-04-25T07:55:20+00:00"
         },
         {
             "name": "sebastian/exporter",
@@ -3904,16 +3904,16 @@
         },
         {
             "name": "vimeo/psalm",
-            "version": "3.2.9",
+            "version": "3.2.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "473c8cb83209de1b66a1487400c0ea47a2ee65cc"
+                "reference": "b9bece4cbcb3f342c8412618f73ca02db98064e8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/473c8cb83209de1b66a1487400c0ea47a2ee65cc",
-                "reference": "473c8cb83209de1b66a1487400c0ea47a2ee65cc",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/b9bece4cbcb3f342c8412618f73ca02db98064e8",
+                "reference": "b9bece4cbcb3f342c8412618f73ca02db98064e8",
                 "shasum": ""
             },
             "require": {
@@ -3939,7 +3939,7 @@
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.2",
                 "phpunit/phpunit": "^6.0 || ^7.0",
-                "psalm/plugin-phpunit": "^0.5.1",
+                "psalm/plugin-phpunit": "^0.5.5",
                 "squizlabs/php_codesniffer": "3.4.0"
             },
             "suggest": {
@@ -3980,7 +3980,7 @@
                 "inspection",
                 "php"
             ],
-            "time": "2019-04-22T17:18:19+00:00"
+            "time": "2019-04-29T16:19:51+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/lib/Doctrine/Common/Collections/AbstractLazyCollection.php
+++ b/lib/Doctrine/Common/Collections/AbstractLazyCollection.php
@@ -287,6 +287,8 @@ abstract class AbstractLazyCollection implements Collection
 
     /**
      * {@inheritDoc}
+     *
+     * @param int|string $offset
      */
     public function offsetExists($offset) : bool
     {
@@ -297,6 +299,10 @@ abstract class AbstractLazyCollection implements Collection
 
     /**
      * {@inheritDoc}
+     *
+     * @param int|string $offset
+     *
+     * @return mixed
      */
     public function offsetGet($offset)
     {
@@ -307,6 +313,9 @@ abstract class AbstractLazyCollection implements Collection
 
     /**
      * {@inheritDoc}
+     *
+     * @param int|string $offset
+     * @param mixed      $value
      */
     public function offsetSet($offset, $value) : void
     {
@@ -316,6 +325,8 @@ abstract class AbstractLazyCollection implements Collection
 
     /**
      * {@inheritDoc}
+     *
+     * @param int|string $offset
      */
     public function offsetUnset($offset) : void
     {

--- a/lib/Doctrine/Common/Collections/AbstractLazyCollection.php
+++ b/lib/Doctrine/Common/Collections/AbstractLazyCollection.php
@@ -29,7 +29,7 @@ abstract class AbstractLazyCollection implements Collection
     /**
      * {@inheritDoc}
      */
-    public function count()
+    public function count(): int
     {
         $this->initialize();
 
@@ -39,7 +39,7 @@ abstract class AbstractLazyCollection implements Collection
     /**
      * {@inheritDoc}
      */
-    public function add($element)
+    public function add($element): bool
     {
         $this->initialize();
 
@@ -49,7 +49,7 @@ abstract class AbstractLazyCollection implements Collection
     /**
      * {@inheritDoc}
      */
-    public function clear()
+    public function clear(): void
     {
         $this->initialize();
         $this->collection->clear();
@@ -58,7 +58,7 @@ abstract class AbstractLazyCollection implements Collection
     /**
      * {@inheritDoc}
      */
-    public function contains($element)
+    public function contains($element): bool
     {
         $this->initialize();
 
@@ -68,7 +68,7 @@ abstract class AbstractLazyCollection implements Collection
     /**
      * {@inheritDoc}
      */
-    public function isEmpty()
+    public function isEmpty(): bool
     {
         $this->initialize();
 
@@ -88,7 +88,7 @@ abstract class AbstractLazyCollection implements Collection
     /**
      * {@inheritDoc}
      */
-    public function removeElement($element)
+    public function removeElement($element): bool
     {
         $this->initialize();
 
@@ -98,7 +98,7 @@ abstract class AbstractLazyCollection implements Collection
     /**
      * {@inheritDoc}
      */
-    public function containsKey($key)
+    public function containsKey($key): bool
     {
         $this->initialize();
 
@@ -118,7 +118,7 @@ abstract class AbstractLazyCollection implements Collection
     /**
      * {@inheritDoc}
      */
-    public function getKeys()
+    public function getKeys(): array
     {
         $this->initialize();
 
@@ -128,7 +128,7 @@ abstract class AbstractLazyCollection implements Collection
     /**
      * {@inheritDoc}
      */
-    public function getValues()
+    public function getValues(): array
     {
         $this->initialize();
 
@@ -138,7 +138,7 @@ abstract class AbstractLazyCollection implements Collection
     /**
      * {@inheritDoc}
      */
-    public function set($key, $value)
+    public function set($key, $value): void
     {
         $this->initialize();
         $this->collection->set($key, $value);
@@ -147,7 +147,7 @@ abstract class AbstractLazyCollection implements Collection
     /**
      * {@inheritDoc}
      */
-    public function toArray()
+    public function toArray(): array
     {
         $this->initialize();
 
@@ -207,7 +207,7 @@ abstract class AbstractLazyCollection implements Collection
     /**
      * {@inheritDoc}
      */
-    public function exists(Closure $p)
+    public function exists(Closure $p): bool
     {
         $this->initialize();
 
@@ -217,7 +217,7 @@ abstract class AbstractLazyCollection implements Collection
     /**
      * {@inheritDoc}
      */
-    public function filter(Closure $p)
+    public function filter(Closure $p): Collection
     {
         $this->initialize();
 
@@ -227,7 +227,7 @@ abstract class AbstractLazyCollection implements Collection
     /**
      * {@inheritDoc}
      */
-    public function forAll(Closure $p)
+    public function forAll(Closure $p): bool
     {
         $this->initialize();
 
@@ -237,7 +237,7 @@ abstract class AbstractLazyCollection implements Collection
     /**
      * {@inheritDoc}
      */
-    public function map(Closure $func)
+    public function map(Closure $func): Collection
     {
         $this->initialize();
 
@@ -247,7 +247,7 @@ abstract class AbstractLazyCollection implements Collection
     /**
      * {@inheritDoc}
      */
-    public function partition(Closure $p)
+    public function partition(Closure $p): array
     {
         $this->initialize();
 
@@ -267,7 +267,7 @@ abstract class AbstractLazyCollection implements Collection
     /**
      * {@inheritDoc}
      */
-    public function slice($offset, $length = null)
+    public function slice(int $offset, ?int $length = null): array
     {
         $this->initialize();
 
@@ -277,7 +277,7 @@ abstract class AbstractLazyCollection implements Collection
     /**
      * {@inheritDoc}
      */
-    public function getIterator()
+    public function getIterator(): \Traversable
     {
         $this->initialize();
 
@@ -287,7 +287,7 @@ abstract class AbstractLazyCollection implements Collection
     /**
      * {@inheritDoc}
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         $this->initialize();
 
@@ -307,7 +307,7 @@ abstract class AbstractLazyCollection implements Collection
     /**
      * {@inheritDoc}
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         $this->initialize();
         $this->collection->offsetSet($offset, $value);
@@ -316,7 +316,7 @@ abstract class AbstractLazyCollection implements Collection
     /**
      * {@inheritDoc}
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         $this->initialize();
         $this->collection->offsetUnset($offset);
@@ -327,7 +327,7 @@ abstract class AbstractLazyCollection implements Collection
      *
      * @return bool
      */
-    public function isInitialized()
+    public function isInitialized(): bool
     {
         return $this->initialized;
     }
@@ -337,7 +337,7 @@ abstract class AbstractLazyCollection implements Collection
      *
      * @return void
      */
-    protected function initialize()
+    protected function initialize(): void
     {
         if ($this->initialized) {
             return;
@@ -352,5 +352,5 @@ abstract class AbstractLazyCollection implements Collection
      *
      * @return void
      */
-    abstract protected function doInitialize();
+    abstract protected function doInitialize(): void;
 }

--- a/lib/Doctrine/Common/Collections/AbstractLazyCollection.php
+++ b/lib/Doctrine/Common/Collections/AbstractLazyCollection.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Common\Collections;
 
 use Closure;
+use Traversable;
 
 /**
  * Lazy collection that is backed by a concrete collection
@@ -29,7 +30,7 @@ abstract class AbstractLazyCollection implements Collection
     /**
      * {@inheritDoc}
      */
-    public function count(): int
+    public function count() : int
     {
         $this->initialize();
 
@@ -39,7 +40,7 @@ abstract class AbstractLazyCollection implements Collection
     /**
      * {@inheritDoc}
      */
-    public function add($element): bool
+    public function add($element) : bool
     {
         $this->initialize();
 
@@ -49,7 +50,7 @@ abstract class AbstractLazyCollection implements Collection
     /**
      * {@inheritDoc}
      */
-    public function clear(): void
+    public function clear() : void
     {
         $this->initialize();
         $this->collection->clear();
@@ -58,7 +59,7 @@ abstract class AbstractLazyCollection implements Collection
     /**
      * {@inheritDoc}
      */
-    public function contains($element): bool
+    public function contains($element) : bool
     {
         $this->initialize();
 
@@ -68,7 +69,7 @@ abstract class AbstractLazyCollection implements Collection
     /**
      * {@inheritDoc}
      */
-    public function isEmpty(): bool
+    public function isEmpty() : bool
     {
         $this->initialize();
 
@@ -88,7 +89,7 @@ abstract class AbstractLazyCollection implements Collection
     /**
      * {@inheritDoc}
      */
-    public function removeElement($element): bool
+    public function removeElement($element) : bool
     {
         $this->initialize();
 
@@ -98,7 +99,7 @@ abstract class AbstractLazyCollection implements Collection
     /**
      * {@inheritDoc}
      */
-    public function containsKey($key): bool
+    public function containsKey($key) : bool
     {
         $this->initialize();
 
@@ -118,7 +119,7 @@ abstract class AbstractLazyCollection implements Collection
     /**
      * {@inheritDoc}
      */
-    public function getKeys(): array
+    public function getKeys() : array
     {
         $this->initialize();
 
@@ -128,7 +129,7 @@ abstract class AbstractLazyCollection implements Collection
     /**
      * {@inheritDoc}
      */
-    public function getValues(): array
+    public function getValues() : array
     {
         $this->initialize();
 
@@ -138,7 +139,7 @@ abstract class AbstractLazyCollection implements Collection
     /**
      * {@inheritDoc}
      */
-    public function set($key, $value): void
+    public function set($key, $value) : void
     {
         $this->initialize();
         $this->collection->set($key, $value);
@@ -147,7 +148,7 @@ abstract class AbstractLazyCollection implements Collection
     /**
      * {@inheritDoc}
      */
-    public function toArray(): array
+    public function toArray() : array
     {
         $this->initialize();
 
@@ -207,7 +208,7 @@ abstract class AbstractLazyCollection implements Collection
     /**
      * {@inheritDoc}
      */
-    public function exists(Closure $p): bool
+    public function exists(Closure $p) : bool
     {
         $this->initialize();
 
@@ -217,7 +218,7 @@ abstract class AbstractLazyCollection implements Collection
     /**
      * {@inheritDoc}
      */
-    public function filter(Closure $p): Collection
+    public function filter(Closure $p) : Collection
     {
         $this->initialize();
 
@@ -227,7 +228,7 @@ abstract class AbstractLazyCollection implements Collection
     /**
      * {@inheritDoc}
      */
-    public function forAll(Closure $p): bool
+    public function forAll(Closure $p) : bool
     {
         $this->initialize();
 
@@ -237,7 +238,7 @@ abstract class AbstractLazyCollection implements Collection
     /**
      * {@inheritDoc}
      */
-    public function map(Closure $func): Collection
+    public function map(Closure $func) : Collection
     {
         $this->initialize();
 
@@ -247,7 +248,7 @@ abstract class AbstractLazyCollection implements Collection
     /**
      * {@inheritDoc}
      */
-    public function partition(Closure $p): array
+    public function partition(Closure $p) : array
     {
         $this->initialize();
 
@@ -267,7 +268,7 @@ abstract class AbstractLazyCollection implements Collection
     /**
      * {@inheritDoc}
      */
-    public function slice(int $offset, ?int $length = null): array
+    public function slice(int $offset, ?int $length = null) : array
     {
         $this->initialize();
 
@@ -277,7 +278,7 @@ abstract class AbstractLazyCollection implements Collection
     /**
      * {@inheritDoc}
      */
-    public function getIterator(): \Traversable
+    public function getIterator() : Traversable
     {
         $this->initialize();
 
@@ -287,7 +288,7 @@ abstract class AbstractLazyCollection implements Collection
     /**
      * {@inheritDoc}
      */
-    public function offsetExists($offset): bool
+    public function offsetExists($offset) : bool
     {
         $this->initialize();
 
@@ -307,7 +308,7 @@ abstract class AbstractLazyCollection implements Collection
     /**
      * {@inheritDoc}
      */
-    public function offsetSet($offset, $value): void
+    public function offsetSet($offset, $value) : void
     {
         $this->initialize();
         $this->collection->offsetSet($offset, $value);
@@ -316,7 +317,7 @@ abstract class AbstractLazyCollection implements Collection
     /**
      * {@inheritDoc}
      */
-    public function offsetUnset($offset): void
+    public function offsetUnset($offset) : void
     {
         $this->initialize();
         $this->collection->offsetUnset($offset);
@@ -324,20 +325,16 @@ abstract class AbstractLazyCollection implements Collection
 
     /**
      * Is the lazy collection already initialized?
-     *
-     * @return bool
      */
-    public function isInitialized(): bool
+    public function isInitialized() : bool
     {
         return $this->initialized;
     }
 
     /**
      * Initialize the collection
-     *
-     * @return void
      */
-    protected function initialize(): void
+    protected function initialize() : void
     {
         if ($this->initialized) {
             return;
@@ -349,8 +346,6 @@ abstract class AbstractLazyCollection implements Collection
 
     /**
      * Do the initialization logic
-     *
-     * @return void
      */
-    abstract protected function doInitialize(): void;
+    abstract protected function doInitialize() : void;
 }

--- a/lib/Doctrine/Common/Collections/AbstractLazyCollection.php
+++ b/lib/Doctrine/Common/Collections/AbstractLazyCollection.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Common\Collections;
 
 use Closure;

--- a/lib/Doctrine/Common/Collections/ArrayCollection.php
+++ b/lib/Doctrine/Common/Collections/ArrayCollection.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Common\Collections;
 
 use ArrayIterator;

--- a/lib/Doctrine/Common/Collections/ArrayCollection.php
+++ b/lib/Doctrine/Common/Collections/ArrayCollection.php
@@ -7,6 +7,7 @@ namespace Doctrine\Common\Collections;
 use ArrayIterator;
 use Closure;
 use Doctrine\Common\Collections\Expr\ClosureExpressionVisitor;
+use Traversable;
 use const ARRAY_FILTER_USE_BOTH;
 use function array_filter;
 use function array_key_exists;
@@ -64,7 +65,7 @@ class ArrayCollection implements Collection, Selectable
     /**
      * {@inheritDoc}
      */
-    public function toArray(): array
+    public function toArray() : array
     {
         return $this->elements;
     }
@@ -145,7 +146,7 @@ class ArrayCollection implements Collection, Selectable
     /**
      * {@inheritDoc}
      */
-    public function removeElement($element): bool
+    public function removeElement($element) : bool
     {
         $key = array_search($element, $this->elements, true);
 
@@ -163,7 +164,7 @@ class ArrayCollection implements Collection, Selectable
      *
      * {@inheritDoc}
      */
-    public function offsetExists($offset): bool
+    public function offsetExists($offset) : bool
     {
         return $this->containsKey($offset);
     }
@@ -183,7 +184,7 @@ class ArrayCollection implements Collection, Selectable
      *
      * {@inheritDoc}
      */
-    public function offsetSet($offset, $value): void
+    public function offsetSet($offset, $value) : void
     {
         if (! isset($offset)) {
             $this->add($value);
@@ -199,7 +200,7 @@ class ArrayCollection implements Collection, Selectable
      *
      * {@inheritDoc}
      */
-    public function offsetUnset($offset): void
+    public function offsetUnset($offset) : void
     {
         $this->remove($offset);
     }
@@ -207,7 +208,7 @@ class ArrayCollection implements Collection, Selectable
     /**
      * {@inheritDoc}
      */
-    public function containsKey($key): bool
+    public function containsKey($key) : bool
     {
         return isset($this->elements[$key]) || array_key_exists($key, $this->elements);
     }
@@ -215,7 +216,7 @@ class ArrayCollection implements Collection, Selectable
     /**
      * {@inheritDoc}
      */
-    public function contains($element): bool
+    public function contains($element) : bool
     {
         return in_array($element, $this->elements, true);
     }
@@ -223,7 +224,7 @@ class ArrayCollection implements Collection, Selectable
     /**
      * {@inheritDoc}
      */
-    public function exists(Closure $p): bool
+    public function exists(Closure $p) : bool
     {
         foreach ($this->elements as $key => $element) {
             if ($p($key, $element)) {
@@ -253,7 +254,7 @@ class ArrayCollection implements Collection, Selectable
     /**
      * {@inheritDoc}
      */
-    public function getKeys(): array
+    public function getKeys() : array
     {
         return array_keys($this->elements);
     }
@@ -261,7 +262,7 @@ class ArrayCollection implements Collection, Selectable
     /**
      * {@inheritDoc}
      */
-    public function getValues(): array
+    public function getValues() : array
     {
         return array_values($this->elements);
     }
@@ -269,7 +270,7 @@ class ArrayCollection implements Collection, Selectable
     /**
      * {@inheritDoc}
      */
-    public function count(): int
+    public function count() : int
     {
         return count($this->elements);
     }
@@ -277,7 +278,7 @@ class ArrayCollection implements Collection, Selectable
     /**
      * {@inheritDoc}
      */
-    public function set($key, $value): void
+    public function set($key, $value) : void
     {
         $this->elements[$key] = $value;
     }
@@ -285,7 +286,7 @@ class ArrayCollection implements Collection, Selectable
     /**
      * {@inheritDoc}
      */
-    public function add($element): bool
+    public function add($element) : bool
     {
         $this->elements[] = $element;
 
@@ -295,7 +296,7 @@ class ArrayCollection implements Collection, Selectable
     /**
      * {@inheritDoc}
      */
-    public function isEmpty(): bool
+    public function isEmpty() : bool
     {
         return empty($this->elements);
     }
@@ -305,7 +306,7 @@ class ArrayCollection implements Collection, Selectable
      *
      * {@inheritDoc}
      */
-    public function getIterator(): \Traversable
+    public function getIterator() : Traversable
     {
         return new ArrayIterator($this->elements);
     }
@@ -315,7 +316,7 @@ class ArrayCollection implements Collection, Selectable
      *
      * @return static
      */
-    public function map(Closure $func): Collection
+    public function map(Closure $func) : Collection
     {
         return $this->createFrom(array_map($func, $this->elements));
     }
@@ -327,7 +328,7 @@ class ArrayCollection implements Collection, Selectable
      *
      * @psalm-return ArrayCollection<TKey,T>
      */
-    public function filter(Closure $p): Collection
+    public function filter(Closure $p) : Collection
     {
         return $this->createFrom(array_filter($this->elements, $p, ARRAY_FILTER_USE_BOTH));
     }
@@ -335,7 +336,7 @@ class ArrayCollection implements Collection, Selectable
     /**
      * {@inheritDoc}
      */
-    public function forAll(Closure $p): bool
+    public function forAll(Closure $p) : bool
     {
         foreach ($this->elements as $key => $element) {
             if (! $p($key, $element)) {
@@ -349,7 +350,7 @@ class ArrayCollection implements Collection, Selectable
     /**
      * {@inheritDoc}
      */
-    public function partition(Closure $p): array
+    public function partition(Closure $p) : array
     {
         $matches = $noMatches = [];
 
@@ -366,10 +367,8 @@ class ArrayCollection implements Collection, Selectable
 
     /**
      * Returns a string representation of this object.
-     *
-     * @return string
      */
-    public function __toString(): string
+    public function __toString() : string
     {
         return self::class . '@' . spl_object_hash($this);
     }
@@ -377,7 +376,7 @@ class ArrayCollection implements Collection, Selectable
     /**
      * {@inheritDoc}
      */
-    public function clear(): void
+    public function clear() : void
     {
         $this->elements = [];
     }
@@ -385,7 +384,7 @@ class ArrayCollection implements Collection, Selectable
     /**
      * {@inheritDoc}
      */
-    public function slice(int $offset, ?int $length = null): array
+    public function slice(int $offset, ?int $length = null) : array
     {
         return array_slice($this->elements, $offset, $length, true);
     }
@@ -393,7 +392,7 @@ class ArrayCollection implements Collection, Selectable
     /**
      * {@inheritDoc}
      */
-    public function matching(Criteria $criteria): Collection
+    public function matching(Criteria $criteria) : Collection
     {
         $expr     = $criteria->getWhereExpression();
         $filtered = $this->elements;

--- a/lib/Doctrine/Common/Collections/ArrayCollection.php
+++ b/lib/Doctrine/Common/Collections/ArrayCollection.php
@@ -411,7 +411,9 @@ class ArrayCollection implements Collection, Selectable
                 $next = ClosureExpressionVisitor::sortByField($field, $ordering === Criteria::DESC ? -1 : 1, $next);
             }
 
-            uasort($filtered, $next);
+            if ($next instanceof Closure) {
+                uasort($filtered, $next);
+            }
         }
 
         $offset = $criteria->getFirstResult();

--- a/lib/Doctrine/Common/Collections/ArrayCollection.php
+++ b/lib/Doctrine/Common/Collections/ArrayCollection.php
@@ -64,7 +64,7 @@ class ArrayCollection implements Collection, Selectable
     /**
      * {@inheritDoc}
      */
-    public function toArray()
+    public function toArray(): array
     {
         return $this->elements;
     }
@@ -145,7 +145,7 @@ class ArrayCollection implements Collection, Selectable
     /**
      * {@inheritDoc}
      */
-    public function removeElement($element)
+    public function removeElement($element): bool
     {
         $key = array_search($element, $this->elements, true);
 
@@ -163,7 +163,7 @@ class ArrayCollection implements Collection, Selectable
      *
      * {@inheritDoc}
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return $this->containsKey($offset);
     }
@@ -183,7 +183,7 @@ class ArrayCollection implements Collection, Selectable
      *
      * {@inheritDoc}
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (! isset($offset)) {
             $this->add($value);
@@ -199,7 +199,7 @@ class ArrayCollection implements Collection, Selectable
      *
      * {@inheritDoc}
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         $this->remove($offset);
     }
@@ -207,7 +207,7 @@ class ArrayCollection implements Collection, Selectable
     /**
      * {@inheritDoc}
      */
-    public function containsKey($key)
+    public function containsKey($key): bool
     {
         return isset($this->elements[$key]) || array_key_exists($key, $this->elements);
     }
@@ -215,7 +215,7 @@ class ArrayCollection implements Collection, Selectable
     /**
      * {@inheritDoc}
      */
-    public function contains($element)
+    public function contains($element): bool
     {
         return in_array($element, $this->elements, true);
     }
@@ -223,7 +223,7 @@ class ArrayCollection implements Collection, Selectable
     /**
      * {@inheritDoc}
      */
-    public function exists(Closure $p)
+    public function exists(Closure $p): bool
     {
         foreach ($this->elements as $key => $element) {
             if ($p($key, $element)) {
@@ -253,7 +253,7 @@ class ArrayCollection implements Collection, Selectable
     /**
      * {@inheritDoc}
      */
-    public function getKeys()
+    public function getKeys(): array
     {
         return array_keys($this->elements);
     }
@@ -261,7 +261,7 @@ class ArrayCollection implements Collection, Selectable
     /**
      * {@inheritDoc}
      */
-    public function getValues()
+    public function getValues(): array
     {
         return array_values($this->elements);
     }
@@ -269,7 +269,7 @@ class ArrayCollection implements Collection, Selectable
     /**
      * {@inheritDoc}
      */
-    public function count()
+    public function count(): int
     {
         return count($this->elements);
     }
@@ -277,7 +277,7 @@ class ArrayCollection implements Collection, Selectable
     /**
      * {@inheritDoc}
      */
-    public function set($key, $value)
+    public function set($key, $value): void
     {
         $this->elements[$key] = $value;
     }
@@ -285,7 +285,7 @@ class ArrayCollection implements Collection, Selectable
     /**
      * {@inheritDoc}
      */
-    public function add($element)
+    public function add($element): bool
     {
         $this->elements[] = $element;
 
@@ -295,7 +295,7 @@ class ArrayCollection implements Collection, Selectable
     /**
      * {@inheritDoc}
      */
-    public function isEmpty()
+    public function isEmpty(): bool
     {
         return empty($this->elements);
     }
@@ -305,7 +305,7 @@ class ArrayCollection implements Collection, Selectable
      *
      * {@inheritDoc}
      */
-    public function getIterator()
+    public function getIterator(): \Traversable
     {
         return new ArrayIterator($this->elements);
     }
@@ -315,7 +315,7 @@ class ArrayCollection implements Collection, Selectable
      *
      * @return static
      */
-    public function map(Closure $func)
+    public function map(Closure $func): Collection
     {
         return $this->createFrom(array_map($func, $this->elements));
     }
@@ -327,7 +327,7 @@ class ArrayCollection implements Collection, Selectable
      *
      * @psalm-return ArrayCollection<TKey,T>
      */
-    public function filter(Closure $p)
+    public function filter(Closure $p): Collection
     {
         return $this->createFrom(array_filter($this->elements, $p, ARRAY_FILTER_USE_BOTH));
     }
@@ -335,7 +335,7 @@ class ArrayCollection implements Collection, Selectable
     /**
      * {@inheritDoc}
      */
-    public function forAll(Closure $p)
+    public function forAll(Closure $p): bool
     {
         foreach ($this->elements as $key => $element) {
             if (! $p($key, $element)) {
@@ -349,7 +349,7 @@ class ArrayCollection implements Collection, Selectable
     /**
      * {@inheritDoc}
      */
-    public function partition(Closure $p)
+    public function partition(Closure $p): array
     {
         $matches = $noMatches = [];
 
@@ -369,7 +369,7 @@ class ArrayCollection implements Collection, Selectable
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return self::class . '@' . spl_object_hash($this);
     }
@@ -377,7 +377,7 @@ class ArrayCollection implements Collection, Selectable
     /**
      * {@inheritDoc}
      */
-    public function clear()
+    public function clear(): void
     {
         $this->elements = [];
     }
@@ -385,7 +385,7 @@ class ArrayCollection implements Collection, Selectable
     /**
      * {@inheritDoc}
      */
-    public function slice($offset, $length = null)
+    public function slice(int $offset, ?int $length = null): array
     {
         return array_slice($this->elements, $offset, $length, true);
     }
@@ -393,7 +393,7 @@ class ArrayCollection implements Collection, Selectable
     /**
      * {@inheritDoc}
      */
-    public function matching(Criteria $criteria)
+    public function matching(Criteria $criteria): Collection
     {
         $expr     = $criteria->getWhereExpression();
         $filtered = $this->elements;

--- a/lib/Doctrine/Common/Collections/ArrayCollection.php
+++ b/lib/Doctrine/Common/Collections/ArrayCollection.php
@@ -17,6 +17,7 @@ use function array_reverse;
 use function array_search;
 use function array_slice;
 use function array_values;
+use function assert;
 use function count;
 use function current;
 use function end;
@@ -163,6 +164,8 @@ class ArrayCollection implements Collection, Selectable
      * Required by interface ArrayAccess.
      *
      * {@inheritDoc}
+     *
+     * @param int|string $offset
      */
     public function offsetExists($offset) : bool
     {
@@ -172,7 +175,9 @@ class ArrayCollection implements Collection, Selectable
     /**
      * Required by interface ArrayAccess.
      *
-     * {@inheritDoc}
+     * @param int|string $offset
+     *
+     * @return mixed
      */
     public function offsetGet($offset)
     {
@@ -182,11 +187,12 @@ class ArrayCollection implements Collection, Selectable
     /**
      * Required by interface ArrayAccess.
      *
-     * {@inheritDoc}
+     * @param int|string|null $offset
+     * @param mixed           $value
      */
     public function offsetSet($offset, $value) : void
     {
-        if (! isset($offset)) {
+        if ($offset === null) {
             $this->add($value);
 
             return;
@@ -198,7 +204,7 @@ class ArrayCollection implements Collection, Selectable
     /**
      * Required by interface ArrayAccess.
      *
-     * {@inheritDoc}
+     * @param int|string $offset
      */
     public function offsetUnset($offset) : void
     {
@@ -305,6 +311,8 @@ class ArrayCollection implements Collection, Selectable
      * Required by interface IteratorAggregate.
      *
      * {@inheritDoc}
+     *
+     * @psalm-return Traversable<TKey, T>
      */
     public function getIterator() : Traversable
     {
@@ -411,9 +419,9 @@ class ArrayCollection implements Collection, Selectable
                 $next = ClosureExpressionVisitor::sortByField($field, $ordering === Criteria::DESC ? -1 : 1, $next);
             }
 
-            if ($next instanceof Closure) {
-                uasort($filtered, $next);
-            }
+            assert($next instanceof Closure);
+
+            uasort($filtered, $next);
         }
 
         $offset = $criteria->getFirstResult();

--- a/lib/Doctrine/Common/Collections/Collection.php
+++ b/lib/Doctrine/Common/Collections/Collection.php
@@ -119,8 +119,8 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
     /**
      * Gets all keys/indices of the collection.
      *
-     * @return int[]|string[] The keys/indices of the collection, in the order of the corresponding
-     *               elements in the collection.
+     * @return array<int, int|string> The keys/indices of the collection, in the order of the corresponding
+     *                                elements in the collection.
      *
      * @psalm-return TKey[]
      */
@@ -254,9 +254,9 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      *
      * @param Closure $p The predicate on which to partition.
      *
-     * @return Collection[] An array with two elements. The first element contains the collection
-     *                      of elements where the predicate returned TRUE, the second element
-     *                      contains the collection of elements where the predicate returned FALSE.
+     * @return array<int, Collection> An array with two elements. The first element contains the collection
+     *                                of elements where the predicate returned TRUE, the second element
+     *                                contains the collection of elements where the predicate returned FALSE.
      *
      * @psalm-param Closure(TKey=, T=):bool $p
      * @psalm-return array{0: Collection<TKey, T>, 1: Collection<TKey, T>}

--- a/lib/Doctrine/Common/Collections/Collection.php
+++ b/lib/Doctrine/Common/Collections/Collection.php
@@ -8,6 +8,7 @@ use ArrayAccess;
 use Closure;
 use Countable;
 use IteratorAggregate;
+use Traversable;
 
 /**
  * The missing (SPL) Collection/Array/OrderedMap interface.
@@ -42,14 +43,12 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      *
      * @psalm-param T $element
      */
-    public function add($element): bool;
+    public function add($element) : bool;
 
     /**
      * Clears the collection, removing all elements.
-     *
-     * @return void
      */
-    public function clear(): void;
+    public function clear() : void;
 
     /**
      * Checks whether an element is contained in the collection.
@@ -61,14 +60,14 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      *
      * @psalm-param T $element
      */
-    public function contains($element): bool;
+    public function contains($element) : bool;
 
     /**
      * Checks whether the collection is empty (contains no elements).
      *
      * @return bool TRUE if the collection is empty, FALSE otherwise.
      */
-    public function isEmpty(): bool;
+    public function isEmpty() : bool;
 
     /**
      * Removes the element at the specified index from the collection.
@@ -91,7 +90,7 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      *
      * @psalm-param T $element
      */
-    public function removeElement($element): bool;
+    public function removeElement($element) : bool;
 
     /**
      * Checks whether the collection contains an element with the specified key/index.
@@ -103,7 +102,7 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      *
      * @psalm-param TKey $key
      */
-    public function containsKey($key): bool;
+    public function containsKey($key) : bool;
 
     /**
      * Gets the element at the specified key/index.
@@ -125,7 +124,7 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      *
      * @psalm-return TKey[]
      */
-    public function getKeys(): array;
+    public function getKeys() : array;
 
     /**
      * Gets all values of the collection.
@@ -135,7 +134,7 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      *
      * @psalm-return T[]
      */
-    public function getValues(): array;
+    public function getValues() : array;
 
     /**
      * Sets an element in the collection at the specified key/index.
@@ -143,12 +142,10 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      * @param string|int $key   The key/index of the element to set.
      * @param mixed      $value The element to set.
      *
-     * @return void
-     *
      * @psalm-param TKey $key
      * @psalm-param T $value
      */
-    public function set($key, $value): void;
+    public function set($key, $value) : void;
 
     /**
      * Gets a native PHP array representation of the collection.
@@ -157,7 +154,7 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      *
      * @psalm-return array<TKey,T>
      */
-    public function toArray(): array;
+    public function toArray() : array;
 
     /**
      * Sets the internal iterator to the first element in the collection and returns this element.
@@ -213,7 +210,7 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      *
      * @psalm-param Closure(TKey=, T=):bool $p
      */
-    public function exists(Closure $p): bool;
+    public function exists(Closure $p) : bool;
 
     /**
      * Returns all the elements of this collection that satisfy the predicate p.
@@ -226,7 +223,7 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      * @psalm-param Closure(T=, TKey=):bool $p
      * @psalm-return Collection<TKey, T>
      */
-    public function filter(Closure $p): self;
+    public function filter(Closure $p) : self;
 
     /**
      * Tests whether the given predicate p holds for all elements of this collection.
@@ -237,7 +234,7 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      *
      * @psalm-param Closure(TKey=, T=):bool $p
      */
-    public function forAll(Closure $p): bool;
+    public function forAll(Closure $p) : bool;
 
     /**
      * Applies the given function to each element in the collection and returns
@@ -249,7 +246,7 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      * @psalm-param Closure(T=):U $func
      * @psalm-return Collection<TKey, U>
      */
-    public function map(Closure $func): self;
+    public function map(Closure $func) : self;
 
     /**
      * Partitions this collection in two collections according to a predicate.
@@ -264,7 +261,7 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      * @psalm-param Closure(TKey=, T=):bool $p
      * @psalm-return array{0: Collection<TKey, T>, 1: Collection<TKey, T>}
      */
-    public function partition(Closure $p): array;
+    public function partition(Closure $p) : array;
 
     /**
      * Gets the index/key of a given element. The comparison of two elements is strict,
@@ -294,17 +291,17 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      *
      * @psalm-return array<TKey,T>
      */
-    public function slice(int $offset, ?int $length = null): array;
+    public function slice(int $offset, ?int $length = null) : array;
 
     /**
      * {@inheritdoc}
      */
-    public function count(): int;
+    public function count() : int;
 
     /**
      * {@inheritdoc}
      */
-    public function getIterator(): \Traversable;
+    public function getIterator() : Traversable;
 
     /**
      * {@inheritdoc}
@@ -314,15 +311,15 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
     /**
      * {@inheritdoc}
      */
-    public function offsetSet($offset, $value): void;
+    public function offsetSet($offset, $value) : void;
 
     /**
      * {@inheritdoc}
      */
-    public function offsetUnset($offset): void;
+    public function offsetUnset($offset) : void;
 
     /**
      * {@inheritdoc}
      */
-    public function offsetExists($offset): bool;
+    public function offsetExists($offset) : bool;
 }

--- a/lib/Doctrine/Common/Collections/Collection.php
+++ b/lib/Doctrine/Common/Collections/Collection.php
@@ -293,33 +293,30 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      */
     public function slice(int $offset, ?int $length = null) : array;
 
-    /**
-     * {@inheritdoc}
-     */
     public function count() : int;
 
-    /**
-     * {@inheritdoc}
-     */
     public function getIterator() : Traversable;
 
     /**
-     * {@inheritdoc}
+     * @param int|string $offset
+     *
+     * @return mixed
      */
     public function offsetGet($offset);
 
     /**
-     * {@inheritdoc}
+     * @param int|string $offset
+     * @param mixed      $value
      */
     public function offsetSet($offset, $value) : void;
 
     /**
-     * {@inheritdoc}
+     * @param int|string $offset
      */
     public function offsetUnset($offset) : void;
 
     /**
-     * {@inheritdoc}
+     * @param int|string $offset
      */
     public function offsetExists($offset) : bool;
 }

--- a/lib/Doctrine/Common/Collections/Collection.php
+++ b/lib/Doctrine/Common/Collections/Collection.php
@@ -42,14 +42,14 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      *
      * @psalm-param T $element
      */
-    public function add($element);
+    public function add($element): bool;
 
     /**
      * Clears the collection, removing all elements.
      *
      * @return void
      */
-    public function clear();
+    public function clear(): void;
 
     /**
      * Checks whether an element is contained in the collection.
@@ -61,14 +61,14 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      *
      * @psalm-param T $element
      */
-    public function contains($element);
+    public function contains($element): bool;
 
     /**
      * Checks whether the collection is empty (contains no elements).
      *
      * @return bool TRUE if the collection is empty, FALSE otherwise.
      */
-    public function isEmpty();
+    public function isEmpty(): bool;
 
     /**
      * Removes the element at the specified index from the collection.
@@ -91,7 +91,7 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      *
      * @psalm-param T $element
      */
-    public function removeElement($element);
+    public function removeElement($element): bool;
 
     /**
      * Checks whether the collection contains an element with the specified key/index.
@@ -103,7 +103,7 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      *
      * @psalm-param TKey $key
      */
-    public function containsKey($key);
+    public function containsKey($key): bool;
 
     /**
      * Gets the element at the specified key/index.
@@ -125,7 +125,7 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      *
      * @psalm-return TKey[]
      */
-    public function getKeys();
+    public function getKeys(): array;
 
     /**
      * Gets all values of the collection.
@@ -135,7 +135,7 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      *
      * @psalm-return T[]
      */
-    public function getValues();
+    public function getValues(): array;
 
     /**
      * Sets an element in the collection at the specified key/index.
@@ -148,7 +148,7 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      * @psalm-param TKey $key
      * @psalm-param T $value
      */
-    public function set($key, $value);
+    public function set($key, $value): void;
 
     /**
      * Gets a native PHP array representation of the collection.
@@ -157,7 +157,7 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      *
      * @psalm-return array<TKey,T>
      */
-    public function toArray();
+    public function toArray(): array;
 
     /**
      * Sets the internal iterator to the first element in the collection and returns this element.
@@ -213,7 +213,7 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      *
      * @psalm-param Closure(TKey=, T=):bool $p
      */
-    public function exists(Closure $p);
+    public function exists(Closure $p): bool;
 
     /**
      * Returns all the elements of this collection that satisfy the predicate p.
@@ -226,7 +226,7 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      * @psalm-param Closure(T=, TKey=):bool $p
      * @psalm-return Collection<TKey, T>
      */
-    public function filter(Closure $p);
+    public function filter(Closure $p): self;
 
     /**
      * Tests whether the given predicate p holds for all elements of this collection.
@@ -237,7 +237,7 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      *
      * @psalm-param Closure(TKey=, T=):bool $p
      */
-    public function forAll(Closure $p);
+    public function forAll(Closure $p): bool;
 
     /**
      * Applies the given function to each element in the collection and returns
@@ -249,7 +249,7 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      * @psalm-param Closure(T=):U $func
      * @psalm-return Collection<TKey, U>
      */
-    public function map(Closure $func);
+    public function map(Closure $func): self;
 
     /**
      * Partitions this collection in two collections according to a predicate.
@@ -264,7 +264,7 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      * @psalm-param Closure(TKey=, T=):bool $p
      * @psalm-return array{0: Collection<TKey, T>, 1: Collection<TKey, T>}
      */
-    public function partition(Closure $p);
+    public function partition(Closure $p): array;
 
     /**
      * Gets the index/key of a given element. The comparison of two elements is strict,
@@ -294,5 +294,35 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      *
      * @psalm-return array<TKey,T>
      */
-    public function slice($offset, $length = null);
+    public function slice(int $offset, ?int $length = null): array;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function count(): int;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIterator(): \Traversable;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function offsetGet($offset);
+
+    /**
+     * {@inheritdoc}
+     */
+    public function offsetSet($offset, $value): void;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function offsetUnset($offset): void;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function offsetExists($offset): bool;
 }

--- a/lib/Doctrine/Common/Collections/Collection.php
+++ b/lib/Doctrine/Common/Collections/Collection.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Common\Collections;
 
 use ArrayAccess;

--- a/lib/Doctrine/Common/Collections/Collection.php
+++ b/lib/Doctrine/Common/Collections/Collection.php
@@ -8,7 +8,6 @@ use ArrayAccess;
 use Closure;
 use Countable;
 use IteratorAggregate;
-use Traversable;
 
 /**
  * The missing (SPL) Collection/Array/OrderedMap interface.
@@ -292,31 +291,4 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      * @psalm-return array<TKey,T>
      */
     public function slice(int $offset, ?int $length = null) : array;
-
-    public function count() : int;
-
-    public function getIterator() : Traversable;
-
-    /**
-     * @param int|string $offset
-     *
-     * @return mixed
-     */
-    public function offsetGet($offset);
-
-    /**
-     * @param int|string $offset
-     * @param mixed      $value
-     */
-    public function offsetSet($offset, $value) : void;
-
-    /**
-     * @param int|string $offset
-     */
-    public function offsetUnset($offset) : void;
-
-    /**
-     * @param int|string $offset
-     */
-    public function offsetExists($offset) : bool;
 }

--- a/lib/Doctrine/Common/Collections/Criteria.php
+++ b/lib/Doctrine/Common/Collections/Criteria.php
@@ -38,7 +38,7 @@ class Criteria
      *
      * @return Criteria
      */
-    public static function create()
+    public static function create(): self
     {
         return new static();
     }
@@ -48,7 +48,7 @@ class Criteria
      *
      * @return ExpressionBuilder
      */
-    public static function expr()
+    public static function expr(): ExpressionBuilder
     {
         if (self::$expressionBuilder === null) {
             self::$expressionBuilder = new ExpressionBuilder();
@@ -64,7 +64,7 @@ class Criteria
      * @param int|null      $firstResult
      * @param int|null      $maxResults
      */
-    public function __construct(?Expression $expression = null, ?array $orderings = null, $firstResult = null, $maxResults = null)
+    public function __construct(?Expression $expression = null, ?array $orderings = null, ?int $firstResult = null, ?int $maxResults = null)
     {
         $this->expression = $expression;
 
@@ -83,7 +83,7 @@ class Criteria
      *
      * @return Criteria
      */
-    public function where(Expression $expression)
+    public function where(Expression $expression): self
     {
         $this->expression = $expression;
 
@@ -96,7 +96,7 @@ class Criteria
      *
      * @return Criteria
      */
-    public function andWhere(Expression $expression)
+    public function andWhere(Expression $expression): self
     {
         if ($this->expression === null) {
             return $this->where($expression);
@@ -116,7 +116,7 @@ class Criteria
      *
      * @return Criteria
      */
-    public function orWhere(Expression $expression)
+    public function orWhere(Expression $expression): self
     {
         if ($this->expression === null) {
             return $this->where($expression);
@@ -135,7 +135,7 @@ class Criteria
      *
      * @return Expression|null
      */
-    public function getWhereExpression()
+    public function getWhereExpression(): ?Expression
     {
         return $this->expression;
     }
@@ -145,7 +145,7 @@ class Criteria
      *
      * @return string[]
      */
-    public function getOrderings()
+    public function getOrderings(): array
     {
         return $this->orderings;
     }
@@ -162,7 +162,7 @@ class Criteria
      *
      * @return Criteria
      */
-    public function orderBy(array $orderings)
+    public function orderBy(array $orderings): self
     {
         $this->orderings = array_map(
             static function (string $ordering) : string {
@@ -179,7 +179,7 @@ class Criteria
      *
      * @return int|null
      */
-    public function getFirstResult()
+    public function getFirstResult(): ?int
     {
         return $this->firstResult;
     }
@@ -191,7 +191,7 @@ class Criteria
      *
      * @return Criteria
      */
-    public function setFirstResult($firstResult)
+    public function setFirstResult(?int $firstResult): self
     {
         $this->firstResult = $firstResult === null ? null : (int) $firstResult;
 
@@ -203,7 +203,7 @@ class Criteria
      *
      * @return int|null
      */
-    public function getMaxResults()
+    public function getMaxResults(): ?int
     {
         return $this->maxResults;
     }
@@ -215,7 +215,7 @@ class Criteria
      *
      * @return Criteria
      */
-    public function setMaxResults($maxResults)
+    public function setMaxResults(?int $maxResults): self
     {
         $this->maxResults = $maxResults === null ? null : (int) $maxResults;
 

--- a/lib/Doctrine/Common/Collections/Criteria.php
+++ b/lib/Doctrine/Common/Collections/Criteria.php
@@ -37,17 +37,15 @@ class Criteria
      *
      * @return Criteria
      */
-    public static function create(): self
+    public static function create() : self
     {
         return new static();
     }
 
     /**
      * Returns the expression builder.
-     *
-     * @return ExpressionBuilder
      */
-    public static function expr(): ExpressionBuilder
+    public static function expr() : ExpressionBuilder
     {
         if (self::$expressionBuilder === null) {
             self::$expressionBuilder = new ExpressionBuilder();
@@ -60,8 +58,6 @@ class Criteria
      * Construct a new Criteria.
      *
      * @param string[]|null $orderings
-     * @param int|null      $firstResult
-     * @param int|null      $maxResults
      */
     public function __construct(?Expression $expression = null, ?array $orderings = null, ?int $firstResult = null, ?int $maxResults = null)
     {
@@ -82,7 +78,7 @@ class Criteria
      *
      * @return Criteria
      */
-    public function where(Expression $expression): self
+    public function where(Expression $expression) : self
     {
         $this->expression = $expression;
 
@@ -95,7 +91,7 @@ class Criteria
      *
      * @return Criteria
      */
-    public function andWhere(Expression $expression): self
+    public function andWhere(Expression $expression) : self
     {
         if ($this->expression === null) {
             return $this->where($expression);
@@ -115,7 +111,7 @@ class Criteria
      *
      * @return Criteria
      */
-    public function orWhere(Expression $expression): self
+    public function orWhere(Expression $expression) : self
     {
         if ($this->expression === null) {
             return $this->where($expression);
@@ -131,10 +127,8 @@ class Criteria
 
     /**
      * Gets the expression attached to this Criteria.
-     *
-     * @return Expression|null
      */
-    public function getWhereExpression(): ?Expression
+    public function getWhereExpression() : ?Expression
     {
         return $this->expression;
     }
@@ -144,7 +138,7 @@ class Criteria
      *
      * @return string[]
      */
-    public function getOrderings(): array
+    public function getOrderings() : array
     {
         return $this->orderings;
     }
@@ -161,7 +155,7 @@ class Criteria
      *
      * @return Criteria
      */
-    public function orderBy(array $orderings): self
+    public function orderBy(array $orderings) : self
     {
         $this->orderings = array_map(
             static function (string $ordering) : string {
@@ -175,10 +169,8 @@ class Criteria
 
     /**
      * Gets the current first result option of this Criteria.
-     *
-     * @return int|null
      */
-    public function getFirstResult(): ?int
+    public function getFirstResult() : ?int
     {
         return $this->firstResult;
     }
@@ -190,7 +182,7 @@ class Criteria
      *
      * @return Criteria
      */
-    public function setFirstResult(?int $firstResult): self
+    public function setFirstResult(?int $firstResult) : self
     {
         $this->firstResult = $firstResult === null ? null : (int) $firstResult;
 
@@ -199,10 +191,8 @@ class Criteria
 
     /**
      * Gets maxResults.
-     *
-     * @return int|null
      */
-    public function getMaxResults(): ?int
+    public function getMaxResults() : ?int
     {
         return $this->maxResults;
     }
@@ -214,7 +204,7 @@ class Criteria
      *
      * @return Criteria
      */
-    public function setMaxResults(?int $maxResults): self
+    public function setMaxResults(?int $maxResults) : self
     {
         $this->maxResults = $maxResults === null ? null : (int) $maxResults;
 

--- a/lib/Doctrine/Common/Collections/Criteria.php
+++ b/lib/Doctrine/Common/Collections/Criteria.php
@@ -23,7 +23,7 @@ class Criteria
     /** @var Expression|null */
     private $expression;
 
-    /** @var string[] */
+    /** @var array<string, string> */
     private $orderings = [];
 
     /** @var int|null */
@@ -57,7 +57,7 @@ class Criteria
     /**
      * Construct a new Criteria.
      *
-     * @param string[]|null $orderings
+     * @param array<string, string>|null $orderings
      */
     public function __construct(?Expression $expression = null, ?array $orderings = null, ?int $firstResult = null, ?int $maxResults = null)
     {
@@ -136,7 +136,7 @@ class Criteria
     /**
      * Gets the current orderings of this Criteria.
      *
-     * @return string[]
+     * @return array<string, string>
      */
     public function getOrderings() : array
     {

--- a/lib/Doctrine/Common/Collections/Criteria.php
+++ b/lib/Doctrine/Common/Collections/Criteria.php
@@ -14,8 +14,7 @@ use function strtoupper;
  */
 class Criteria
 {
-    public const ASC = 'ASC';
-
+    public const ASC  = 'ASC';
     public const DESC = 'DESC';
 
     /** @var ExpressionBuilder|null */

--- a/lib/Doctrine/Common/Collections/Criteria.php
+++ b/lib/Doctrine/Common/Collections/Criteria.php
@@ -184,7 +184,7 @@ class Criteria
      */
     public function setFirstResult(?int $firstResult) : self
     {
-        $this->firstResult = $firstResult === null ? null : (int) $firstResult;
+        $this->firstResult = $firstResult;
 
         return $this;
     }
@@ -206,7 +206,7 @@ class Criteria
      */
     public function setMaxResults(?int $maxResults) : self
     {
-        $this->maxResults = $maxResults === null ? null : (int) $maxResults;
+        $this->maxResults = $maxResults;
 
         return $this;
     }

--- a/lib/Doctrine/Common/Collections/Criteria.php
+++ b/lib/Doctrine/Common/Collections/Criteria.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Common\Collections;
 
 use Doctrine\Common\Collections\Expr\CompositeExpression;

--- a/lib/Doctrine/Common/Collections/Criteria.php
+++ b/lib/Doctrine/Common/Collections/Criteria.php
@@ -151,7 +151,7 @@ class Criteria
      * @see Criteria::ASC
      * @see Criteria::DESC
      *
-     * @param string[] $orderings
+     * @param array<string, string> $orderings
      *
      * @return Criteria
      */

--- a/lib/Doctrine/Common/Collections/Expr/ClosureExpressionVisitor.php
+++ b/lib/Doctrine/Common/Collections/Expr/ClosureExpressionVisitor.php
@@ -32,7 +32,6 @@ class ClosureExpressionVisitor extends ExpressionVisitor
      * method, __get, __call).
      *
      * @param object|array $object
-     * @param string       $field
      *
      * @return mixed
      */
@@ -89,13 +88,8 @@ class ClosureExpressionVisitor extends ExpressionVisitor
 
     /**
      * Helper for sorting arrays of objects based on multiple fields + orientations.
-     *
-     * @param string $name
-     * @param int    $orientation
-     *
-     * @return Closure
      */
-    public static function sortByField(string $name, int $orientation = 1, ?\Closure $next = null): \Closure
+    public static function sortByField(string $name, int $orientation = 1, ?Closure $next = null) : Closure
     {
         if (! $next) {
             $next = static function () : int {

--- a/lib/Doctrine/Common/Collections/Expr/ClosureExpressionVisitor.php
+++ b/lib/Doctrine/Common/Collections/Expr/ClosureExpressionVisitor.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Common\Collections\Expr;
 
 use ArrayAccess;

--- a/lib/Doctrine/Common/Collections/Expr/ClosureExpressionVisitor.php
+++ b/lib/Doctrine/Common/Collections/Expr/ClosureExpressionVisitor.php
@@ -36,7 +36,7 @@ class ClosureExpressionVisitor extends ExpressionVisitor
      *
      * @return mixed
      */
-    public static function getObjectFieldValue($object, $field)
+    public static function getObjectFieldValue($object, string $field)
     {
         if (is_array($object)) {
             return $object[$field];
@@ -95,7 +95,7 @@ class ClosureExpressionVisitor extends ExpressionVisitor
      *
      * @return Closure
      */
-    public static function sortByField($name, $orientation = 1, ?Closure $next = null)
+    public static function sortByField(string $name, int $orientation = 1, ?\Closure $next = null): \Closure
     {
         if (! $next) {
             $next = static function () : int {

--- a/lib/Doctrine/Common/Collections/Expr/ClosureExpressionVisitor.php
+++ b/lib/Doctrine/Common/Collections/Expr/ClosureExpressionVisitor.php
@@ -123,47 +123,38 @@ class ClosureExpressionVisitor extends ExpressionVisitor
                 return static function ($object) use ($field, $value) : bool {
                     return ClosureExpressionVisitor::getObjectFieldValue($object, $field) === $value;
                 };
-
             case Comparison::NEQ:
                 return static function ($object) use ($field, $value) : bool {
                     return ClosureExpressionVisitor::getObjectFieldValue($object, $field) !== $value;
                 };
-
             case Comparison::LT:
                 return static function ($object) use ($field, $value) : bool {
                     return ClosureExpressionVisitor::getObjectFieldValue($object, $field) < $value;
                 };
-
             case Comparison::LTE:
                 return static function ($object) use ($field, $value) : bool {
                     return ClosureExpressionVisitor::getObjectFieldValue($object, $field) <= $value;
                 };
-
             case Comparison::GT:
                 return static function ($object) use ($field, $value) : bool {
                     return ClosureExpressionVisitor::getObjectFieldValue($object, $field) > $value;
                 };
-
             case Comparison::GTE:
                 return static function ($object) use ($field, $value) : bool {
                     return ClosureExpressionVisitor::getObjectFieldValue($object, $field) >= $value;
                 };
-
             case Comparison::IN:
                 return static function ($object) use ($field, $value) : bool {
                     return in_array(ClosureExpressionVisitor::getObjectFieldValue($object, $field), $value, true);
                 };
-
             case Comparison::NIN:
                 return static function ($object) use ($field, $value) : bool {
                     return ! in_array(ClosureExpressionVisitor::getObjectFieldValue($object, $field), $value, true);
                 };
-
             case Comparison::CONTAINS:
                 return static function ($object) use ($field, $value) {
                     return strpos(ClosureExpressionVisitor::getObjectFieldValue($object, $field), $value) !== false;
                 };
-
             case Comparison::MEMBER_OF:
                 return static function ($object) use ($field, $value) : bool {
                     $fieldValues = ClosureExpressionVisitor::getObjectFieldValue($object, $field);
@@ -174,17 +165,14 @@ class ClosureExpressionVisitor extends ExpressionVisitor
 
                     return in_array($value, $fieldValues, true);
                 };
-
             case Comparison::STARTS_WITH:
                 return static function ($object) use ($field, $value) : bool {
                     return strpos(ClosureExpressionVisitor::getObjectFieldValue($object, $field), $value) === 0;
                 };
-
             case Comparison::ENDS_WITH:
                 return static function ($object) use ($field, $value) : bool {
                     return $value === substr(ClosureExpressionVisitor::getObjectFieldValue($object, $field), -strlen($value));
                 };
-
             default:
                 throw new RuntimeException('Unknown comparison operator: ' . $comparison->getOperator());
         }

--- a/lib/Doctrine/Common/Collections/Expr/Comparison.php
+++ b/lib/Doctrine/Common/Collections/Expr/Comparison.php
@@ -37,7 +37,7 @@ class Comparison implements Expression
      * @param string $operator
      * @param mixed  $value
      */
-    public function __construct($field, $operator, $value)
+    public function __construct(string $field, string $operator, $value)
     {
         if (! ($value instanceof Value)) {
             $value = new Value($value);
@@ -51,13 +51,13 @@ class Comparison implements Expression
     /**
      * @return string
      */
-    public function getField()
+    public function getField(): string
     {
         return $this->field;
     }
 
     /**
-     * @return Value
+     * @return mixed
      */
     public function getValue()
     {
@@ -67,7 +67,7 @@ class Comparison implements Expression
     /**
      * @return string
      */
-    public function getOperator()
+    public function getOperator(): string
     {
         return $this->op;
     }

--- a/lib/Doctrine/Common/Collections/Expr/Comparison.php
+++ b/lib/Doctrine/Common/Collections/Expr/Comparison.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Common\Collections\Expr;
 
 /**

--- a/lib/Doctrine/Common/Collections/Expr/Comparison.php
+++ b/lib/Doctrine/Common/Collections/Expr/Comparison.php
@@ -33,9 +33,7 @@ class Comparison implements Expression
     private $value;
 
     /**
-     * @param string $field
-     * @param string $operator
-     * @param mixed  $value
+     * @param mixed $value
      */
     public function __construct(string $field, string $operator, $value)
     {
@@ -48,10 +46,7 @@ class Comparison implements Expression
         $this->value = $value;
     }
 
-    /**
-     * @return string
-     */
-    public function getField(): string
+    public function getField() : string
     {
         return $this->field;
     }
@@ -64,10 +59,7 @@ class Comparison implements Expression
         return $this->value;
     }
 
-    /**
-     * @return string
-     */
-    public function getOperator(): string
+    public function getOperator() : string
     {
         return $this->op;
     }

--- a/lib/Doctrine/Common/Collections/Expr/Comparison.php
+++ b/lib/Doctrine/Common/Collections/Expr/Comparison.php
@@ -51,10 +51,7 @@ class Comparison implements Expression
         return $this->field;
     }
 
-    /**
-     * @return mixed
-     */
-    public function getValue()
+    public function getValue() : Value
     {
         return $this->value;
     }

--- a/lib/Doctrine/Common/Collections/Expr/CompositeExpression.php
+++ b/lib/Doctrine/Common/Collections/Expr/CompositeExpression.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Common\Collections\Expr;
 
 use RuntimeException;

--- a/lib/Doctrine/Common/Collections/Expr/CompositeExpression.php
+++ b/lib/Doctrine/Common/Collections/Expr/CompositeExpression.php
@@ -17,11 +17,11 @@ class CompositeExpression implements Expression
     /** @var string */
     private $type;
 
-    /** @var Expression[] */
+    /** @var array<int, Expression> */
     private $expressions = [];
 
     /**
-     * @param array $expressions
+     * @param array<int, Expression> $expressions
      *
      * @throws RuntimeException
      */
@@ -44,7 +44,7 @@ class CompositeExpression implements Expression
     /**
      * Returns the list of expressions nested in this composite.
      *
-     * @return Expression[]
+     * @return array<int, Expression>
      */
     public function getExpressionList() : array
     {

--- a/lib/Doctrine/Common/Collections/Expr/CompositeExpression.php
+++ b/lib/Doctrine/Common/Collections/Expr/CompositeExpression.php
@@ -21,8 +21,7 @@ class CompositeExpression implements Expression
     private $expressions = [];
 
     /**
-     * @param string $type
-     * @param array  $expressions
+     * @param array $expressions
      *
      * @throws RuntimeException
      */
@@ -47,15 +46,12 @@ class CompositeExpression implements Expression
      *
      * @return Expression[]
      */
-    public function getExpressionList(): array
+    public function getExpressionList() : array
     {
         return $this->expressions;
     }
 
-    /**
-     * @return string
-     */
-    public function getType(): string
+    public function getType() : string
     {
         return $this->type;
     }

--- a/lib/Doctrine/Common/Collections/Expr/CompositeExpression.php
+++ b/lib/Doctrine/Common/Collections/Expr/CompositeExpression.php
@@ -26,7 +26,7 @@ class CompositeExpression implements Expression
      *
      * @throws RuntimeException
      */
-    public function __construct($type, array $expressions)
+    public function __construct(string $type, array $expressions)
     {
         $this->type = $type;
 
@@ -47,7 +47,7 @@ class CompositeExpression implements Expression
      *
      * @return Expression[]
      */
-    public function getExpressionList()
+    public function getExpressionList(): array
     {
         return $this->expressions;
     }
@@ -55,7 +55,7 @@ class CompositeExpression implements Expression
     /**
      * @return string
      */
-    public function getType()
+    public function getType(): string
     {
         return $this->type;
     }

--- a/lib/Doctrine/Common/Collections/Expr/Expression.php
+++ b/lib/Doctrine/Common/Collections/Expr/Expression.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Common\Collections\Expr;
 
 /**

--- a/lib/Doctrine/Common/Collections/Expr/ExpressionVisitor.php
+++ b/lib/Doctrine/Common/Collections/Expr/ExpressionVisitor.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Common\Collections\Expr;
 
 use RuntimeException;

--- a/lib/Doctrine/Common/Collections/Expr/Value.php
+++ b/lib/Doctrine/Common/Collections/Expr/Value.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Common\Collections\Expr;
 
 class Value implements Expression

--- a/lib/Doctrine/Common/Collections/ExpressionBuilder.php
+++ b/lib/Doctrine/Common/Collections/ExpressionBuilder.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Common\Collections;
 
 use Doctrine\Common\Collections\Expr\Comparison;

--- a/lib/Doctrine/Common/Collections/ExpressionBuilder.php
+++ b/lib/Doctrine/Common/Collections/ExpressionBuilder.php
@@ -20,42 +20,32 @@ class ExpressionBuilder
 {
     /**
      * @param mixed $x
-     *
-     * @return CompositeExpression
      */
-    public function andX($x = null): CompositeExpression
+    public function andX($x = null) : CompositeExpression
     {
         return new CompositeExpression(CompositeExpression::TYPE_AND, func_get_args());
     }
 
     /**
      * @param mixed $x
-     *
-     * @return CompositeExpression
      */
-    public function orX($x = null): CompositeExpression
+    public function orX($x = null) : CompositeExpression
     {
         return new CompositeExpression(CompositeExpression::TYPE_OR, func_get_args());
     }
 
     /**
-     * @param string $field
-     * @param mixed  $value
-     *
-     * @return Comparison
+     * @param mixed $value
      */
-    public function eq(string $field, $value): Comparison
+    public function eq(string $field, $value) : Comparison
     {
         return new Comparison($field, Comparison::EQ, new Value($value));
     }
 
     /**
-     * @param string $field
-     * @param mixed  $value
-     *
-     * @return Comparison
+     * @param mixed $value
      */
-    public function gt(string $field, $value): Comparison
+    public function gt(string $field, $value) : Comparison
     {
         return new Comparison($field, Comparison::GT, new Value($value));
     }
@@ -72,110 +62,78 @@ class ExpressionBuilder
     }
 
     /**
-     * @param string $field
-     * @param mixed  $value
-     *
-     * @return Comparison
+     * @param mixed $value
      */
-    public function gte(string $field, $value): Comparison
+    public function gte(string $field, $value) : Comparison
     {
         return new Comparison($field, Comparison::GTE, new Value($value));
     }
 
     /**
-     * @param string $field
-     * @param mixed  $value
-     *
-     * @return Comparison
+     * @param mixed $value
      */
-    public function lte(string $field, $value): Comparison
+    public function lte(string $field, $value) : Comparison
     {
         return new Comparison($field, Comparison::LTE, new Value($value));
     }
 
     /**
-     * @param string $field
-     * @param mixed  $value
-     *
-     * @return Comparison
+     * @param mixed $value
      */
-    public function neq(string $field, $value): Comparison
+    public function neq(string $field, $value) : Comparison
     {
         return new Comparison($field, Comparison::NEQ, new Value($value));
     }
 
-    /**
-     * @param string $field
-     *
-     * @return Comparison
-     */
-    public function isNull(string $field): Comparison
+    public function isNull(string $field) : Comparison
     {
         return new Comparison($field, Comparison::EQ, new Value(null));
     }
 
     /**
-     * @param string $field
-     * @param array  $values
-     *
-     * @return Comparison
+     * @param array $values
      */
-    public function in(string $field, array $values): Comparison
+    public function in(string $field, array $values) : Comparison
     {
         return new Comparison($field, Comparison::IN, new Value($values));
     }
 
     /**
-     * @param string $field
-     * @param array  $values
-     *
-     * @return Comparison
+     * @param array $values
      */
-    public function notIn(string $field, array $values): Comparison
+    public function notIn(string $field, array $values) : Comparison
     {
         return new Comparison($field, Comparison::NIN, new Value($values));
     }
 
     /**
-     * @param string $field
-     * @param mixed  $value
-     *
-     * @return Comparison
+     * @param mixed $value
      */
-    public function contains(string $field, $value): Comparison
+    public function contains(string $field, $value) : Comparison
     {
         return new Comparison($field, Comparison::CONTAINS, new Value($value));
     }
 
     /**
-     * @param string $field
-     * @param mixed  $value
-     *
-     * @return Comparison
+     * @param mixed $value
      */
-    public function memberOf(string $field, $value): Comparison
+    public function memberOf(string $field, $value) : Comparison
     {
         return new Comparison($field, Comparison::MEMBER_OF, new Value($value));
     }
 
     /**
-     * @param string $field
-     * @param mixed  $value
-     *
-     * @return Comparison
+     * @param mixed $value
      */
-    public function startsWith(string $field, $value): Comparison
+    public function startsWith(string $field, $value) : Comparison
     {
         return new Comparison($field, Comparison::STARTS_WITH, new Value($value));
     }
 
     /**
-     * @param string $field
-     * @param mixed  $value
-     *
-     * @return Comparison
+     * @param mixed $value
      */
-    public function endsWith(string $field, $value): Comparison
+    public function endsWith(string $field, $value) : Comparison
     {
         return new Comparison($field, Comparison::ENDS_WITH, new Value($value));
     }

--- a/lib/Doctrine/Common/Collections/ExpressionBuilder.php
+++ b/lib/Doctrine/Common/Collections/ExpressionBuilder.php
@@ -23,7 +23,7 @@ class ExpressionBuilder
      *
      * @return CompositeExpression
      */
-    public function andX($x = null)
+    public function andX($x = null): CompositeExpression
     {
         return new CompositeExpression(CompositeExpression::TYPE_AND, func_get_args());
     }
@@ -33,7 +33,7 @@ class ExpressionBuilder
      *
      * @return CompositeExpression
      */
-    public function orX($x = null)
+    public function orX($x = null): CompositeExpression
     {
         return new CompositeExpression(CompositeExpression::TYPE_OR, func_get_args());
     }
@@ -44,7 +44,7 @@ class ExpressionBuilder
      *
      * @return Comparison
      */
-    public function eq($field, $value)
+    public function eq(string $field, $value): Comparison
     {
         return new Comparison($field, Comparison::EQ, new Value($value));
     }
@@ -55,7 +55,7 @@ class ExpressionBuilder
      *
      * @return Comparison
      */
-    public function gt($field, $value)
+    public function gt(string $field, $value): Comparison
     {
         return new Comparison($field, Comparison::GT, new Value($value));
     }
@@ -77,7 +77,7 @@ class ExpressionBuilder
      *
      * @return Comparison
      */
-    public function gte($field, $value)
+    public function gte(string $field, $value): Comparison
     {
         return new Comparison($field, Comparison::GTE, new Value($value));
     }
@@ -88,7 +88,7 @@ class ExpressionBuilder
      *
      * @return Comparison
      */
-    public function lte($field, $value)
+    public function lte(string $field, $value): Comparison
     {
         return new Comparison($field, Comparison::LTE, new Value($value));
     }
@@ -99,7 +99,7 @@ class ExpressionBuilder
      *
      * @return Comparison
      */
-    public function neq($field, $value)
+    public function neq(string $field, $value): Comparison
     {
         return new Comparison($field, Comparison::NEQ, new Value($value));
     }
@@ -109,7 +109,7 @@ class ExpressionBuilder
      *
      * @return Comparison
      */
-    public function isNull($field)
+    public function isNull(string $field): Comparison
     {
         return new Comparison($field, Comparison::EQ, new Value(null));
     }
@@ -120,7 +120,7 @@ class ExpressionBuilder
      *
      * @return Comparison
      */
-    public function in($field, array $values)
+    public function in(string $field, array $values): Comparison
     {
         return new Comparison($field, Comparison::IN, new Value($values));
     }
@@ -131,7 +131,7 @@ class ExpressionBuilder
      *
      * @return Comparison
      */
-    public function notIn($field, array $values)
+    public function notIn(string $field, array $values): Comparison
     {
         return new Comparison($field, Comparison::NIN, new Value($values));
     }
@@ -142,7 +142,7 @@ class ExpressionBuilder
      *
      * @return Comparison
      */
-    public function contains($field, $value)
+    public function contains(string $field, $value): Comparison
     {
         return new Comparison($field, Comparison::CONTAINS, new Value($value));
     }
@@ -153,7 +153,7 @@ class ExpressionBuilder
      *
      * @return Comparison
      */
-    public function memberOf($field, $value)
+    public function memberOf(string $field, $value): Comparison
     {
         return new Comparison($field, Comparison::MEMBER_OF, new Value($value));
     }
@@ -164,7 +164,7 @@ class ExpressionBuilder
      *
      * @return Comparison
      */
-    public function startsWith($field, $value)
+    public function startsWith(string $field, $value): Comparison
     {
         return new Comparison($field, Comparison::STARTS_WITH, new Value($value));
     }
@@ -175,7 +175,7 @@ class ExpressionBuilder
      *
      * @return Comparison
      */
-    public function endsWith($field, $value)
+    public function endsWith(string $field, $value): Comparison
     {
         return new Comparison($field, Comparison::ENDS_WITH, new Value($value));
     }

--- a/lib/Doctrine/Common/Collections/ExpressionBuilder.php
+++ b/lib/Doctrine/Common/Collections/ExpressionBuilder.php
@@ -6,8 +6,8 @@ namespace Doctrine\Common\Collections;
 
 use Doctrine\Common\Collections\Expr\Comparison;
 use Doctrine\Common\Collections\Expr\CompositeExpression;
+use Doctrine\Common\Collections\Expr\Expression;
 use Doctrine\Common\Collections\Expr\Value;
-use function func_get_args;
 
 /**
  * Builder for Expressions in the {@link Selectable} interface.
@@ -18,20 +18,14 @@ use function func_get_args;
  */
 class ExpressionBuilder
 {
-    /**
-     * @param mixed $x
-     */
-    public function andX($x = null) : CompositeExpression
+    public function andX(Expression ...$expressions) : CompositeExpression
     {
-        return new CompositeExpression(CompositeExpression::TYPE_AND, func_get_args());
+        return new CompositeExpression(CompositeExpression::TYPE_AND, $expressions);
     }
 
-    /**
-     * @param mixed $x
-     */
-    public function orX($x = null) : CompositeExpression
+    public function orX(Expression ...$expressions) : CompositeExpression
     {
-        return new CompositeExpression(CompositeExpression::TYPE_OR, func_get_args());
+        return new CompositeExpression(CompositeExpression::TYPE_OR, $expressions);
     }
 
     /**
@@ -51,12 +45,9 @@ class ExpressionBuilder
     }
 
     /**
-     * @param string $field
-     * @param mixed  $value
-     *
-     * @return Comparison
+     * @param mixed $value
      */
-    public function lt($field, $value)
+    public function lt(string $field, $value) : Comparison
     {
         return new Comparison($field, Comparison::LT, new Value($value));
     }

--- a/lib/Doctrine/Common/Collections/Selectable.php
+++ b/lib/Doctrine/Common/Collections/Selectable.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Common\Collections;
 
 /**

--- a/lib/Doctrine/Common/Collections/Selectable.php
+++ b/lib/Doctrine/Common/Collections/Selectable.php
@@ -29,5 +29,5 @@ interface Selectable
      *
      * @psalm-return Collection<TKey,T>
      */
-    public function matching(Criteria $criteria): Collection;
+    public function matching(Criteria $criteria) : Collection;
 }

--- a/lib/Doctrine/Common/Collections/Selectable.php
+++ b/lib/Doctrine/Common/Collections/Selectable.php
@@ -29,5 +29,5 @@ interface Selectable
      *
      * @psalm-return Collection<TKey,T>
      */
-    public function matching(Criteria $criteria);
+    public function matching(Criteria $criteria): Collection;
 }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -13,9 +13,6 @@
     <file>tests</file>
 
     <rule ref="Doctrine">
-        <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingParameterTypeHint"/>
-        <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingReturnTypeHint"/>
-
         <!-- Since Collections are built around mixed content, this has no value here -->
         <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingTraversablePropertyTypeHintSpecification"/>
         <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingTraversableParameterTypeHintSpecification"/>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -13,7 +13,6 @@
     <file>tests</file>
 
     <rule ref="Doctrine">
-        <exclude name="SlevomatCodingStandard.TypeHints.DeclareStrictTypes"/>
         <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingParameterTypeHint"/>
         <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingReturnTypeHint"/>
 

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,5 @@
 parameters:
-    level: 6
+    level: 7
 
     paths:
         - lib

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,9 @@
+parameters:
+    level: 3
+
+    paths:
+        - lib
+
+includes:
+    - vendor/phpstan/phpstan-phpunit/extension.neon
+    - vendor/phpstan/phpstan-phpunit/rules.neon

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,5 @@
 parameters:
-    level: 3
+    level: 6
 
     paths:
         - lib

--- a/tests/Doctrine/Tests/Common/Collections/AbstractLazyArrayCollectionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/AbstractLazyArrayCollectionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\Common\Collections;
 
 use Doctrine\Common\Collections\ArrayCollection;

--- a/tests/Doctrine/Tests/Common/Collections/AbstractLazyCollectionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/AbstractLazyCollectionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\Common\Collections;
 
 use Doctrine\Common\Collections\ArrayCollection;

--- a/tests/Doctrine/Tests/Common/Collections/ArrayCollectionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/ArrayCollectionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\Common\Collections;
 
 use Doctrine\Common\Collections\ArrayCollection;

--- a/tests/Doctrine/Tests/Common/Collections/BaseArrayCollectionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/BaseArrayCollectionTest.php
@@ -23,15 +23,17 @@ abstract class BaseArrayCollectionTest extends TestCase
 {
     abstract protected function buildCollection(array $elements = []) : Collection;
 
-    protected function isSelectable($obj) : bool
+    protected function isSelectable(object $obj) : bool
     {
         return $obj instanceof Selectable;
     }
 
     /**
+     * @param array<string|int, string|int> $elements
+     *
      * @dataProvider provideDifferentElements
      */
-    public function testToArray($elements) : void
+    public function testToArray(array $elements) : void
     {
         $collection = $this->buildCollection($elements);
 
@@ -39,27 +41,33 @@ abstract class BaseArrayCollectionTest extends TestCase
     }
 
     /**
+     * @param array<string|int, string|int> $elements
+     *
      * @dataProvider provideDifferentElements
      */
-    public function testFirst($elements) : void
+    public function testFirst(array $elements) : void
     {
         $collection = $this->buildCollection($elements);
         self::assertSame(reset($elements), $collection->first());
     }
 
     /**
+     * @param array<string|int, string|int> $elements
+     *
      * @dataProvider provideDifferentElements
      */
-    public function testLast($elements) : void
+    public function testLast(array $elements) : void
     {
         $collection = $this->buildCollection($elements);
         self::assertSame(end($elements), $collection->last());
     }
 
     /**
+     * @param array<string|int, string|int> $elements
+     *
      * @dataProvider provideDifferentElements
      */
-    public function testKey($elements) : void
+    public function testKey(array $elements) : void
     {
         $collection = $this->buildCollection($elements);
 
@@ -72,9 +80,11 @@ abstract class BaseArrayCollectionTest extends TestCase
     }
 
     /**
+     * @param array<string|int, string|int> $elements
+     *
      * @dataProvider provideDifferentElements
      */
-    public function testNext($elements) : void
+    public function testNext(array $elements) : void
     {
         $collection = $this->buildCollection($elements);
 
@@ -93,9 +103,11 @@ abstract class BaseArrayCollectionTest extends TestCase
     }
 
     /**
+     * @param array<string|int, string|int> $elements
+     *
      * @dataProvider provideDifferentElements
      */
-    public function testCurrent($elements) : void
+    public function testCurrent(array $elements) : void
     {
         $collection = $this->buildCollection($elements);
 
@@ -108,9 +120,11 @@ abstract class BaseArrayCollectionTest extends TestCase
     }
 
     /**
+     * @param array<string|int, string|int> $elements
+     *
      * @dataProvider provideDifferentElements
      */
-    public function testGetKeys($elements) : void
+    public function testGetKeys(array $elements) : void
     {
         $collection = $this->buildCollection($elements);
 
@@ -118,9 +132,11 @@ abstract class BaseArrayCollectionTest extends TestCase
     }
 
     /**
+     * @param array<string|int, string|int> $elements
+     *
      * @dataProvider provideDifferentElements
      */
-    public function testGetValues($elements) : void
+    public function testGetValues(array $elements) : void
     {
         $collection = $this->buildCollection($elements);
 
@@ -128,9 +144,11 @@ abstract class BaseArrayCollectionTest extends TestCase
     }
 
     /**
+     * @param array<string|int, string|int> $elements
+     *
      * @dataProvider provideDifferentElements
      */
-    public function testCount($elements) : void
+    public function testCount(array $elements) : void
     {
         $collection = $this->buildCollection($elements);
 
@@ -138,9 +156,11 @@ abstract class BaseArrayCollectionTest extends TestCase
     }
 
     /**
+     * @param array<string|int, string|int> $elements
+     *
      * @dataProvider provideDifferentElements
      */
-    public function testIterator($elements) : void
+    public function testIterator(array $elements) : void
     {
         $collection = $this->buildCollection($elements);
 

--- a/tests/Doctrine/Tests/Common/Collections/BaseArrayCollectionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/BaseArrayCollectionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\Common\Collections;
 
 use Doctrine\Common\Collections\Collection;

--- a/tests/Doctrine/Tests/Common/Collections/BaseCollectionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/BaseCollectionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\Common\Collections;
 
 use Doctrine\Common\Collections\Collection;

--- a/tests/Doctrine/Tests/Common/Collections/ClosureExpressionVisitorTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/ClosureExpressionVisitorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\Common\Collections;
 
 use Doctrine\Common\Collections\Expr\ClosureExpressionVisitor;

--- a/tests/Doctrine/Tests/Common/Collections/ClosureExpressionVisitorTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/ClosureExpressionVisitorTest.php
@@ -279,6 +279,12 @@ class TestObject
     /** @var mixed */
     private $qux;
 
+    /**
+     * @param mixed $foo
+     * @param mixed $bar
+     * @param mixed $baz
+     * @param mixed $qux
+     */
     public function __construct($foo = null, $bar = null, $baz = null, $qux = null)
     {
         $this->foo = $foo;
@@ -287,6 +293,11 @@ class TestObject
         $this->qux = $qux;
     }
 
+    /**
+     * @param array<int, mixed> $arguments
+     *
+     * @return mixed
+     */
     public function __call(string $name, array $arguments)
     {
         if ($name === 'getqux') {
@@ -294,16 +305,25 @@ class TestObject
         }
     }
 
+    /**
+     * @return mixed
+     */
     public function getFoo()
     {
         return $this->foo;
     }
 
+    /**
+     * @return mixed
+     */
     public function getBar()
     {
         return $this->bar;
     }
 
+    /**
+     * @return mixed
+     */
     public function isBaz()
     {
         return $this->baz;
@@ -320,7 +340,7 @@ class TestObjectNotCamelCase
         $this->foo_bar = $foo_bar;
     }
 
-    public function getFooBar()
+    public function getFooBar() : ?int
     {
         return $this->foo_bar;
     }
@@ -370,15 +390,23 @@ class TestObjectBothPublic
 {
     /** @var mixed */
     public $foo_bar;
+
     /** @var mixed */
     public $fooBar;
 
+    /**
+     * @param mixed $foo_bar
+     * @param mixed $fooBar
+     */
     public function __construct($foo_bar = null, $fooBar = null)
     {
         $this->foo_bar = $foo_bar;
         $this->fooBar  = $fooBar;
     }
 
+    /**
+     * @return mixed
+     */
     public function getFooBar()
     {
         return $this->foo_bar;

--- a/tests/Doctrine/Tests/Common/Collections/CollectionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/CollectionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\Common\Collections;
 
 use Doctrine\Common\Collections\ArrayCollection;

--- a/tests/Doctrine/Tests/Common/Collections/CriteriaTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/CriteriaTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\Common\Collections;
 
 use Doctrine\Common\Collections\Criteria;

--- a/tests/Doctrine/Tests/Common/Collections/DerivedCollectionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/DerivedCollectionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\Common\Collections;
 
 use Doctrine\Common\Collections\Criteria;

--- a/tests/Doctrine/Tests/Common/Collections/Expr/CompositeExpressionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/Expr/CompositeExpressionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\Common\Collections\Expr;
 
 use Doctrine\Common\Collections\Expr\CompositeExpression;

--- a/tests/Doctrine/Tests/Common/Collections/Expr/CompositeExpressionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/Expr/CompositeExpressionTest.php
@@ -25,6 +25,8 @@ class CompositeExpressionTest extends TestCase
     }
 
     /**
+     * @param string|Value $expression
+     *
      * @dataProvider invalidDataProvider
      */
     public function testExceptions($expression) : void

--- a/tests/Doctrine/Tests/Common/Collections/Expr/ValueTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/Expr/ValueTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\Common\Collections\Expr;
 
 use Doctrine\Common\Collections\Expr\ExpressionVisitor;

--- a/tests/Doctrine/Tests/Common/Collections/ExpressionBuilderTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/ExpressionBuilderTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\Common\Collections;
 
 use Doctrine\Common\Collections\Expr\Comparison;

--- a/tests/Doctrine/Tests/Common/Collections/ExpressionBuilderTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/ExpressionBuilderTest.php
@@ -8,7 +8,6 @@ use Doctrine\Common\Collections\Expr\Comparison;
 use Doctrine\Common\Collections\Expr\CompositeExpression;
 use Doctrine\Common\Collections\ExpressionBuilder;
 use PHPUnit\Framework\TestCase;
-use RuntimeException;
 
 /**
  * @group DDC-1637
@@ -37,12 +36,6 @@ class ExpressionBuilderTest extends TestCase
 
         self::assertInstanceOf(CompositeExpression::class, $expr);
         self::assertEquals(CompositeExpression::TYPE_OR, $expr->getType());
-    }
-
-    public function testInvalidAndXArgument() : void
-    {
-        $this->expectException(RuntimeException::class);
-        $this->builder->andX('foo');
     }
 
     public function testEq() : void

--- a/tests/Doctrine/Tests/DerivedArrayCollection.php
+++ b/tests/Doctrine/Tests/DerivedArrayCollection.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests;
 
 use Doctrine\Common\Collections\ArrayCollection;

--- a/tests/Doctrine/Tests/DerivedArrayCollection.php
+++ b/tests/Doctrine/Tests/DerivedArrayCollection.php
@@ -22,7 +22,7 @@ final class DerivedArrayCollection extends ArrayCollection
         parent::__construct($elements);
     }
 
-    protected function createFrom(array $elements) : self
+    protected function createFrom(array $elements) : parent
     {
         return new static($this->foo, $elements);
     }

--- a/tests/Doctrine/Tests/LazyArrayCollection.php
+++ b/tests/Doctrine/Tests/LazyArrayCollection.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests;
 
 use Doctrine\Common\Collections\AbstractLazyCollection;


### PR DESCRIPTION
Work originally started in #125 

- Bump dev-master branch alias to `2.0.x-dev`
- Require PHP 7.2
- Upgrade PHPStan to 0.11
- Increase PHPStan to Level 7
- Add strict type hints everywhere
- Remove some of the exclusion rules in `phpcs.xml.dist`
- Sort packages in `composer.json`
