### PR TITLE
Unit test improvements

### DIFF
--- a/tests/Doctrine/Tests/Common/Collections/BaseArrayCollectionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/BaseArrayCollectionTest.php
@@ -296,7 +296,7 @@ abstract class BaseArrayCollectionTest extends TestCase
         self::assertSame(null, $collection->get('non-existent'), 'Get non existent element');
     }
 
-    public function testMatchingWithSortingPreservesyKeys(): void
+    public function testMatchingWithSortingPreserveKeys(): void
     {
         $object1 = new stdClass();
         $object2 = new stdClass();

--- a/tests/Doctrine/Tests/Common/Collections/ClosureExpressionVisitorTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/ClosureExpressionVisitorTest.php
@@ -371,8 +371,7 @@ class ClosureExpressionVisitorTest extends TestCase
 
         usort($objects, $sort);
 
-        self::assertSame($firstElement, $objects[0]);
-        self::assertSame($secondElement, $objects[1]);
+        self::assertSame([$firstElement, $secondElement], $objects);
     }
 
     public function testSortDelegate(): void

--- a/tests/Doctrine/Tests/Common/Collections/Expr/ComparisonTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/Expr/ComparisonTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Common\Collections\Expr;
+
+use Doctrine\Common\Collections\Expr\Comparison;
+use Doctrine\Common\Collections\Expr\ExpressionVisitor;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversDefaultClass \Doctrine\Common\Collections\Expr\Comparison
+ */
+class ComparisonTest extends TestCase
+{
+    /**
+     * @covers ::visit
+     */
+    public function testVisit(): void
+    {
+        $callableExpected = static function (): void {
+        };
+
+        $comparison = new Comparison('foo', Comparison::EQ, 3);
+
+        $visitor = self::createMock(ExpressionVisitor::class);
+        $visitor->expects(self::once())
+            ->method('walkComparison')
+            ->with($comparison)
+            ->willReturn($callableExpected);
+
+        self::assertSame($callableExpected, $comparison->visit($visitor));
+    }
+}


### PR DESCRIPTION
# Unit test improvements

## Increase code coverage
- Doctrine\Common\Collections\Expr\ClosureExpressionVisitor
- Doctrine\Common\Collections\Expr\Comparison
- Doctrine\Common\Collections\Expr\ExpressionVisitor

## Fix test name
- Doctrine\Tests\Common\Collections\BaseArrayCollectionTest::testMatchingWithSortingPreservesyKeys to Doctrine\Tests\Common\Collections\BaseArrayCollectionTest::testMatchingWithSortingPreserveKeys

## New tests
Doctrine\Tests\Common\Collections\ClosureExpressionVisitorTest::testGetObjectFieldValueArrayAccess:
https://github.com/doctrine/collections/blob/534712ad689fed8c2609f86e6f3466fb24eb4a6d/lib/Doctrine/Common/Collections/Expr/ClosureExpressionVisitor.php#L68

Doctrine\Tests\Common\Collections\ClosureExpressionVisitorTest::testGetObjectFieldValuePublicPropertyIsNull:
https://github.com/doctrine/collections/blob/534712ad689fed8c2609f86e6f3466fb24eb4a6d/lib/Doctrine/Common/Collections/Expr/ClosureExpressionVisitor.php#L88

Doctrine\Tests\Common\Collections\ClosureExpressionVisitorTest::testSortByFieldKeepOrderWhenSameValue:
https://github.com/doctrine/collections/blob/534712ad689fed8c2609f86e6f3466fb24eb4a6d/lib/Doctrine/Common/Collections/Expr/ClosureExpressionVisitor.php#L98

Doctrine\Tests\Common\Collections\ClosureExpressionVisitorTest::testWalkMemberOfComparisonWithObject:
https://github.com/doctrine/collections/blob/534712ad689fed8c2609f86e6f3466fb24eb4a6d/lib/Doctrine/Common/Collections/Expr/ClosureExpressionVisitor.php#L178

Doctrine\Tests\Common\Collections\ClosureExpressionVisitorTest::testWalkUnknownOperatorComparisonThrowException:
https://github.com/doctrine/collections/blob/534712ad689fed8c2609f86e6f3466fb24eb4a6d/lib/Doctrine/Common/Collections/Expr/ClosureExpressionVisitor.php#L195

Doctrine\Tests\Common\Collections\CollectionTest::testMatchingCallable:
https://github.com/doctrine/collections/blob/534712ad689fed8c2609f86e6f3466fb24eb4a6d/lib/Doctrine/Common/Collections/Expr/ClosureExpressionVisitor.php#L204

Doctrine\Tests\Common\Collections\ClosureExpressionVisitorTest::testWalkUnknownCompositeExpressionThrowException:
https://github.com/doctrine/collections/blob/534712ad689fed8c2609f86e6f3466fb24eb4a6d/lib/Doctrine/Common/Collections/Expr/ClosureExpressionVisitor.php#L226

Doctrine\Tests\Common\Collections\Expr\ComparisonTest::testVisit:
https://github.com/doctrine/collections/blob/534712ad689fed8c2609f86e6f3466fb24eb4a6d/lib/Doctrine/Common/Collections/Expr/Comparison.php#L69

Doctrine\Tests\Common\Collections\CollectionTest::testMatchingCallable:
https://github.com/doctrine/collections/blob/534712ad689fed8c2609f86e6f3466fb24eb4a6d/lib/Doctrine/Common/Collections/Expr/ExpressionVisitor.php#L51-L52

Doctrine\Tests\Common\Collections\ClosureExpressionVisitorTest::testWalkOrAndCompositeExpression,
Doctrine\Tests\Common\Collections\ClosureExpressionVisitorTest::testWalkAndOrCompositeExpression:
https://github.com/doctrine/collections/blob/534712ad689fed8c2609f86e6f3466fb24eb4a6d/lib/Doctrine/Common/Collections/Expr/ExpressionVisitor.php#L54-L55

Doctrine\Tests\Common\Collections\CollectionTest::testMatchingUnknownThrowException:
https://github.com/doctrine/collections/blob/534712ad689fed8c2609f86e6f3466fb24eb4a6d/lib/Doctrine/Common/Collections/Expr/ExpressionVisitor.php#L58