### PR TITLE
Update index.rst

### DIFF
--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -152,7 +152,7 @@ filter
 ------
 
 Returns all the elements of this collection for which your callback function returns `true`.
-The order of the elements is preserved.
+The order and keys of the elements are preserved.
 
 .. code-block:: php
     $collection = new ArrayCollection([1, 2, 3]);


### PR DESCRIPTION
Since `ArrayCollection::filter` uses `array_filter` under the hood, the filtering keeps array indices untouched.
This caused me quite some time debugging, because I wasn't expecting the filtered collection would have gaps between array indices (that led to serializing to an object instead an array, in JSON etc.)