### PR TITLE
PHPStan already supports array-key as template type variable bound

### DIFF
--- a/lib/Doctrine/Common/Collections/AbstractLazyCollection.php
+++ b/lib/Doctrine/Common/Collections/AbstractLazyCollection.php
@@ -8,7 +8,6 @@ use Traversable;
 /**
  * Lazy collection that is backed by a concrete collection
  *
- * @phpstan-template TKey
  * @psalm-template TKey of array-key
  * @psalm-template T
  * @template-implements Collection<TKey,T>

--- a/lib/Doctrine/Common/Collections/ArrayCollection.php
+++ b/lib/Doctrine/Common/Collections/ArrayCollection.php
@@ -35,7 +35,6 @@ use const ARRAY_FILTER_USE_BOTH;
  * serialize a collection use {@link toArray()} and reconstruct the collection
  * manually.
  *
- * @phpstan-template TKey
  * @psalm-template TKey of array-key
  * @psalm-template T
  * @template-implements Collection<TKey,T>
@@ -92,7 +91,6 @@ class ArrayCollection implements Collection, Selectable
      *
      * @psalm-template K of array-key
      * @psalm-template V
-     * @phpstan-template K
      *
      * @psalm-param array<K,V> $elements
      * @psalm-return static<K,V>

--- a/lib/Doctrine/Common/Collections/Collection.php
+++ b/lib/Doctrine/Common/Collections/Collection.php
@@ -24,7 +24,6 @@ use IteratorAggregate;
  * position unless you explicitly positioned it before. Prefer iteration with
  * external iterators.
  *
- * @phpstan-template TKey
  * @psalm-template TKey of array-key
  * @psalm-template T
  * @template-extends IteratorAggregate<TKey, T>

--- a/lib/Doctrine/Common/Collections/Selectable.php
+++ b/lib/Doctrine/Common/Collections/Selectable.php
@@ -14,7 +14,6 @@ namespace Doctrine\Common\Collections;
  * this API can implement efficient database access without having to ask the
  * EntityManager or Repositories.
  *
- * @phpstan-template TKey
  * @psalm-template TKey as array-key
  * @psalm-template T
  */

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -10,5 +10,5 @@ parameters:
                 - 'lib/Doctrine/Common/Collections/ArrayCollection.php'
                 - 'lib/Doctrine/Common/Collections/Criteria.php'
         -
-            message: '~Array \(array\<TKey, T\>\) does not accept key int\.~'
+            message: '~Array \(array\<TKey of \(int\|string\), T\>\) does not accept key int\.~'
             path: 'lib/Doctrine/Common/Collections/ArrayCollection.php'

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -49,5 +49,10 @@
         <RawObjectIteration errorLevel="info" />
 
         <InvalidStringClass errorLevel="info" />
+        <UnsafeGenericInstantiation>
+            <errorLevel type="suppress">
+                <file name="lib/Doctrine/Common/Collections/ArrayCollection.php"/>
+            </errorLevel>
+        </UnsafeGenericInstantiation>
     </issueHandlers>
 </psalm>


### PR DESCRIPTION
It's now even counter-productive to leave `@phpstan-template` there.