### PR TITLE
fix #210 by including psalm-* annotations to ArrayCollection#map()

### DIFF
--- a/lib/Doctrine/Common/Collections/ArrayCollection.php
+++ b/lib/Doctrine/Common/Collections/ArrayCollection.php
@@ -312,6 +312,10 @@ class ArrayCollection implements Collection, Selectable
      * {@inheritDoc}
      *
      * @return static
+     *
+     * @psalm-template U
+     * @psalm-param Closure(T=):U $func
+     * @psalm-return static<TKey, U>
      */
     public function map(Closure $func)
     {


### PR DESCRIPTION
Apparently, psalm cannot reuse `@psalm-template` from parent's method declaration using `@inheritdoc`, so we cannot just specify `@psalm-return static<TKey, U>`.

Fixes #210