### PR TITLE
PHP 8.0 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "php": "^7.1.3 || ^8.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.0",
+        "phpunit/phpunit": "^7.5 || ^9.1.5",
         "doctrine/coding-standard": "^6.0",
         "phpstan/phpstan-shim": "^0.9.2",
         "vimeo/psalm": "^3.8.1"

--- a/tests/Doctrine/Tests/Common/Collections/BaseCollectionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/BaseCollectionTest.php
@@ -203,7 +203,7 @@ abstract class BaseCollectionTest extends TestCase
         $this->collection[] = 'three';
 
         $slice = $this->collection->slice(0, 1);
-        self::assertInternalType('array', $slice);
+        self::assertIsArray($slice);
         self::assertEquals(['one'], $slice);
 
         $slice = $this->collection->slice(1);


### PR DESCRIPTION
- assertInternalType => assertIsArray
- PHPUnit 7.5 and 9.1 to allow for PHP 8 

These are just changes to the CI pipeline to make the nightly / PHP 8 build run. Does not need a new minor version.