### PR TITLE
Initialize $element property of ArrayCollection

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
         "phpstan/phpstan": "^0.11",
         "phpstan/phpstan-phpunit": "^0.11",
         "phpunit/phpunit": "^8.0",
-        "vimeo/psalm": "^3.2.2"
+        "vimeo/psalm": "^3.2.2",
+        "ext-json": "*"
     },
     "config": {
         "sort-packages": true

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3de09763c323dabde63b7e08cc80035a",
+    "content-hash": "7b422f1cfd1e76d362ff1a43a54ef643",
     "packages": [],
     "packages-dev": [
         {
@@ -4136,5 +4136,7 @@
     "platform": {
         "php": "^7.2"
     },
-    "platform-dev": []
+    "platform-dev": {
+        "ext-json": "*"
+    }
 }

--- a/lib/Doctrine/Common/Collections/ArrayCollection.php
+++ b/lib/Doctrine/Common/Collections/ArrayCollection.php
@@ -49,7 +49,7 @@ class ArrayCollection implements Collection, Selectable
      * @psalm-var array<TKey,T>
      * @var array
      */
-    private $elements;
+    private $elements = [];
 
     /**
      * Initializes a new ArrayCollection.

--- a/tests/Doctrine/Tests/Common/Collections/ArrayCollectionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/ArrayCollectionTest.php
@@ -6,6 +6,11 @@ namespace Doctrine\Tests\Common\Collections;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
+use Serializable;
+use function json_decode;
+use function json_encode;
+use function serialize;
+use function unserialize;
 
 /**
  * Tests for {@see \Doctrine\Common\Collections\ArrayCollection}.
@@ -17,5 +22,34 @@ class ArrayCollectionTest extends BaseArrayCollectionTest
     protected function buildCollection(array $elements = []) : Collection
     {
         return new ArrayCollection($elements);
+    }
+
+    public function testUnserializeEmptyArrayCollection() : void
+    {
+        $collection            = new SerializableArrayCollection();
+        $serializeCollection   = serialize($collection);
+        $unserializeCollection = unserialize($serializeCollection);
+
+        $this->assertIsArray($unserializeCollection->getValues());
+        $this->assertCount(0, $unserializeCollection->getValues());
+    }
+}
+
+/**
+ * We can't implement Serializable interface on anonymous class
+ */
+class SerializableArrayCollection extends ArrayCollection implements Serializable
+{
+    public function serialize() : string
+    {
+        return json_encode($this->getKeys());
+    }
+
+    // phpcs:ignore SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingParameterTypeHint
+    public function unserialize($serialized) : void
+    {
+        foreach (json_decode($serialized) as $value) {
+            parent::add($value);
+        }
     }
 }


### PR DESCRIPTION
Initialize the property $element to an Array in order to avoid warning when we unserialize a serialized array (see #155) :

`Warning: array_values() expects parameter 1 to be array, null given`
