### PR TITLE
Utilizing Expression::visit method instead of switch-case

### DIFF
--- a/lib/Doctrine/Common/Collections/Expr/ExpressionVisitor.php
+++ b/lib/Doctrine/Common/Collections/Expr/ExpressionVisitor.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\Common\Collections\Expr;
 
 use RuntimeException;
-use function get_class;
 
 /**
  * An Expression visitor walks a graph of expressions and turns them into a

--- a/lib/Doctrine/Common/Collections/Expr/ExpressionVisitor.php
+++ b/lib/Doctrine/Common/Collections/Expr/ExpressionVisitor.php
@@ -43,15 +43,6 @@ abstract class ExpressionVisitor
      */
     public function dispatch(Expression $expr)
     {
-        switch (true) {
-            case $expr instanceof Comparison:
-                return $this->walkComparison($expr);
-            case $expr instanceof Value:
-                return $this->walkValue($expr);
-            case $expr instanceof CompositeExpression:
-                return $this->walkCompositeExpression($expr);
-            default:
-                throw new RuntimeException('Unknown Expression ' . get_class($expr));
-        }
+        return $expr->visit($this);
     }
 }


### PR DESCRIPTION
While working with Criteria API, I noticed that `visit` method in Expression is never used and duplicate logic exists in `ExpressionVisitor::dispatch`

By calling `visit`, a developer can implement his own "logic" and hook into `ExpressionVisitor`

My use case: I was trying to implement my own "Comparison" to work with a discriminator field but I can't add any logic to "visit" method because it's not called.

Ref.: https://github.com/doctrine/orm/issues/5908
