### PR TITLE
Remove stale branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,10 +33,5 @@
         "psr-4": {
             "Doctrine\\Tests\\": "tests/Doctrine/Tests"
         }
-    },
-    "extra": {
-        "branch-alias": {
-            "dev-master": "1.6.x-dev"
-        }
     }
 }


### PR DESCRIPTION
This was useful when master was 1.6, but currently it is 2.0, so this
will only cause confusion. When releasing 2.0.0, we should create a
similar commit on the newly created 2.0.x branch, and bump that number
in the master branch.