### PR TITLE
Add ArrayCollection map() method capability to access inner array key

### DIFF
--- a/lib/Doctrine/Common/Collections/ArrayCollection.php
+++ b/lib/Doctrine/Common/Collections/ArrayCollection.php
@@ -325,12 +325,12 @@ class ArrayCollection implements Collection, Selectable
      * @return static
      *
      * @psalm-template U
-     * @psalm-param Closure(T=):U $func
+     * @psalm-param Closure(T=, TKey=):U $func
      * @psalm-return static<TKey, U>
      */
     public function map(Closure $func) : Collection
     {
-        return $this->createFrom(array_map($func, $this->elements));
+        return $this->createFrom(array_map($func, $this->elements, array_keys($this->elements)));
     }
 
     /**


### PR DESCRIPTION
This enhancement gives to map() Closure the capability to access also the keys of the inner array holding the elements. Until now, we were able to access just the element on map Closure but not the key. So I propose to add the ability to access also the key for do some statements inside the Closure with key related.

I have the need to add it since in my project I must get the asociative key to take a decision in function of the current key element and I thought that may be usefull for everyone in some other projects to access the key of current processing element
