### PR TITLE
Allow accessing fields with a method of the same name

### DIFF
--- a/lib/Doctrine/Common/Collections/Expr/ClosureExpressionVisitor.php
+++ b/lib/Doctrine/Common/Collections/Expr/ClosureExpressionVisitor.php
@@ -28,8 +28,8 @@ class ClosureExpressionVisitor extends ExpressionVisitor
 {
     /**
      * Accesses the field of a given object. This field has to be public
-     * directly or indirectly (through an accessor get*, is*, or a magic
-     * method, __get, __call).
+     * directly or indirectly (through an accessor of the same name, get*, is*,
+     * or a magic method, __get, __call).
      *
      * @param object|array $object
      *
@@ -39,6 +39,10 @@ class ClosureExpressionVisitor extends ExpressionVisitor
     {
         if (is_array($object)) {
             return $object[$field];
+        }
+
+        if (method_exists($object, $field)) {
+            return $object->$field();
         }
 
         $accessors = ['get', 'is'];

--- a/tests/Doctrine/Tests/Common/Collections/ClosureExpressionVisitorTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/ClosureExpressionVisitorTest.php
@@ -40,6 +40,13 @@ class ClosureExpressionVisitorTest extends TestCase
         self::assertTrue($this->visitor->getObjectFieldValue($object, 'isBaz'));
     }
 
+    public function testGetObjectFieldValueAccessorWithoutPrefix() : void
+    {
+        $object = new TestObject(1, 2, 3, true);
+
+        self::assertTrue($this->visitor->getObjectFieldValue($object, 'quux'));
+    }
+
     public function testGetObjectFieldValueIsAccessorCamelCase() : void
     {
         $object = new TestObjectNotCamelCase(1);
@@ -279,18 +286,22 @@ class TestObject
     /** @var mixed */
     private $qux;
 
+    /** @var mixed */
+    private $quux;
+
     /**
      * @param mixed $foo
      * @param mixed $bar
      * @param mixed $baz
      * @param mixed $qux
      */
-    public function __construct($foo = null, $bar = null, $baz = null, $qux = null)
+    public function __construct($foo = null, $bar = null, $baz = null, $qux = null, $quux = null)
     {
         $this->foo = $foo;
         $this->bar = $bar;
         $this->baz = $baz;
         $this->qux = $qux;
+        $this->quux = $qux;
     }
 
     /**
@@ -327,6 +338,14 @@ class TestObject
     public function isBaz()
     {
         return $this->baz;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function quux()
+    {
+        return $this->quux;
     }
 }
 


### PR DESCRIPTION
Running a matching over a criteria lead me to an error that I cannot access the field. I then discovered the run lacks checking the object for methods with the same name as the field has. I find it a common practice to ommit the get keyword in getter methods. Thus this PR