### PR TITLE
Add method to create a new collection with fixed index

### DIFF
--- a/lib/Doctrine/Common/Collections/ArrayCollection.php
+++ b/lib/Doctrine/Common/Collections/ArrayCollection.php
@@ -438,4 +438,12 @@ class ArrayCollection implements Collection, Selectable
 
         return $this->createFrom($filtered);
     }
+
+    /**
+     * Rebuilds the collection with new keys
+     */
+    public function rebuildKeys()
+    {
+        return $this->createFrom(array_values($this->elements));
+    }
 }

--- a/tests/Doctrine/Tests/Common/Collections/ArrayCollectionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/ArrayCollectionTest.php
@@ -12,8 +12,29 @@ use Doctrine\Common\Collections\Collection;
  */
 class ArrayCollectionTest extends BaseArrayCollectionTest
 {
+    /**
+     * @param array $elements
+     *
+     * @return Collection|ArrayCollection
+     */
     protected function buildCollection(array $elements = []) : Collection
     {
         return new ArrayCollection($elements);
+    }
+
+    public function testRebuildKeys()
+    {
+        $collection = $this->buildCollection([
+            ['foo' => 1, 'bar' => 2],
+            ['foo' => 2, 'bar' => 4],
+            ['foo' => 2, 'bar' => 3],
+        ]);
+
+        $collection->remove(1);
+
+        $this->assertEquals([
+            ['foo' => 1, 'bar' => 2],
+            ['foo' => 2, 'bar' => 3],
+        ], $collection->rebuildKeys()->toArray());
     }
 }


### PR DESCRIPTION
Add a method to create a new collection with rebuilded keys.

If you use a method that unsets an element in the collection, the keys are not continuous anymore. This can create problems if you serialize an ArrayCollection as an JSON. For JavaScript this would be an object and not an array anymore.