### PR TITLE
Use explicit `@return` when implementing base PHP types

### DIFF
--- a/lib/Doctrine/Common/Collections/AbstractLazyCollection.php
+++ b/lib/Doctrine/Common/Collections/AbstractLazyCollection.php
@@ -3,6 +3,7 @@
 namespace Doctrine\Common\Collections;
 
 use Closure;
+use Traversable;
 
 /**
  * Lazy collection that is backed by a concrete collection
@@ -27,6 +28,8 @@ abstract class AbstractLazyCollection implements Collection
 
     /**
      * {@inheritDoc}
+     *
+     * @return int
      */
     public function count()
     {
@@ -275,6 +278,10 @@ abstract class AbstractLazyCollection implements Collection
 
     /**
      * {@inheritDoc}
+     *
+     * @return Traversable<int|string, mixed>
+     *
+     * @psalm-return Traversable<TKey,T>
      */
     public function getIterator()
     {
@@ -285,6 +292,8 @@ abstract class AbstractLazyCollection implements Collection
 
     /**
      * {@inheritDoc}
+     *
+     * @return bool
      *
      * @psalm-param TKey $offset
      */

--- a/lib/Doctrine/Common/Collections/ArrayCollection.php
+++ b/lib/Doctrine/Common/Collections/ArrayCollection.php
@@ -5,6 +5,7 @@ namespace Doctrine\Common\Collections;
 use ArrayIterator;
 use Closure;
 use Doctrine\Common\Collections\Expr\ClosureExpressionVisitor;
+use Traversable;
 
 use function array_filter;
 use function array_key_exists;
@@ -169,6 +170,8 @@ class ArrayCollection implements Collection, Selectable
      *
      * {@inheritDoc}
      *
+     * @return bool
+     *
      * @psalm-param TKey $offset
      */
     public function offsetExists($offset)
@@ -280,6 +283,8 @@ class ArrayCollection implements Collection, Selectable
 
     /**
      * {@inheritDoc}
+     *
+     * @return int
      */
     public function count()
     {
@@ -318,9 +323,11 @@ class ArrayCollection implements Collection, Selectable
     }
 
     /**
-     * Required by interface IteratorAggregate.
-     *
      * {@inheritDoc}
+     *
+     * @return Traversable<int|string, mixed>
+     *
+     * @psalm-return Traversable<TKey,T>
      */
     public function getIterator()
     {


### PR DESCRIPTION
This PR replaces `{@inheritdoc}` that relate to internal PHP types by explicit `@return` annotations.

This removes the need to rely on external knowledge to get some understanding of the annotations.

Note that similar explicit annotations are already used in some places in the codebase.