### PR TITLE
Update Criteria.php

### DIFF
--- a/lib/Doctrine/Common/Collections/Criteria.php
+++ b/lib/Doctrine/Common/Collections/Criteria.php
@@ -19,7 +19,7 @@ class Criteria
 
     public const DESC = 'DESC';
 
-    /** @var ExpressionBuilder|null */
+    /** @var ExpressionBuilder */
     private static $expressionBuilder;
 
     /** @var Expression|null */


### PR DESCRIPTION
When using the expr function, it return `self::$expressionBuilder` which is typed |null. IDE shows possible null exeption occur. However `public static function expr()` can never return null as if self::$expressionBuilder is null, it initialize it.

The 2 solutions to manage this are:
- Type `self::$expressionBuilder` not nullable
- Type the function return type as `ExpressionBuilder`