### PR TITLE
Remove PHP 7.4 from `allow_failures` matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,6 @@ install:
 script: ./vendor/bin/phpunit
 
 jobs:
-  allow_failures:
-    - php: 7.4snapshot
-
   include:
     - stage: Test
       env: COVERAGE


### PR DESCRIPTION
In order to ensure that branch `1.6` is forward compatible with PHP 7.4, let's allow the jobs to fail.