### PR TITLE
[backport] Fix return type of Collection::key()

### DIFF
--- a/lib/Doctrine/Common/Collections/Collection.php
+++ b/lib/Doctrine/Common/Collections/Collection.php
@@ -179,9 +179,9 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
     /**
      * Gets the key/index of the element at the current iterator position.
      *
-     * @return int|string
+     * @return int|string|null
      *
-     * @psalm-return TKey
+     * @psalm-return TKey|null
      */
     public function key();
 


### PR DESCRIPTION
This PR proposes to backport the annotation fix by @enumag from master to 1.6.x. There's no functionality changed, it just fixes the docblock that was wrong in the first place (as `ArrayCollection::key()` does return `null` on empty collections).