### PR TITLE
Enable strict comparison for arrays of scalar values (1.6.x)

### DIFF
--- a/lib/Doctrine/Common/Collections/Expr/ClosureExpressionVisitor.php
+++ b/lib/Doctrine/Common/Collections/Expr/ClosureExpressionVisitor.php
@@ -7,6 +7,7 @@ use Closure;
 use RuntimeException;
 use function in_array;
 use function is_array;
+use function is_scalar;
 use function iterator_to_array;
 use function method_exists;
 use function preg_match;
@@ -155,12 +156,16 @@ class ClosureExpressionVisitor extends ExpressionVisitor
 
             case Comparison::IN:
                 return static function ($object) use ($field, $value) : bool {
-                    return in_array(ClosureExpressionVisitor::getObjectFieldValue($object, $field), $value, true);
+                    $fieldValue = ClosureExpressionVisitor::getObjectFieldValue($object, $field);
+
+                    return in_array($fieldValue, $value, is_scalar($fieldValue));
                 };
 
             case Comparison::NIN:
                 return static function ($object) use ($field, $value) : bool {
-                    return ! in_array(ClosureExpressionVisitor::getObjectFieldValue($object, $field), $value, true);
+                    $fieldValue = ClosureExpressionVisitor::getObjectFieldValue($object, $field);
+
+                    return ! in_array($fieldValue, $value, is_scalar($fieldValue));
                 };
 
             case Comparison::CONTAINS:

--- a/tests/Doctrine/Tests/Common/Collections/ClosureExpressionVisitorTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/ClosureExpressionVisitorTest.php
@@ -143,6 +143,17 @@ class ClosureExpressionVisitorTest extends TestCase
         self::assertTrue($closure(new TestObject('04')));
     }
 
+    public function testWalkInComparisonObjects() : void
+    {
+        $closure = $this->visitor->walkComparison($this->builder->in('foo', [new TestObject(1), new TestObject(2), new TestObject(4)]));
+
+        self::assertTrue($closure(new TestObject(new TestObject(2))));
+        self::assertTrue($closure(new TestObject(new TestObject(1))));
+        self::assertFalse($closure(new TestObject(new TestObject(0))));
+        self::assertTrue($closure(new TestObject(new TestObject(4))));
+        self::assertFalse($closure(new TestObject(new TestObject('baz'))));
+    }
+
     public function testWalkNotInComparison() : void
     {
         $closure = $this->visitor->walkComparison($this->builder->notIn('foo', [1, 2, 3, '04']));
@@ -152,6 +163,17 @@ class ClosureExpressionVisitorTest extends TestCase
         self::assertTrue($closure(new TestObject(0)));
         self::assertTrue($closure(new TestObject(4)));
         self::assertFalse($closure(new TestObject('04')));
+    }
+
+    public function testWalkNotInComparisonObjects() : void
+    {
+        $closure = $this->visitor->walkComparison($this->builder->notIn('foo', [new TestObject(1), new TestObject(2), new TestObject(4)]));
+
+        self::assertFalse($closure(new TestObject(new TestObject(1))));
+        self::assertFalse($closure(new TestObject(new TestObject(2))));
+        self::assertTrue($closure(new TestObject(new TestObject(0))));
+        self::assertFalse($closure(new TestObject(new TestObject(4))));
+        self::assertTrue($closure(new TestObject(new TestObject('baz'))));
     }
 
     public function testWalkContainsComparison() : void


### PR DESCRIPTION
This was originally created for #168, but I branched from v1.6.x and merged the previous changes into this PR to keep it in line with v1.6. It's the exact same changes from 168 just merged on top of v1.6.x