### PR TITLE
Revert "Update Psalm and fix a few issues"

### DIFF
--- a/lib/Doctrine/Common/Collections/AbstractLazyCollection.php
+++ b/lib/Doctrine/Common/Collections/AbstractLazyCollection.php
@@ -294,8 +294,6 @@ abstract class AbstractLazyCollection implements Collection
     /**
      * {@inheritDoc}
      *
-     * @psalm-param TKey $offset
-     *
      * @return bool
      */
     #[ReturnTypeWillChange]
@@ -308,9 +306,6 @@ abstract class AbstractLazyCollection implements Collection
 
     /**
      * {@inheritDoc}
-     *
-     * @param int|string $offset
-     * @psalm-param TKey $offset
      *
      * @return mixed
      */
@@ -325,9 +320,6 @@ abstract class AbstractLazyCollection implements Collection
     /**
      * {@inheritDoc}
      *
-     * @param mixed $value
-     * @psalm-param TKey $offset
-     *
      * @return void
      */
     #[ReturnTypeWillChange]
@@ -339,8 +331,6 @@ abstract class AbstractLazyCollection implements Collection
 
     /**
      * {@inheritDoc}
-     *
-     * @psalm-param TKey $offset
      *
      * @return void
      */

--- a/lib/Doctrine/Common/Collections/ArrayCollection.php
+++ b/lib/Doctrine/Common/Collections/ArrayCollection.php
@@ -167,8 +167,6 @@ class ArrayCollection implements Collection, Selectable
      *
      * {@inheritDoc}
      *
-     * @psalm-param TKey $offset
-     *
      * @return bool
      */
     #[ReturnTypeWillChange]
@@ -181,8 +179,6 @@ class ArrayCollection implements Collection, Selectable
      * Required by interface ArrayAccess.
      *
      * {@inheritDoc}
-     *
-     * @psalm-param TKey $offset
      *
      * @return mixed
      */
@@ -215,8 +211,6 @@ class ArrayCollection implements Collection, Selectable
      * Required by interface ArrayAccess.
      *
      * {@inheritDoc}
-     *
-     * @psalm-param TKey $offset
      *
      * @return void
      */


### PR DESCRIPTION
This selectively reverts commit
6476b7e127f36dbc0989a65474b7a3b711f085ed, now that PHPStan understands
array-key. Note that the introduced return types are preserved because
it should be that way whenever the #[ReturnTypeWillChange] attribute
appears.

Another big reason to revert this is that the phpdoc for offsetSet is
wrong, it should have been TKey|null, not just TKey.