### PR TITLE
Use variadic params in ExpressionBuilder#andX() and #orX()

### DIFF
--- a/lib/Doctrine/Common/Collections/ExpressionBuilder.php
+++ b/lib/Doctrine/Common/Collections/ExpressionBuilder.php
@@ -5,7 +5,6 @@ namespace Doctrine\Common\Collections;
 use Doctrine\Common\Collections\Expr\Comparison;
 use Doctrine\Common\Collections\Expr\CompositeExpression;
 use Doctrine\Common\Collections\Expr\Value;
-use function func_get_args;
 
 /**
  * Builder for Expressions in the {@link Selectable} interface.
@@ -17,23 +16,23 @@ use function func_get_args;
 class ExpressionBuilder
 {
     /**
-     * @param mixed $x
+     * @param mixed ...$expressions
      *
      * @return CompositeExpression
      */
-    public function andX($x = null)
+    public function andX(...$expressions)
     {
-        return new CompositeExpression(CompositeExpression::TYPE_AND, func_get_args());
+        return new CompositeExpression(CompositeExpression::TYPE_AND, $expressions);
     }
 
     /**
-     * @param mixed $x
+     * @param mixed ...$expressions
      *
      * @return CompositeExpression
      */
-    public function orX($x = null)
+    public function orX(...$expressions)
     {
-        return new CompositeExpression(CompositeExpression::TYPE_OR, func_get_args());
+        return new CompositeExpression(CompositeExpression::TYPE_OR, $expressions);
     }
 
     /**


### PR DESCRIPTION
### What?
Changes `andX()` and `orX()` method declarations of `ExpressionBuilder` class from `andX($x = null)` to `andX(...$expressions)`.

### Why?
When using psalm static analyzer, it may report a false positive "TooManyArguments" error when making a call to `ExpressionBuilder#andX()` (`orX()`). This is because in its declaration there is only one parameter.

### Can it be done?
As long as doctrine/collections `^1.6` depend on PHP `^7.1` , and variadic params were introduced in PHP 5.6, this can be done in this library. It does also not introduce any BC breaks.