### PR TITLE
Admit no prefix as getter

### DIFF
--- a/lib/Doctrine/Common/Collections/Expr/ClosureExpressionVisitor.php
+++ b/lib/Doctrine/Common/Collections/Expr/ClosureExpressionVisitor.php
@@ -42,7 +42,7 @@ class ClosureExpressionVisitor extends ExpressionVisitor
             return $object[$field];
         }
 
-        $accessors = ['get', 'is'];
+        $accessors = ['get', 'is', ''];
 
         foreach ($accessors as $accessor) {
             $accessor .= $field;

--- a/tests/Doctrine/Tests/Common/Collections/ClosureExpressionVisitorTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/ClosureExpressionVisitorTest.php
@@ -81,6 +81,14 @@ class ClosureExpressionVisitorTest extends TestCase
         self::assertEquals(2, $this->visitor->getObjectFieldValue($object, 'fooBar'));
     }
 
+    public function testGetObjectFieldValueBlankAccessor(): void
+    {
+        $object = new TestObjectBlankGetter(1);
+
+        self::assertEquals(1, $this->visitor->getObjectFieldValue($object, 'foobar'));
+        self::assertEquals(1, $this->visitor->getObjectFieldValue($object, 'fooBar'));
+    }
+
     public function testGetObjectFieldValueMagicCallMethod(): void
     {
         $object = new TestObject(1, 2, true, 3);
@@ -539,5 +547,21 @@ class TestObjectBothPublic
     public function getFooBar()
     {
         return $this->foo_bar;
+    }
+}
+
+class TestObjectBlankGetter
+{
+    /** @var int|null */
+    public $fooBar;
+
+    public function __construct(?int $fooBar = null)
+    {
+        $this->fooBar = $fooBar;
+    }
+
+    public function fooBar(): ?int
+    {
+        return $this->fooBar;
     }
 }


### PR DESCRIPTION
As an alternative to reflection or closure hacking to properly get the private property whenever not using `getXXX()` `isXXX()` accessors,
just added blank prefix '' to call DDD oriented notation (ex. `id()` )

Is adverted to who want to use this in a future, that if the method returns a valueObject, to use ::CONTAINS operator that casts to string, although the VO must be stringable