### PR TITLE
reflect that ExpressionBuilder#andX() and orX() params are variadic in PHPDoc

### DIFF
--- a/lib/Doctrine/Common/Collections/ExpressionBuilder.php
+++ b/lib/Doctrine/Common/Collections/ExpressionBuilder.php
@@ -17,7 +17,7 @@ use function func_get_args;
 class ExpressionBuilder
 {
     /**
-     * @param mixed $x
+     * @param mixed ...$x
      *
      * @return CompositeExpression
      */
@@ -27,7 +27,7 @@ class ExpressionBuilder
     }
 
     /**
-     * @param mixed $x
+     * @param mixed ...$x
      *
      * @return CompositeExpression
      */


### PR DESCRIPTION
Like https://github.com/doctrine/collections/pull/217 but changes only PHPDoc