### PR TITLE
Fix of branch name for doctrine website build

### DIFF
--- a/.doctrine-project.json
+++ b/.doctrine-project.json
@@ -1,20 +1,20 @@
 {
-	"active": true,
-	"name": "Collections",
-	"slug": "collections",
-	"docsSlug": "doctrine-collections",
-	"versions": [
-		{
-			"name": "2.0",
-			"branchName": "master",
-			"slug": "latest",
-			"upcoming": true
-		},
+    "active": true,
+    "name": "Collections",
+    "slug": "collections",
+    "docsSlug": "doctrine-collections",
+    "versions": [
+        {
+            "name": "2.0",
+            "branchName": "master",
+            "slug": "latest",
+            "upcoming": true
+        },
         {
             "name": "1.6",
-            "branchName": "1.6",
+            "branchName": "1.6.x",
             "slug": "1.6",
             "current": true
         }
-	]
+    ]
 }


### PR DESCRIPTION
This should fix the collections version infos and the build error `error: pathspec 'origin/1.6' did not match any file(s) known to git` on Doctrine website build.