### PR TITLE
Merge release 1.6.6 into 1.7.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Doctrine Collections
 
 [![Build Status](https://travis-ci.org/doctrine/collections.svg?branch=master)](https://travis-ci.org/doctrine/collections)
-[![Code Coverage](https://codecov.io/gh/doctrine/collections/branch/cache/graph/badge.svg)](https://codecov.io/gh/doctrine/collections/branch/master)
+[![Code Coverage](https://codecov.io/gh/doctrine/collections/branch/master/graph/badge.svg)](https://codecov.io/gh/doctrine/collections/branch/master)
 
 Collections Abstraction library
 

--- a/lib/Doctrine/Common/Collections/Collection.php
+++ b/lib/Doctrine/Common/Collections/Collection.php
@@ -179,9 +179,9 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
     /**
      * Gets the key/index of the element at the current iterator position.
      *
-     * @return int|string
+     * @return int|string|null
      *
-     * @psalm-return TKey
+     * @psalm-return TKey|null
      */
     public function key();
 


### PR DESCRIPTION
Release [1.6.6](https://github.com/doctrine/collections/milestone/13)



1.6.6
=====

- Total issues resolved: **0**
- Total pull requests resolved: **1**
- Total contributors: **1**

Bug
---

 - [241: &#91;backport&#93; Fix return type of Collection::key()](https://github.com/doctrine/collections/pull/241) thanks to @weirdan


