### PR TITLE
Allow for covariant elements in Collection

### DIFF
--- a/lib/Doctrine/Common/Collections/AbstractLazyCollection.php
+++ b/lib/Doctrine/Common/Collections/AbstractLazyCollection.php
@@ -7,8 +7,8 @@ use Closure;
 /**
  * Lazy collection that is backed by a concrete collection
  *
- * @psalm-template TKey of array-key
- * @psalm-template T
+ * @psalm-template-covariant TKey of array-key
+ * @psalm-template-covariant T
  * @template-implements Collection<TKey,T>
  */
 abstract class AbstractLazyCollection implements Collection

--- a/lib/Doctrine/Common/Collections/ArrayCollection.php
+++ b/lib/Doctrine/Common/Collections/ArrayCollection.php
@@ -32,8 +32,8 @@ use function uasort;
  * serialize a collection use {@link toArray()} and reconstruct the collection
  * manually.
  *
- * @psalm-template TKey of array-key
- * @psalm-template T
+ * @psalm-template-covariant TKey of array-key
+ * @psalm-template-covariant T
  * @template-implements Collection<TKey,T>
  * @template-implements Selectable<TKey,T>
  */

--- a/lib/Doctrine/Common/Collections/Collection.php
+++ b/lib/Doctrine/Common/Collections/Collection.php
@@ -24,8 +24,8 @@ use IteratorAggregate;
  * position unless you explicitly positioned it before. Prefer iteration with
  * external iterators.
  *
- * @psalm-template TKey of array-key
- * @psalm-template T
+ * @psalm-template-covariant TKey of array-key
+ * @psalm-template-covariant T
  * @template-extends IteratorAggregate<TKey, T>
  * @template-extends ArrayAccess<TKey|null, T>
  */

--- a/lib/Doctrine/Common/Collections/Selectable.php
+++ b/lib/Doctrine/Common/Collections/Selectable.php
@@ -14,8 +14,8 @@ namespace Doctrine\Common\Collections;
  * this API can implement efficient database access without having to ask the
  * EntityManager or Repositories.
  *
- * @psalm-template TKey as array-key
- * @psalm-template T
+ * @psalm-template-covariant TKey as array-key
+ * @psalm-template-covariant T
  */
 interface Selectable
 {


### PR DESCRIPTION
With covariant return types in PHP 7.4, I think Collection should also allow for that.

Getting this errors with Psalm and covariant elements:

 - `
ERROR: InvalidReturnType - src/Sylius/Component/Core/Model/Promotion.php:41:36 - The declared return type 'Doctrine\Common\Collections\Collection<array-key, Sylius\Component\Channel\Model\ChannelInterface>' for Sylius\Component\Core\Model\Promotion::getChannels is incorrect, got 'Doctrine\Common\Collections\Collection<array-key, Sylius\Component\Core\Model\ChannelInterface>'
    public function getChannels(): Collection
`

 - `
ERROR: InvalidReturnStatement - src/Sylius/Component/Core/Model/Promotion.php:43:16 - The type 'Doctrine\Common\Collections\Collection<array-key, Sylius\Component\Core\Model\ChannelInterface>' does not match the declared return type 'Doctrine\Common\Collections\Collection<array-key, Sylius\Component\Channel\Model\ChannelInterface>' for Sylius\Component\Core\Model\Promotion::getChannels
        return $this->channels;
`

To provide some background:
 - `Sylius\Component\Core\Model\ChannelInterface` extends `Sylius\Component\Channel\Model\ChannelInterface`
 - `Sylius\Component\Core\Model\Promotion` extends `Sylius\Component\Promotion\Model\Promotion`
 - `Sylius\Component\Promotion\Model\Promotion::getChannels()` defines its return type as `Collection<array-key, Sylius\Component\Channel\Model\ChannelInterface>`
 - `Sylius\Component\Core\Model\Promotion::getChannels()` returns property typed with `Collection<array-key, Sylius\Component\Core\Model\ChannelInterface>`

Please let me know if it should be treated as a bugfix or as a new feature, I can rebase if needed.