### PR TITLE
Add method find in ArrayCollection

### DIFF
--- a/lib/Doctrine/Common/Collections/AbstractLazyCollection.php
+++ b/lib/Doctrine/Common/Collections/AbstractLazyCollection.php
@@ -228,6 +228,16 @@ abstract class AbstractLazyCollection implements Collection
     /**
      * {@inheritDoc}
      */
+    public function find(Closure $func)
+    {
+        $this->initialize();
+
+        return $this->collection->find($func);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function forAll(Closure $p) : bool
     {
         $this->initialize();

--- a/lib/Doctrine/Common/Collections/ArrayCollection.php
+++ b/lib/Doctrine/Common/Collections/ArrayCollection.php
@@ -351,8 +351,11 @@ class ArrayCollection implements Collection, Selectable
     public function find(Closure $func)
     {
         foreach ($this->elements as $key => $element) {
-            if ($func($element, $key) === true) return $element;
+            if ($func($element, $key) === true) {
+                return $element;
+            }
         }
+
         return null;
     }
 

--- a/lib/Doctrine/Common/Collections/ArrayCollection.php
+++ b/lib/Doctrine/Common/Collections/ArrayCollection.php
@@ -348,6 +348,17 @@ class ArrayCollection implements Collection, Selectable
     /**
      * {@inheritDoc}
      */
+    public function find(Closure $func)
+    {
+        foreach ($this->elements as $key => $element) {
+            if ($func($element, $key) === true) return $element;
+        }
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function forAll(Closure $p) : bool
     {
         foreach ($this->elements as $key => $element) {

--- a/lib/Doctrine/Common/Collections/Collection.php
+++ b/lib/Doctrine/Common/Collections/Collection.php
@@ -153,7 +153,7 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      *
      * @psalm-return array<TKey,T>
      */
-    public function toArray() : array;
+    public function toArray(): array;
 
     /**
      * Sets the internal iterator to the first element in the collection and returns this element.
@@ -223,6 +223,18 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      * @psalm-return Collection<TKey, T>
      */
     public function filter(Closure $p) : self;
+
+    /**
+     * Return the value of first element found in array of elements that satisfies the $func.
+     * 
+     * @param Closure $func The predicate used to find element.
+     * 
+     * @return mixed|null The element if found or NULL if not.
+     * 
+     * @psalm-param Closure(T=, TKey=):bool $func
+     * @psalm-return T|null
+     */
+    public function find(Closure $func);
 
     /**
      * Tests whether the given predicate p holds for all elements of this collection.

--- a/lib/Doctrine/Common/Collections/Collection.php
+++ b/lib/Doctrine/Common/Collections/Collection.php
@@ -153,7 +153,7 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      *
      * @psalm-return array<TKey,T>
      */
-    public function toArray(): array;
+    public function toArray() : array;
 
     /**
      * Sets the internal iterator to the first element in the collection and returns this element.
@@ -226,11 +226,11 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
 
     /**
      * Return the value of first element found in array of elements that satisfies the $func.
-     * 
+     *
      * @param Closure $func The predicate used to find element.
-     * 
+     *
      * @return mixed|null The element if found or NULL if not.
-     * 
+     *
      * @psalm-param Closure(T=, TKey=):bool $func
      * @psalm-return T|null
      */

--- a/tests/Doctrine/Tests/Common/Collections/AbstractLazyCollectionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/AbstractLazyCollectionTest.php
@@ -50,6 +50,18 @@ class AbstractLazyCollectionTest extends BaseCollectionTest
         self::assertEquals([0 => 1, 2 => 3], $res->toArray());
     }
 
+    public function testFindInitializes() : void
+    {
+        /** @var LazyArrayCollection $collection */
+        $collection = $this->buildCollection([1, 3, 'foo']);
+
+        $res = $collection->find(static function ($value) {
+            return $value === 3;
+        });
+
+        self::assertEquals(3, $res);
+    }
+
     public function testForAllInitializes() : void
     {
         $collection = $this->buildCollection(['foo', 'bar']);

--- a/tests/Doctrine/Tests/Common/Collections/BaseArrayCollectionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/BaseArrayCollectionTest.php
@@ -235,6 +235,28 @@ abstract class BaseArrayCollectionTest extends TestCase
         self::assertFalse($collection->containsKey('non-existent'), "Doesn't contain key");
     }
 
+    public function testFindElement() : void
+    {
+        $elements   = [1, 2, 3, 17];
+        $collection = $this->buildCollection($elements);
+
+        self::assertNull($collection->find(static function ($element) {
+            return $element === 0;
+        }));
+
+        self::assertEquals($collection->find(static function ($element) {
+            return $element === 2;
+        }), 2);
+
+        self::assertNull($collection->find(static function ($element) {
+            return $element === 4;
+        }));
+
+        self::assertEquals($collection->find(static function ($_, $key) {
+            return $key === 3;
+        }), 17);
+    }
+
     public function testEmpty() : void
     {
         $collection = $this->buildCollection();

--- a/tests/Doctrine/Tests/Common/Collections/BaseCollectionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/BaseCollectionTest.php
@@ -97,7 +97,7 @@ abstract class BaseCollectionTest extends TestCase
         $resThree = $this->collection->find(static function ($element) {
             return $element === 4;
         });
-        
+
         self::assertEquals(3, $resOne);
         self::assertNull($resTwo);
         self::assertNull($resThree);
@@ -117,7 +117,7 @@ abstract class BaseCollectionTest extends TestCase
         $resTwo = $this->collection->find(static function ($_, $key) {
             return $key === 17;
         });
-        
+
         self::assertEquals('foo', $resOne);
         self::assertNull($resTwo);
     }

--- a/tests/Doctrine/Tests/Common/Collections/BaseCollectionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/BaseCollectionTest.php
@@ -79,6 +79,49 @@ abstract class BaseCollectionTest extends TestCase
         self::assertSame([0 => 1, 2 => 3, 4 => 5], $res->toArray());
     }
 
+    public function testFindByElement() : void
+    {
+        $this->collection->add(1);
+        $this->collection->add(2);
+        $this->collection->add('foo');
+        $this->collection->add(3);
+
+        $resOne = $this->collection->find(static function ($element) {
+            return $element === 3;
+        });
+
+        $resTwo = $this->collection->find(static function ($element) {
+            return $element === 0;
+        });
+
+        $resThree = $this->collection->find(static function ($element) {
+            return $element === 4;
+        });
+        
+        self::assertEquals(3, $resOne);
+        self::assertNull($resTwo);
+        self::assertNull($resThree);
+    }
+
+    public function testFindByKey() : void
+    {
+        $this->collection->add(1);
+        $this->collection->add(2);
+        $this->collection->add('foo');
+        $this->collection->add(3);
+
+        $resOne = $this->collection->find(static function ($_, $key) {
+            return $key === 2;
+        });
+
+        $resTwo = $this->collection->find(static function ($_, $key) {
+            return $key === 17;
+        });
+        
+        self::assertEquals('foo', $resOne);
+        self::assertNull($resTwo);
+    }
+
     public function testFirstAndLast() : void
     {
         $this->collection->add('one');


### PR DESCRIPTION
This enhancement gives the possibility of the found an element in ArrayCollection or remove any element of an easier and faster way.

A simple way to remove element using Doctrine (when all elements is found): 

```
$userEntity = $this->entityManager->getRepository(User::class)->findOneByUuid('123');

$tags = $userEntity->getTags(); // This method return a ArrayCollection of entity Tag

$tagFound = $tags->find(fn($element) => $element->getId() === '321');

$tags->removeElement($tagFound);
```