### PR TITLE
Ignore never used mutators in Infection

### DIFF
--- a/infection.json.dist
+++ b/infection.json.dist
@@ -9,6 +9,9 @@
         "text": "infection.log"
     },
     "mutators": {
-        "@default": true
+        "@default": true,
+        "Equal": false,
+        "EqualIdentical": false,
+        "NotEqual": false
     }
 }


### PR DESCRIPTION
Doctrine's Coding Standard forbids the usage of equal and not equal operators, making [these mutators](https://infection.github.io/guide/mutators.html#Equal-or-Identical-Checks) pointless.