### PR TITLE
Add ReturnTypeWillChange where necessary

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.4"
+          - "8.0"
 
     steps:
       - name: "Checkout"

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.4"
+          - "8.0"
 
     steps:
       - name: "Checkout code"
@@ -44,7 +44,7 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.4"
+          - "8.0"
 
     steps:
       - name: "Checkout code"

--- a/lib/Doctrine/Common/Collections/AbstractLazyCollection.php
+++ b/lib/Doctrine/Common/Collections/AbstractLazyCollection.php
@@ -3,6 +3,7 @@
 namespace Doctrine\Common\Collections;
 
 use Closure;
+use ReturnTypeWillChange;
 use Traversable;
 
 /**
@@ -30,6 +31,7 @@ abstract class AbstractLazyCollection implements Collection
      *
      * @return int
      */
+    #[ReturnTypeWillChange]
     public function count()
     {
         $this->initialize();
@@ -282,6 +284,7 @@ abstract class AbstractLazyCollection implements Collection
      *
      * @psalm-return Traversable<TKey,T>
      */
+    #[ReturnTypeWillChange]
     public function getIterator()
     {
         $this->initialize();
@@ -296,6 +299,7 @@ abstract class AbstractLazyCollection implements Collection
      *
      * @psalm-param TKey $offset
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         $this->initialize();
@@ -312,6 +316,7 @@ abstract class AbstractLazyCollection implements Collection
      *
      * @psalm-param TKey $offset
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         $this->initialize();
@@ -326,6 +331,7 @@ abstract class AbstractLazyCollection implements Collection
      *
      * @psalm-param TKey $offset
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         $this->initialize();
@@ -337,6 +343,7 @@ abstract class AbstractLazyCollection implements Collection
      *
      * @psalm-param TKey $offset
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         $this->initialize();

--- a/lib/Doctrine/Common/Collections/ArrayCollection.php
+++ b/lib/Doctrine/Common/Collections/ArrayCollection.php
@@ -5,6 +5,7 @@ namespace Doctrine\Common\Collections;
 use ArrayIterator;
 use Closure;
 use Doctrine\Common\Collections\Expr\ClosureExpressionVisitor;
+use ReturnTypeWillChange;
 use Traversable;
 
 use function array_filter;
@@ -172,6 +173,7 @@ class ArrayCollection implements Collection, Selectable
      *
      * @psalm-param TKey $offset
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return $this->containsKey($offset);
@@ -184,6 +186,7 @@ class ArrayCollection implements Collection, Selectable
      *
      * @psalm-param TKey $offset
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->get($offset);
@@ -194,6 +197,7 @@ class ArrayCollection implements Collection, Selectable
      *
      * {@inheritDoc}
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (! isset($offset)) {
@@ -212,6 +216,7 @@ class ArrayCollection implements Collection, Selectable
      *
      * @psalm-param TKey $offset
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         $this->remove($offset);
@@ -284,6 +289,7 @@ class ArrayCollection implements Collection, Selectable
      *
      * @return int
      */
+    #[ReturnTypeWillChange]
     public function count()
     {
         return count($this->elements);
@@ -327,6 +333,7 @@ class ArrayCollection implements Collection, Selectable
      *
      * @psalm-return Traversable<TKey,T>
      */
+    #[ReturnTypeWillChange]
     public function getIterator()
     {
         return new ArrayIterator($this->elements);

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -12,3 +12,6 @@ parameters:
         -
             message: '~Array \(array\<TKey of \(int\|string\), T\>\) does not accept key int\.~'
             path: 'lib/Doctrine/Common/Collections/ArrayCollection.php'
+
+        # This class is new in PHP 8.1 and PHPStan does not know it yet.
+        - '/Attribute class ReturnTypeWillChange does not exist./'

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -54,5 +54,12 @@
                 <file name="lib/Doctrine/Common/Collections/ArrayCollection.php"/>
             </errorLevel>
         </UnsafeGenericInstantiation>
+
+        <UndefinedAttributeClass>
+            <errorLevel type="suppress">
+                <!-- This class is new in PHP 8.1 and Psalm does not know it yet. -->
+                <referencedClass name="ReturnTypeWillChange"/>
+            </errorLevel>
+        </UndefinedAttributeClass>
     </issueHandlers>
 </psalm>


### PR DESCRIPTION
PHP 8.1 will issue a deprecation for implementations of several core interfaces without a return type declaration. This PR proposes to suppress that deprecation for now because we cannot add those return types without breaking BC and bumping the PHP requirement.