### PR TITLE
Comparison BIT_AND

### DIFF
--- a/lib/Doctrine/Common/Collections/Expr/ClosureExpressionVisitor.php
+++ b/lib/Doctrine/Common/Collections/Expr/ClosureExpressionVisitor.php
@@ -173,6 +173,12 @@ class ClosureExpressionVisitor extends ExpressionVisitor
                 return static function ($object) use ($field, $value) : bool {
                     return $value === substr(ClosureExpressionVisitor::getObjectFieldValue($object, $field), -strlen($value));
                 };
+            case Comparison::BIT_AND:
+                return static function ($object) use ($field, $value) : bool {
+                    $fieldValue = ClosureExpressionVisitor::getObjectFieldValue($object, $field);
+
+                    return ($fieldValue & $value) === $value;
+                };
             default:
                 throw new RuntimeException('Unknown comparison operator: ' . $comparison->getOperator());
         }

--- a/lib/Doctrine/Common/Collections/Expr/Comparison.php
+++ b/lib/Doctrine/Common/Collections/Expr/Comparison.php
@@ -22,6 +22,7 @@ class Comparison implements Expression
     public const MEMBER_OF   = 'MEMBER_OF';
     public const STARTS_WITH = 'STARTS_WITH';
     public const ENDS_WITH   = 'ENDS_WITH';
+    public const BIT_AND     = 'BIT_AND';
 
     /** @var string */
     private $field;

--- a/lib/Doctrine/Common/Collections/ExpressionBuilder.php
+++ b/lib/Doctrine/Common/Collections/ExpressionBuilder.php
@@ -128,4 +128,12 @@ class ExpressionBuilder
     {
         return new Comparison($field, Comparison::ENDS_WITH, new Value($value));
     }
+
+    /**
+     * @param mixed $value
+     */
+    public function bitAnd(string $field, $value) : Comparison
+    {
+        return new Comparison($field, Comparison::BIT_AND, new Value($value));
+    }
 }

--- a/tests/Doctrine/Tests/Common/Collections/ClosureExpressionVisitorTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/ClosureExpressionVisitorTest.php
@@ -198,7 +198,27 @@ class ClosureExpressionVisitorTest extends TestCase
         self::assertTrue($closure(new TestObject('4')));
         self::assertTrue($closure(new TestObject(5)));
         self::assertTrue($closure(new TestObject('5')));
+        self::assertTrue($closure(new TestObject(12)));
+        self::assertTrue($closure(new TestObject('12')));
         self::assertFalse($closure(new TestObject(2)));
+        self::assertFalse($closure(new TestObject('2')));
+        self::assertFalse($closure(new TestObject(8)));
+        self::assertFalse($closure(new TestObject('8')));
+        self::assertFalse($closure(new TestObject(11)));
+        self::assertFalse($closure(new TestObject('11')));
+
+        $closure = $this->visitor->walkComparison($this->builder->bitAnd('foo', 6));
+
+        self::assertTrue($closure(new TestObject(6)));
+        self::assertTrue($closure(new TestObject('6')));
+        self::assertTrue($closure(new TestObject(7)));
+        self::assertTrue($closure(new TestObject('7')));
+        self::assertFalse($closure(new TestObject(4)));
+        self::assertFalse($closure(new TestObject('4')));
+        self::assertFalse($closure(new TestObject(5)));
+        self::assertFalse($closure(new TestObject('5')));
+        self::assertFalse($closure(new TestObject(24)));
+        self::assertFalse($closure(new TestObject('24')));
     }
 
     public function testWalkAndCompositeExpression() : void

--- a/tests/Doctrine/Tests/Common/Collections/ClosureExpressionVisitorTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/ClosureExpressionVisitorTest.php
@@ -190,6 +190,17 @@ class ClosureExpressionVisitorTest extends TestCase
         self::assertFalse($closure(new TestObject('hello')));
     }
 
+    public function testWalkBitAndComparison() : void
+    {
+        $closure = $this->visitor->walkComparison($this->builder->bitAnd('foo', 4));
+
+        self::assertTrue($closure(new TestObject(4)));
+        self::assertTrue($closure(new TestObject('4')));
+        self::assertTrue($closure(new TestObject(5)));
+        self::assertTrue($closure(new TestObject('5')));
+        self::assertFalse($closure(new TestObject(2)));
+    }
+
     public function testWalkAndCompositeExpression() : void
     {
         $closure = $this->visitor->walkCompositeExpression(

--- a/tests/Doctrine/Tests/Common/Collections/ExpressionBuilderTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/ExpressionBuilderTest.php
@@ -146,7 +146,6 @@ class ExpressionBuilderTest extends TestCase
     {
         $expr = $this->builder->bitAnd('b', 4);
 
-        self::assertInstanceOf(Comparison::class, $expr);
         self::assertEquals(Comparison::BIT_AND, $expr->getOperator());
     }
 }

--- a/tests/Doctrine/Tests/Common/Collections/ExpressionBuilderTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/ExpressionBuilderTest.php
@@ -141,4 +141,12 @@ class ExpressionBuilderTest extends TestCase
         self::assertInstanceOf(Comparison::class, $expr);
         self::assertEquals(Comparison::ENDS_WITH, $expr->getOperator());
     }
+
+    public function testBitAnd() : void
+    {
+        $expr = $this->builder->bitAnd('b', 4);
+
+        self::assertInstanceOf(Comparison::class, $expr);
+        self::assertEquals(Comparison::BIT_AND, $expr->getOperator());
+    }
 }


### PR DESCRIPTION
I was missing a "bit and" comparison for building criteria expression on bit mask fields.

e.g bit mask:

1: imported
2: canceled
4: deleted
8: ...

foo = 5 (1+4)

$expressionBuilder->bitAnd('foo', 1) // true
$expressionBuilder->bitAnd('foo', 5) // true
$expressionBuilder->bitAnd('foo', 2) // false

Implementation and tests included.