### PR TITLE
Add toList() function

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+patreon: phpdoctrine
+tidelift: packagist/doctrine%2Fcollections
+custom: https://www.doctrine-project.org/sponsorship.html

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Collections Abstraction library
 
 ### v1.6.1
 
-This release, combined with the release of [`doctrine/collections` `v1.6.1`](https://github.com/doctrine/collections/releases/tag/v1.6.1),
+This release, combined with the release of [`doctrine/annotations` `v1.6.1`](https://github.com/doctrine/annotations/releases/tag/v1.6.1),
 fixes an issue where parsing annotations was not possible
 for classes within `doctrine/collections`.
 

--- a/UPGRADING-2.0.md
+++ b/UPGRADING-2.0.md
@@ -1,0 +1,61 @@
+Upgrading from 1.x to 2.0
+=========================
+
+
+## BC breaking changes
+
+Native parameter and return types were added.
+As a consequence, some signatures were changed and will have to be adjusted in sub-classes.
+
+
+Note that in order to keep compatibility with both 1.x and 2.x versions, extending code would have to omit the added parameter types and add the return types. This would only work in PHP 7.2+ which is the first version featuring [parameter widening](https://wiki.php.net/rfc/parameter-no-type-variance).
+
+
+You can find a list of major changes to public API below.
+
+#### Doctrine\Common\Collections\Collection
+
+|             before             |                  after                         |
+|-------------------------------:|:-----------------------------------------------|
+| add($element)                  | add($element): bool                            |
+| clear()                        | clear(): void                                  |
+| contains($element)             | contains($element): bool                       |
+| isEmpty()                      | isEmpty(): bool                                |
+| removeElement($element)        | removeElement($element): bool                  |
+| containsKey($key)              | containsKey($key): bool                        |
+| getKeys()                      | getKeys(): array                               |
+| getValues()                    | getValues(): array                             |
+| set($key, $value)              | set($key, $value): void                        |
+| toArray()                      | toArray(): array                               |
+| exists(Closure $p)             | exists(Closure $p): bool                       |
+| filter(Closure $p)             | filter(Closure $p): self                       |
+| forAll(Closure $p)             | forAll(Closure $p): bool                       |
+| map(Closure $func)             | map(Closure $func): self                       |
+| partition(Closure $p)          | partition(Closure $p): array                   |
+| slice($offset, $length = null) | slice(int $offset, ?int $length = null): array |
+| count()                        | count(): int                                   |
+| getIterator()                  | getIterator(): \Traversable                    |
+| offsetSet($offset, $value)     | offsetSet($offset, $value): void               |
+| offsetUnset($offset)           | offsetUnset($offset): void                     |
+| offsetExists($offset)          | offsetExists($offset): bool                    |
+
+#### Doctrine\Common\Collections\AbstractLazyCollection
+
+|      before     |         after         |
+|----------------:|:----------------------|
+| isInitialized() | isInitialized(): bool |
+| initialize()    | initialize(): void    |
+| doInitialize()  | doInitialize(): void  |
+
+#### Doctrine\Common\Collections\ArrayCollection
+
+|            before           |               after               |
+|----------------------------:|:----------------------------------|
+| createFrom(array $elements) | createFrom(array $elements): self |
+| __toString()                | __toString(): string              |
+
+#### Doctrine\Common\Collections\Selectable
+
+|             before           |                   after                  |
+|-----------------------------:|:-----------------------------------------|
+| matching(Criteria $criteria) | matching(Criteria $criteria): Collection |

--- a/UPGRADING-2.0.md
+++ b/UPGRADING-2.0.md
@@ -1,15 +1,12 @@
 Upgrading from 1.x to 2.0
 =========================
 
-
 ## BC breaking changes
 
 Native parameter and return types were added.
 As a consequence, some signatures were changed and will have to be adjusted in sub-classes.
 
-
 Note that in order to keep compatibility with both 1.x and 2.x versions, extending code would have to omit the added parameter types and add the return types. This would only work in PHP 7.2+ which is the first version featuring [parameter widening](https://wiki.php.net/rfc/parameter-no-type-variance).
-
 
 You can find a list of major changes to public API below.
 

--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -302,17 +302,17 @@ matching
 --------
 
 Selects all elements from a selectable that match the expression and
-returns a new collection containing these elements.
+returns a new collection containing these elements and preserved keys.
 
 .. code-block:: php
     use Doctrine\Common\Collections\Criteria;
     use Doctrine\Common\Collections\Expr\Comparison;
 
     $collection = new ArrayCollection([
-        [
+        'wage' => [
             'name' => 'jwage',
         ],
-        [
+        'roman' => [
             'name' => 'romanb',
         ],
     ]);
@@ -323,6 +323,6 @@ returns a new collection containing these elements.
 
     $criteria->where($expr);
 
-    $matched = $collection->matching($criteria); // ['jwage']
+    $matchingCollection = $collection->matching($criteria); // [ 'wage' => [ 'name' => 'jwage' ]]
 
 You can read more about expressions :ref:`here <expressions>`.

--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -229,6 +229,18 @@ Applies the given function to each element in the collection and returns a new c
         return $value + 1;
     }); // [2, 3, 4]
 
+reduce
+------
+
+Applies iteratively the given function to each element in the collection, so as to reduce the collection to a single value.
+
+.. code-block:: php
+    $collection = new ArrayCollection([1, 2, 3]);
+
+    $reduce = $collection->reduce(function(int $accumulator, int $value): int {
+        return $accumulator + $value;
+    }, 0); // 6
+
 next
 ----
 

--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -148,15 +148,15 @@ Tests for the existence of an element that satisfies the given predicate.
         return $value === 'first';
     }); // true
 
-findOne
--------
+findFirst
+---------
 
 Returns the first element of this collection that satisfies the given predicate.
 
 .. code-block:: php
     $collection = new Collection([1, 2, 3, 2, 1]);
 
-    $one = $collection->findOne(function(int $key, int $value): bool {
+    $one = $collection->findFirst(function(int $key, int $value): bool {
         return $value > 2 && $key > 1;
     }); // 3
 

--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -148,6 +148,18 @@ Tests for the existence of an element that satisfies the given predicate.
         return $value === 'first';
     }); // true
 
+findOne
+-------
+
+Returns the first element of this collection that satisfies the given predicate.
+
+.. code-block:: php
+    $collection = new Collection([1, 2, 3, 2, 1]);
+
+    $one = $collection->findOne(function(int $key, int $value): bool {
+        return $value > 2 && $key > 1;
+    }); // 3
+
 filter
 ------
 

--- a/docs/en/serialization.rst
+++ b/docs/en/serialization.rst
@@ -1,0 +1,29 @@
+Serialization
+=============
+
+Using (un-)serialize() on a collection is not a supported use-case
+and may break when changes on the collection's internals happen in the future.
+If a collection needs to be serialized, use ``toArray()`` and reconstruct
+the collection manually.
+
+.. code-block:: php
+
+    $collection = new ArrayCollection([1, 2, 3]);
+    $serialized = serialize($collection->toArray());
+
+A reconstruction is also necessary when the collection contains objects with
+infinite recursion of dependencies like in this ``json_serialize()`` example:
+
+.. code-block:: php
+
+    $foo = new Foo();
+    $bar = new Bar();
+
+    $foo->setBar($bar);
+    $bar->setFoo($foo);
+
+    $collection = new ArrayCollection([$foo]);
+    $json       = json_serialize($collection->toArray()); // recursion detected
+
+Serializer libraries can be used to create the serialization-output to prevent
+errors.

--- a/docs/en/sidebar.rst
+++ b/docs/en/sidebar.rst
@@ -6,3 +6,4 @@
     expression-builder
     derived-collections
     lazy-collections
+    serialization

--- a/infection.json.dist
+++ b/infection.json.dist
@@ -1,0 +1,14 @@
+{
+    "timeout": 2,
+    "source": {
+        "directories": [
+            "lib"
+        ]
+    },
+    "logs": {
+        "text": "infection.log"
+    },
+    "mutators": {
+        "@default": true
+    }
+}

--- a/lib/Doctrine/Common/Collections/AbstractLazyCollection.php
+++ b/lib/Doctrine/Common/Collections/AbstractLazyCollection.php
@@ -219,6 +219,13 @@ abstract class AbstractLazyCollection implements Collection
         return $this->collection->exists($p);
     }
 
+    public function findOne(Closure $func)
+    {
+        $this->initialize();
+
+        return $this->collection->findOne($func);
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/lib/Doctrine/Common/Collections/AbstractLazyCollection.php
+++ b/lib/Doctrine/Common/Collections/AbstractLazyCollection.php
@@ -160,6 +160,16 @@ abstract class AbstractLazyCollection implements Collection
     }
 
     /**
+     * @return list<T>
+     */
+    public function toList(): array
+    {
+        $this->initialize();
+
+        return $this->collection->toList();
+    }
+
+    /**
      * {@inheritDoc}
      */
     public function first()

--- a/lib/Doctrine/Common/Collections/AbstractLazyCollection.php
+++ b/lib/Doctrine/Common/Collections/AbstractLazyCollection.php
@@ -219,11 +219,14 @@ abstract class AbstractLazyCollection implements Collection
         return $this->collection->exists($p);
     }
 
-    public function findOne(Closure $func)
+    /**
+     * {@inheritDoc}
+     */
+    public function findFirst(Closure $func)
     {
         $this->initialize();
 
-        return $this->collection->findOne($func);
+        return $this->collection->findFirst($func);
     }
 
     /**

--- a/lib/Doctrine/Common/Collections/AbstractLazyCollection.php
+++ b/lib/Doctrine/Common/Collections/AbstractLazyCollection.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Common\Collections;
 
 use Closure;

--- a/lib/Doctrine/Common/Collections/ArrayCollection.php
+++ b/lib/Doctrine/Common/Collections/ArrayCollection.php
@@ -52,7 +52,7 @@ class ArrayCollection implements Collection, Selectable
      * @psalm-var array<TKey,T>
      * @var mixed[]
      */
-    private $elements;
+    private $elements = [];
 
     /**
      * Initializes a new ArrayCollection.

--- a/lib/Doctrine/Common/Collections/ArrayCollection.php
+++ b/lib/Doctrine/Common/Collections/ArrayCollection.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Common\Collections;
 
 use ArrayIterator;

--- a/lib/Doctrine/Common/Collections/ArrayCollection.php
+++ b/lib/Doctrine/Common/Collections/ArrayCollection.php
@@ -75,6 +75,17 @@ class ArrayCollection implements Collection, Selectable
     }
 
     /**
+     * @return list<T>
+     */
+    public function toList(): array
+    {
+        if (\PHP_VERSION_ID >= 80100 && \array_is_list($this->elements)) {
+            return $this->elements;
+        }
+        return \array_values($this->elements);
+    }
+
+    /**
      * {@inheritDoc}
      */
     public function first()

--- a/lib/Doctrine/Common/Collections/ArrayCollection.php
+++ b/lib/Doctrine/Common/Collections/ArrayCollection.php
@@ -14,6 +14,7 @@ use function array_filter;
 use function array_key_exists;
 use function array_keys;
 use function array_map;
+use function array_reduce;
 use function array_reverse;
 use function array_search;
 use function array_slice;
@@ -352,6 +353,14 @@ class ArrayCollection implements Collection, Selectable
     public function map(Closure $func)
     {
         return $this->createFrom(array_map($func, $this->elements));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function reduce(Closure $func, $initial = null)
+    {
+        return array_reduce($this->elements, $func, $initial);
     }
 
     /**

--- a/lib/Doctrine/Common/Collections/ArrayCollection.php
+++ b/lib/Doctrine/Common/Collections/ArrayCollection.php
@@ -450,7 +450,7 @@ class ArrayCollection implements Collection, Selectable
         $length = $criteria->getMaxResults();
 
         if ($offset || $length) {
-            $filtered = array_slice($filtered, (int) $offset, $length);
+            $filtered = array_slice($filtered, (int) $offset, $length, true);
         }
 
         return $this->createFrom($filtered);

--- a/lib/Doctrine/Common/Collections/ArrayCollection.php
+++ b/lib/Doctrine/Common/Collections/ArrayCollection.php
@@ -445,7 +445,9 @@ class ArrayCollection implements Collection, Selectable
                 $next = ClosureExpressionVisitor::sortByField($field, $ordering === Criteria::DESC ? -1 : 1, $next);
             }
 
-            uasort($filtered, $next);
+            if ($next instanceof Closure) {
+                uasort($filtered, $next);
+            }
         }
 
         $offset = $criteria->getFirstResult();

--- a/lib/Doctrine/Common/Collections/Collection.php
+++ b/lib/Doctrine/Common/Collections/Collection.php
@@ -257,7 +257,7 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      *
      * @psalm-template TReturn
      * @psalm-template TInitial
-     * @psalm-param Closure(TReturn|TInitial, T):TReturn $func
+     * @psalm-param Closure(TReturn|TInitial|null, T):(TInitial|TReturn) $func
      * @psalm-param TInitial|null $initial
      * @psalm-return TReturn|TInitial|null
      */

--- a/lib/Doctrine/Common/Collections/Collection.php
+++ b/lib/Doctrine/Common/Collections/Collection.php
@@ -41,14 +41,14 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      *
      * @return true Always TRUE.
      */
-    public function add($element);
+    public function add($element): bool;
 
     /**
      * Clears the collection, removing all elements.
      *
      * @return void
      */
-    public function clear();
+    public function clear(): void;
 
     /**
      * Checks whether an element is contained in the collection.
@@ -59,14 +59,14 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      *
      * @return bool TRUE if the collection contains the element, FALSE otherwise.
      */
-    public function contains($element);
+    public function contains($element): bool;
 
     /**
      * Checks whether the collection is empty (contains no elements).
      *
      * @return bool TRUE if the collection is empty, FALSE otherwise.
      */
-    public function isEmpty();
+    public function isEmpty(): bool;
 
     /**
      * Removes the element at the specified index from the collection.
@@ -87,7 +87,7 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      *
      * @return bool TRUE if this collection contained the specified element, FALSE otherwise.
      */
-    public function removeElement($element);
+    public function removeElement($element): bool;
 
     /**
      * Checks whether the collection contains an element with the specified key/index.
@@ -98,7 +98,7 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      * @return bool TRUE if the collection contains an element with the specified key/index,
      *              FALSE otherwise.
      */
-    public function containsKey($key);
+    public function containsKey($key): bool;
 
     /**
      * Gets the element at the specified key/index.
@@ -118,7 +118,7 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      *               elements in the collection.
      * @psalm-return TKey[]
      */
-    public function getKeys();
+    public function getKeys(): array;
 
     /**
      * Gets all values of the collection.
@@ -127,7 +127,7 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      *                 order they appear in the collection.
      * @psalm-return list<T>
      */
-    public function getValues();
+    public function getValues(): array;
 
     /**
      * Sets an element in the collection at the specified key/index.
@@ -139,7 +139,7 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      *
      * @return void
      */
-    public function set($key, $value);
+    public function set($key, $value): void;
 
     /**
      * Gets a native PHP array representation of the collection.
@@ -147,7 +147,7 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      * @return mixed[]
      * @psalm-return array<TKey,T>
      */
-    public function toArray();
+    public function toArray(): array;
 
     /**
      * Sets the internal iterator to the first element in the collection and returns this element.
@@ -197,7 +197,7 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      *
      * @return bool TRUE if the predicate is TRUE for at least one element, FALSE otherwise.
      */
-    public function exists(Closure $p);
+    public function exists(Closure $p): bool;
 
     /**
      * Returns all the elements of this collection that satisfy the predicate p.
@@ -209,7 +209,7 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      * @return Collection<mixed> A collection with the results of the filter operation.
      * @psalm-return Collection<TKey, T>
      */
-    public function filter(Closure $p);
+    public function filter(Closure $p): self;
 
     /**
      * Tests whether the given predicate p holds for all elements of this collection.
@@ -219,7 +219,7 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      *
      * @return bool TRUE, if the predicate yields TRUE for all elements, FALSE otherwise.
      */
-    public function forAll(Closure $p);
+    public function forAll(Closure $p): bool;
 
     /**
      * Applies the given function to each element in the collection and returns
@@ -232,7 +232,7 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      *
      * @psalm-template U
      */
-    public function map(Closure $func);
+    public function map(Closure $func): self;
 
     /**
      * Partitions this collection in two collections according to a predicate.
@@ -246,7 +246,7 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      *                      contains the collection of elements where the predicate returned FALSE.
      * @psalm-return array{0: Collection<TKey, T>, 1: Collection<TKey, T>}
      */
-    public function partition(Closure $p);
+    public function partition(Closure $p): array;
 
     /**
      * Gets the index/key of a given element. The comparison of two elements is strict,
@@ -274,5 +274,35 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      * @return mixed[]
      * @psalm-return array<TKey,T>
      */
-    public function slice($offset, $length = null);
+    public function slice(int $offset, ?int $length = null): array;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function count(): int;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIterator(): \Traversable;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function offsetGet($offset);
+
+    /**
+     * {@inheritdoc}
+     */
+    public function offsetSet($offset, $value): void;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function offsetUnset($offset): void;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function offsetExists($offset): bool;
 }

--- a/lib/Doctrine/Common/Collections/Collection.php
+++ b/lib/Doctrine/Common/Collections/Collection.php
@@ -200,6 +200,19 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
     public function exists(Closure $p): bool;
 
     /**
+     * Returns the first element of this collection that satisfies the predicate p.
+     *
+     * @param Closure $p The predicate.
+     *
+     * @return mixed The first element respecting the predicate,
+     *               null if no element respects the predicate.
+     *
+     * @psalm-param Closure(TKey=, T=):bool $p
+     * @psalm-return T|null
+     */
+    public function findOne(Closure $p);
+
+    /**
      * Returns all the elements of this collection that satisfy the predicate p.
      * The order of the elements is preserved.
      *

--- a/lib/Doctrine/Common/Collections/Collection.php
+++ b/lib/Doctrine/Common/Collections/Collection.php
@@ -30,6 +30,8 @@ use IteratorAggregate;
  * @psalm-template T
  * @template-extends IteratorAggregate<TKey, T>
  * @template-extends ArrayAccess<TKey, T>
+ *
+ * @method array toList()
  */
 interface Collection extends Countable, IteratorAggregate, ArrayAccess
 {
@@ -148,6 +150,13 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      * @psalm-return array<TKey,T>
      */
     public function toArray(): array;
+
+    ///**
+    // * Gets a native PHP list representation of the collection.
+    // *
+    // * @psalm-return list<T>
+    // */
+    //public function toList(): array;
 
     /**
      * Sets the internal iterator to the first element in the collection and returns this element.

--- a/lib/Doctrine/Common/Collections/Collection.php
+++ b/lib/Doctrine/Common/Collections/Collection.php
@@ -248,6 +248,22 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
     public function map(Closure $func): self;
 
     /**
+     * Applies iteratively the given function to each element in the collection,
+     * so as to reduce the collection to a single value.
+     *
+     * @param mixed $initial
+     *
+     * @return mixed
+     *
+     * @psalm-template TReturn
+     * @psalm-template TInitial
+     * @psalm-param Closure(TReturn|TInitial, T):TReturn $func
+     * @psalm-param TInitial|null $initial
+     * @psalm-return TReturn|TInitial|null
+     */
+    public function reduce(Closure $func, $initial = null);
+
+    /**
      * Partitions this collection in two collections according to a predicate.
      * Keys are preserved in the resulting collections.
      *

--- a/lib/Doctrine/Common/Collections/Collection.php
+++ b/lib/Doctrine/Common/Collections/Collection.php
@@ -210,7 +210,7 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      * @psalm-param Closure(TKey=, T=):bool $p
      * @psalm-return T|null
      */
-    public function findOne(Closure $p);
+    public function findFirst(Closure $p);
 
     /**
      * Returns all the elements of this collection that satisfy the predicate p.

--- a/lib/Doctrine/Common/Collections/Collection.php
+++ b/lib/Doctrine/Common/Collections/Collection.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Common\Collections;
 
 use ArrayAccess;

--- a/lib/Doctrine/Common/Collections/Criteria.php
+++ b/lib/Doctrine/Common/Collections/Criteria.php
@@ -154,7 +154,7 @@ class Criteria
      * @see Criteria::ASC
      * @see Criteria::DESC
      *
-     * @param string[] $orderings
+     * @param array<string, string> $orderings
      *
      * @return Criteria
      */

--- a/lib/Doctrine/Common/Collections/Criteria.php
+++ b/lib/Doctrine/Common/Collections/Criteria.php
@@ -26,7 +26,7 @@ class Criteria
     /** @var Expression|null */
     private $expression;
 
-    /** @var string[] */
+    /** @var array<string, string> */
     private $orderings = [];
 
     /** @var int|null */
@@ -60,7 +60,7 @@ class Criteria
     /**
      * Construct a new Criteria.
      *
-     * @param string[]|null $orderings
+     * @param array<string, string>|null $orderings
      */
     public function __construct(?Expression $expression = null, ?array $orderings = null, ?int $firstResult = null, ?int $maxResults = null)
     {
@@ -139,7 +139,7 @@ class Criteria
     /**
      * Gets the current orderings of this Criteria.
      *
-     * @return string[]
+     * @return array<string, string>
      */
     public function getOrderings() : array
     {

--- a/lib/Doctrine/Common/Collections/Criteria.php
+++ b/lib/Doctrine/Common/Collections/Criteria.php
@@ -41,7 +41,7 @@ class Criteria
      *
      * @return Criteria
      */
-    public static function create()
+    public static function create(): self
     {
         return new static();
     }
@@ -51,7 +51,7 @@ class Criteria
      *
      * @return ExpressionBuilder
      */
-    public static function expr()
+    public static function expr(): ExpressionBuilder
     {
         if (self::$expressionBuilder === null) {
             self::$expressionBuilder = new ExpressionBuilder();
@@ -67,7 +67,7 @@ class Criteria
      * @param int|null      $firstResult
      * @param int|null      $maxResults
      */
-    public function __construct(?Expression $expression = null, ?array $orderings = null, $firstResult = null, $maxResults = null)
+    public function __construct(?Expression $expression = null, ?array $orderings = null, ?int $firstResult = null, ?int $maxResults = null)
     {
         $this->expression = $expression;
 
@@ -86,7 +86,7 @@ class Criteria
      *
      * @return Criteria
      */
-    public function where(Expression $expression)
+    public function where(Expression $expression): self
     {
         $this->expression = $expression;
 
@@ -99,7 +99,7 @@ class Criteria
      *
      * @return Criteria
      */
-    public function andWhere(Expression $expression)
+    public function andWhere(Expression $expression): self
     {
         if ($this->expression === null) {
             return $this->where($expression);
@@ -119,7 +119,7 @@ class Criteria
      *
      * @return Criteria
      */
-    public function orWhere(Expression $expression)
+    public function orWhere(Expression $expression): self
     {
         if ($this->expression === null) {
             return $this->where($expression);
@@ -138,7 +138,7 @@ class Criteria
      *
      * @return Expression|null
      */
-    public function getWhereExpression()
+    public function getWhereExpression(): ?Expression
     {
         return $this->expression;
     }
@@ -148,7 +148,7 @@ class Criteria
      *
      * @return string[]
      */
-    public function getOrderings()
+    public function getOrderings(): array
     {
         return $this->orderings;
     }
@@ -165,7 +165,7 @@ class Criteria
      *
      * @return Criteria
      */
-    public function orderBy(array $orderings)
+    public function orderBy(array $orderings): self
     {
         $this->orderings = array_map(
             static function (string $ordering): string {
@@ -182,7 +182,7 @@ class Criteria
      *
      * @return int|null
      */
-    public function getFirstResult()
+    public function getFirstResult(): ?int
     {
         return $this->firstResult;
     }
@@ -194,7 +194,7 @@ class Criteria
      *
      * @return Criteria
      */
-    public function setFirstResult($firstResult)
+    public function setFirstResult(?int $firstResult): self
     {
         $this->firstResult = $firstResult;
 
@@ -206,7 +206,7 @@ class Criteria
      *
      * @return int|null
      */
-    public function getMaxResults()
+    public function getMaxResults(): ?int
     {
         return $this->maxResults;
     }
@@ -218,7 +218,7 @@ class Criteria
      *
      * @return Criteria
      */
-    public function setMaxResults($maxResults)
+    public function setMaxResults(?int $maxResults): self
     {
         $this->maxResults = $maxResults;
 

--- a/lib/Doctrine/Common/Collections/Criteria.php
+++ b/lib/Doctrine/Common/Collections/Criteria.php
@@ -17,8 +17,7 @@ use function strtoupper;
  */
 class Criteria
 {
-    public const ASC = 'ASC';
-
+    public const ASC  = 'ASC';
     public const DESC = 'DESC';
 
     /** @var ExpressionBuilder|null */

--- a/lib/Doctrine/Common/Collections/Criteria.php
+++ b/lib/Doctrine/Common/Collections/Criteria.php
@@ -40,17 +40,15 @@ class Criteria
      *
      * @return Criteria
      */
-    public static function create(): self
+    public static function create() : self
     {
         return new static();
     }
 
     /**
      * Returns the expression builder.
-     *
-     * @return ExpressionBuilder
      */
-    public static function expr(): ExpressionBuilder
+    public static function expr() : ExpressionBuilder
     {
         if (self::$expressionBuilder === null) {
             self::$expressionBuilder = new ExpressionBuilder();
@@ -63,8 +61,6 @@ class Criteria
      * Construct a new Criteria.
      *
      * @param string[]|null $orderings
-     * @param int|null      $firstResult
-     * @param int|null      $maxResults
      */
     public function __construct(?Expression $expression = null, ?array $orderings = null, ?int $firstResult = null, ?int $maxResults = null)
     {
@@ -85,7 +81,7 @@ class Criteria
      *
      * @return Criteria
      */
-    public function where(Expression $expression): self
+    public function where(Expression $expression) : self
     {
         $this->expression = $expression;
 
@@ -98,7 +94,7 @@ class Criteria
      *
      * @return Criteria
      */
-    public function andWhere(Expression $expression): self
+    public function andWhere(Expression $expression) : self
     {
         if ($this->expression === null) {
             return $this->where($expression);
@@ -118,7 +114,7 @@ class Criteria
      *
      * @return Criteria
      */
-    public function orWhere(Expression $expression): self
+    public function orWhere(Expression $expression) : self
     {
         if ($this->expression === null) {
             return $this->where($expression);
@@ -134,10 +130,8 @@ class Criteria
 
     /**
      * Gets the expression attached to this Criteria.
-     *
-     * @return Expression|null
      */
-    public function getWhereExpression(): ?Expression
+    public function getWhereExpression() : ?Expression
     {
         return $this->expression;
     }
@@ -147,7 +141,7 @@ class Criteria
      *
      * @return string[]
      */
-    public function getOrderings(): array
+    public function getOrderings() : array
     {
         return $this->orderings;
     }
@@ -164,7 +158,7 @@ class Criteria
      *
      * @return Criteria
      */
-    public function orderBy(array $orderings): self
+    public function orderBy(array $orderings) : self
     {
         $this->orderings = array_map(
             static function (string $ordering): string {
@@ -178,10 +172,8 @@ class Criteria
 
     /**
      * Gets the current first result option of this Criteria.
-     *
-     * @return int|null
      */
-    public function getFirstResult(): ?int
+    public function getFirstResult() : ?int
     {
         return $this->firstResult;
     }
@@ -193,7 +185,7 @@ class Criteria
      *
      * @return Criteria
      */
-    public function setFirstResult(?int $firstResult): self
+    public function setFirstResult(?int $firstResult) : self
     {
         $this->firstResult = $firstResult;
 
@@ -202,10 +194,8 @@ class Criteria
 
     /**
      * Gets maxResults.
-     *
-     * @return int|null
      */
-    public function getMaxResults(): ?int
+    public function getMaxResults() : ?int
     {
         return $this->maxResults;
     }
@@ -217,7 +207,7 @@ class Criteria
      *
      * @return Criteria
      */
-    public function setMaxResults(?int $maxResults): self
+    public function setMaxResults(?int $maxResults) : self
     {
         $this->maxResults = $maxResults;
 

--- a/lib/Doctrine/Common/Collections/Criteria.php
+++ b/lib/Doctrine/Common/Collections/Criteria.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Common\Collections;
 
 use Doctrine\Common\Collections\Expr\CompositeExpression;

--- a/lib/Doctrine/Common/Collections/Expr/ClosureExpressionVisitor.php
+++ b/lib/Doctrine/Common/Collections/Expr/ClosureExpressionVisitor.php
@@ -164,7 +164,7 @@ class ClosureExpressionVisitor extends ExpressionVisitor
                     return ! in_array($fieldValue, $value, is_scalar($fieldValue));
                 };
             case Comparison::CONTAINS:
-                return static function ($object) use ($field, $value) {
+                return static function ($object) use ($field, $value) : bool {
                     return strpos(ClosureExpressionVisitor::getObjectFieldValue($object, $field), $value) !== false;
                 };
             case Comparison::MEMBER_OF:

--- a/lib/Doctrine/Common/Collections/Expr/ClosureExpressionVisitor.php
+++ b/lib/Doctrine/Common/Collections/Expr/ClosureExpressionVisitor.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Common\Collections\Expr;
 
 use ArrayAccess;

--- a/lib/Doctrine/Common/Collections/Expr/ClosureExpressionVisitor.php
+++ b/lib/Doctrine/Common/Collections/Expr/ClosureExpressionVisitor.php
@@ -131,51 +131,42 @@ class ClosureExpressionVisitor extends ExpressionVisitor
                 return static function ($object) use ($field, $value): bool {
                     return ClosureExpressionVisitor::getObjectFieldValue($object, $field) === $value;
                 };
-
             case Comparison::NEQ:
                 return static function ($object) use ($field, $value): bool {
                     return ClosureExpressionVisitor::getObjectFieldValue($object, $field) !== $value;
                 };
-
             case Comparison::LT:
                 return static function ($object) use ($field, $value): bool {
                     return ClosureExpressionVisitor::getObjectFieldValue($object, $field) < $value;
                 };
-
             case Comparison::LTE:
                 return static function ($object) use ($field, $value): bool {
                     return ClosureExpressionVisitor::getObjectFieldValue($object, $field) <= $value;
                 };
-
             case Comparison::GT:
                 return static function ($object) use ($field, $value): bool {
                     return ClosureExpressionVisitor::getObjectFieldValue($object, $field) > $value;
                 };
-
             case Comparison::GTE:
                 return static function ($object) use ($field, $value): bool {
                     return ClosureExpressionVisitor::getObjectFieldValue($object, $field) >= $value;
                 };
-
             case Comparison::IN:
                 return static function ($object) use ($field, $value): bool {
                     $fieldValue = ClosureExpressionVisitor::getObjectFieldValue($object, $field);
 
                     return in_array($fieldValue, $value, is_scalar($fieldValue));
                 };
-
             case Comparison::NIN:
                 return static function ($object) use ($field, $value): bool {
                     $fieldValue = ClosureExpressionVisitor::getObjectFieldValue($object, $field);
 
                     return ! in_array($fieldValue, $value, is_scalar($fieldValue));
                 };
-
             case Comparison::CONTAINS:
                 return static function ($object) use ($field, $value) {
                     return strpos(ClosureExpressionVisitor::getObjectFieldValue($object, $field), $value) !== false;
                 };
-
             case Comparison::MEMBER_OF:
                 return static function ($object) use ($field, $value): bool {
                     $fieldValues = ClosureExpressionVisitor::getObjectFieldValue($object, $field);
@@ -186,17 +177,14 @@ class ClosureExpressionVisitor extends ExpressionVisitor
 
                     return in_array($value, $fieldValues, true);
                 };
-
             case Comparison::STARTS_WITH:
                 return static function ($object) use ($field, $value): bool {
                     return strpos(ClosureExpressionVisitor::getObjectFieldValue($object, $field), $value) === 0;
                 };
-
             case Comparison::ENDS_WITH:
                 return static function ($object) use ($field, $value): bool {
                     return $value === substr(ClosureExpressionVisitor::getObjectFieldValue($object, $field), -strlen($value));
                 };
-
             default:
                 throw new RuntimeException('Unknown comparison operator: ' . $comparison->getOperator());
         }

--- a/lib/Doctrine/Common/Collections/Expr/ClosureExpressionVisitor.php
+++ b/lib/Doctrine/Common/Collections/Expr/ClosureExpressionVisitor.php
@@ -38,7 +38,7 @@ class ClosureExpressionVisitor extends ExpressionVisitor
      *
      * @return mixed
      */
-    public static function getObjectFieldValue($object, $field)
+    public static function getObjectFieldValue($object, string $field)
     {
         if (is_array($object)) {
             return $object[$field];
@@ -97,7 +97,7 @@ class ClosureExpressionVisitor extends ExpressionVisitor
      *
      * @return Closure
      */
-    public static function sortByField($name, $orientation = 1, ?Closure $next = null)
+    public static function sortByField(string $name, int $orientation = 1, ?\Closure $next = null): \Closure
     {
         if (! $next) {
             $next = static function (): int {

--- a/lib/Doctrine/Common/Collections/Expr/Comparison.php
+++ b/lib/Doctrine/Common/Collections/Expr/Comparison.php
@@ -37,7 +37,7 @@ class Comparison implements Expression
      * @param string $operator
      * @param mixed  $value
      */
-    public function __construct($field, $operator, $value)
+    public function __construct(string $field, string $operator, $value)
     {
         if (! ($value instanceof Value)) {
             $value = new Value($value);
@@ -51,13 +51,13 @@ class Comparison implements Expression
     /**
      * @return string
      */
-    public function getField()
+    public function getField(): string
     {
         return $this->field;
     }
 
     /**
-     * @return Value
+     * @return mixed
      */
     public function getValue()
     {
@@ -67,7 +67,7 @@ class Comparison implements Expression
     /**
      * @return string
      */
-    public function getOperator()
+    public function getOperator(): string
     {
         return $this->op;
     }

--- a/lib/Doctrine/Common/Collections/Expr/Comparison.php
+++ b/lib/Doctrine/Common/Collections/Expr/Comparison.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Common\Collections\Expr;
 
 /**

--- a/lib/Doctrine/Common/Collections/Expr/Comparison.php
+++ b/lib/Doctrine/Common/Collections/Expr/Comparison.php
@@ -33,9 +33,7 @@ class Comparison implements Expression
     private $value;
 
     /**
-     * @param string $field
-     * @param string $operator
-     * @param mixed  $value
+     * @param mixed $value
      */
     public function __construct(string $field, string $operator, $value)
     {
@@ -48,10 +46,7 @@ class Comparison implements Expression
         $this->value = $value;
     }
 
-    /**
-     * @return string
-     */
-    public function getField(): string
+    public function getField() : string
     {
         return $this->field;
     }
@@ -64,10 +59,7 @@ class Comparison implements Expression
         return $this->value;
     }
 
-    /**
-     * @return string
-     */
-    public function getOperator(): string
+    public function getOperator() : string
     {
         return $this->op;
     }

--- a/lib/Doctrine/Common/Collections/Expr/Comparison.php
+++ b/lib/Doctrine/Common/Collections/Expr/Comparison.php
@@ -51,10 +51,7 @@ class Comparison implements Expression
         return $this->field;
     }
 
-    /**
-     * @return mixed
-     */
-    public function getValue()
+    public function getValue() : Value
     {
         return $this->value;
     }

--- a/lib/Doctrine/Common/Collections/Expr/CompositeExpression.php
+++ b/lib/Doctrine/Common/Collections/Expr/CompositeExpression.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Common\Collections\Expr;
 
 use RuntimeException;

--- a/lib/Doctrine/Common/Collections/Expr/CompositeExpression.php
+++ b/lib/Doctrine/Common/Collections/Expr/CompositeExpression.php
@@ -26,7 +26,7 @@ class CompositeExpression implements Expression
      *
      * @throws RuntimeException
      */
-    public function __construct($type, array $expressions)
+    public function __construct(string $type, array $expressions)
     {
         $this->type = $type;
 
@@ -48,7 +48,7 @@ class CompositeExpression implements Expression
      *
      * @return Expression[]
      */
-    public function getExpressionList()
+    public function getExpressionList(): array
     {
         return $this->expressions;
     }
@@ -56,7 +56,7 @@ class CompositeExpression implements Expression
     /**
      * @return string
      */
-    public function getType()
+    public function getType(): string
     {
         return $this->type;
     }

--- a/lib/Doctrine/Common/Collections/Expr/Expression.php
+++ b/lib/Doctrine/Common/Collections/Expr/Expression.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Common\Collections\Expr;
 
 /**

--- a/lib/Doctrine/Common/Collections/Expr/ExpressionVisitor.php
+++ b/lib/Doctrine/Common/Collections/Expr/ExpressionVisitor.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Common\Collections\Expr;
 
 use RuntimeException;

--- a/lib/Doctrine/Common/Collections/Expr/Value.php
+++ b/lib/Doctrine/Common/Collections/Expr/Value.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Common\Collections\Expr;
 
 class Value implements Expression

--- a/lib/Doctrine/Common/Collections/ExpressionBuilder.php
+++ b/lib/Doctrine/Common/Collections/ExpressionBuilder.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Common\Collections;
 
 use Doctrine\Common\Collections\Expr\Comparison;

--- a/lib/Doctrine/Common/Collections/ExpressionBuilder.php
+++ b/lib/Doctrine/Common/Collections/ExpressionBuilder.php
@@ -24,7 +24,7 @@ class ExpressionBuilder
      *
      * @return CompositeExpression
      */
-    public function andX($x = null)
+    public function andX($x = null): CompositeExpression
     {
         return new CompositeExpression(CompositeExpression::TYPE_AND, func_get_args());
     }
@@ -34,7 +34,7 @@ class ExpressionBuilder
      *
      * @return CompositeExpression
      */
-    public function orX($x = null)
+    public function orX($x = null): CompositeExpression
     {
         return new CompositeExpression(CompositeExpression::TYPE_OR, func_get_args());
     }
@@ -45,7 +45,7 @@ class ExpressionBuilder
      *
      * @return Comparison
      */
-    public function eq($field, $value)
+    public function eq(string $field, $value): Comparison
     {
         return new Comparison($field, Comparison::EQ, new Value($value));
     }
@@ -56,7 +56,7 @@ class ExpressionBuilder
      *
      * @return Comparison
      */
-    public function gt($field, $value)
+    public function gt(string $field, $value): Comparison
     {
         return new Comparison($field, Comparison::GT, new Value($value));
     }
@@ -78,7 +78,7 @@ class ExpressionBuilder
      *
      * @return Comparison
      */
-    public function gte($field, $value)
+    public function gte(string $field, $value): Comparison
     {
         return new Comparison($field, Comparison::GTE, new Value($value));
     }
@@ -89,7 +89,7 @@ class ExpressionBuilder
      *
      * @return Comparison
      */
-    public function lte($field, $value)
+    public function lte(string $field, $value): Comparison
     {
         return new Comparison($field, Comparison::LTE, new Value($value));
     }
@@ -100,7 +100,7 @@ class ExpressionBuilder
      *
      * @return Comparison
      */
-    public function neq($field, $value)
+    public function neq(string $field, $value): Comparison
     {
         return new Comparison($field, Comparison::NEQ, new Value($value));
     }
@@ -110,7 +110,7 @@ class ExpressionBuilder
      *
      * @return Comparison
      */
-    public function isNull($field)
+    public function isNull(string $field): Comparison
     {
         return new Comparison($field, Comparison::EQ, new Value(null));
     }
@@ -121,7 +121,7 @@ class ExpressionBuilder
      *
      * @return Comparison
      */
-    public function in($field, array $values)
+    public function in(string $field, array $values): Comparison
     {
         return new Comparison($field, Comparison::IN, new Value($values));
     }
@@ -132,7 +132,7 @@ class ExpressionBuilder
      *
      * @return Comparison
      */
-    public function notIn($field, array $values)
+    public function notIn(string $field, array $values): Comparison
     {
         return new Comparison($field, Comparison::NIN, new Value($values));
     }
@@ -143,7 +143,7 @@ class ExpressionBuilder
      *
      * @return Comparison
      */
-    public function contains($field, $value)
+    public function contains(string $field, $value): Comparison
     {
         return new Comparison($field, Comparison::CONTAINS, new Value($value));
     }
@@ -154,7 +154,7 @@ class ExpressionBuilder
      *
      * @return Comparison
      */
-    public function memberOf($field, $value)
+    public function memberOf(string $field, $value): Comparison
     {
         return new Comparison($field, Comparison::MEMBER_OF, new Value($value));
     }
@@ -165,7 +165,7 @@ class ExpressionBuilder
      *
      * @return Comparison
      */
-    public function startsWith($field, $value)
+    public function startsWith(string $field, $value): Comparison
     {
         return new Comparison($field, Comparison::STARTS_WITH, new Value($value));
     }
@@ -176,7 +176,7 @@ class ExpressionBuilder
      *
      * @return Comparison
      */
-    public function endsWith($field, $value)
+    public function endsWith(string $field, $value): Comparison
     {
         return new Comparison($field, Comparison::ENDS_WITH, new Value($value));
     }

--- a/lib/Doctrine/Common/Collections/Selectable.php
+++ b/lib/Doctrine/Common/Collections/Selectable.php
@@ -21,7 +21,7 @@ interface Selectable
 {
     /**
      * Selects all elements from a selectable that match the expression and
-     * returns a new collection containing these elements.
+     * returns a new collection containing these elements and preserved keys.
      *
      * @return Collection<mixed>
      * @psalm-return Collection<TKey,T>

--- a/lib/Doctrine/Common/Collections/Selectable.php
+++ b/lib/Doctrine/Common/Collections/Selectable.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Common\Collections;
 
 /**

--- a/lib/Doctrine/Common/Collections/Selectable.php
+++ b/lib/Doctrine/Common/Collections/Selectable.php
@@ -28,5 +28,5 @@ interface Selectable
      * @return Collection<mixed>
      * @psalm-return Collection<TKey,T>
      */
-    public function matching(Criteria $criteria);
+    public function matching(Criteria $criteria): Collection;
 }

--- a/lib/Doctrine/Common/Collections/Selectable.php
+++ b/lib/Doctrine/Common/Collections/Selectable.php
@@ -28,5 +28,5 @@ interface Selectable
      * @return Collection<mixed>
      * @psalm-return Collection<TKey,T>
      */
-    public function matching(Criteria $criteria): Collection;
+    public function matching(Criteria $criteria) : Collection;
 }

--- a/tests/Doctrine/Tests/Common/Collections/AbstractLazyArrayCollectionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/AbstractLazyArrayCollectionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\Common\Collections;
 
 use Doctrine\Common\Collections\ArrayCollection;

--- a/tests/Doctrine/Tests/Common/Collections/AbstractLazyCollectionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/AbstractLazyCollectionTest.php
@@ -6,6 +6,9 @@ namespace Doctrine\Tests\Common\Collections;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Tests\LazyArrayCollection;
+use function is_array;
+use function is_numeric;
+use function is_string;
 
 /**
  * Tests for {@see \Doctrine\Common\Collections\AbstractLazyCollection}.
@@ -17,5 +20,97 @@ class AbstractLazyCollectionTest extends BaseCollectionTest
     protected function setUp(): void
     {
         $this->collection = new LazyArrayCollection(new ArrayCollection());
+    }
+
+    private function buildCollection(array $elements) : LazyArrayCollection
+    {
+        return new LazyArrayCollection(new ArrayCollection($elements));
+    }
+
+    public function testClearInitializes() : void
+    {
+        /** @var LazyArrayCollection $collection */
+        $collection = $this->buildCollection(['a', 'b', 'c']);
+
+        $collection->clear();
+
+        self::assertTrue($collection->isInitialized());
+        self::assertCount(0, $collection);
+    }
+
+    public function testFilterInitializes() : void
+    {
+        /** @var LazyArrayCollection $collection */
+        $collection = $this->buildCollection([1, 'foo', 3]);
+
+        $res = $collection->filter(static function ($value) {
+            return is_numeric($value);
+        });
+
+        self::assertEquals([0 => 1, 2 => 3], $res->toArray());
+    }
+
+    public function testForAllInitializes() : void
+    {
+        $collection = $this->buildCollection(['foo', 'bar']);
+
+        self::assertEquals($collection->forAll(static function ($k, $e) {
+            return is_string($e);
+        }), true);
+
+        self::assertEquals($collection->forAll(static function ($k, $e) {
+            return is_array($e);
+        }), false);
+    }
+
+    public function testMapInitializes() : void
+    {
+        $collection = $this->buildCollection([1, 2]);
+
+        $res = $collection->map(static function ($e) {
+            return $e * 2;
+        });
+        self::assertEquals([2, 4], $res->toArray());
+    }
+
+    public function testPartitionInitializes() : void
+    {
+        $collection = $this->buildCollection([true, false]);
+        $partition  = $collection->partition(static function ($k, $e) {
+            return $e === true;
+        });
+        self::assertEquals($partition[0][0], true);
+        self::assertEquals($partition[1][0], false);
+    }
+
+    public function testSliceInitializes() : void
+    {
+        $collection = $this->buildCollection(['one', 'two', 'three']);
+
+        $slice = $collection->slice(0, 1);
+        self::assertIsArray($slice);
+        self::assertEquals(['one'], $slice);
+
+        $slice = $collection->slice(1);
+        self::assertEquals([1 => 'two', 2 => 'three'], $slice);
+
+        $slice = $collection->slice(1, 1);
+        self::assertEquals([1 => 'two'], $slice);
+    }
+
+    public function testGetInitializes() : void
+    {
+        $value      = 'foo';
+        $collection = $this->buildCollection([$value]);
+        $this->assertSame($value, $collection[0]);
+    }
+
+    public function testUnsetInitializes() : void
+    {
+        $collection = $this->buildCollection(['foo', 'bar']);
+
+        $collection->offsetUnset(0);
+        self::assertCount(1, $collection);
+        self::assertFalse(isset($collection[0]));
     }
 }

--- a/tests/Doctrine/Tests/Common/Collections/AbstractLazyCollectionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/AbstractLazyCollectionTest.php
@@ -113,4 +113,10 @@ class AbstractLazyCollectionTest extends BaseCollectionTest
         self::assertCount(1, $collection);
         self::assertFalse(isset($collection[0]));
     }
+
+    public function testToList(): void
+    {
+        $this->assertSame(['foo', 'bar'], $this->buildCollection(['foo', 'bar'])->toList());
+        $this->assertSame(['foo', 'bar'], $this->buildCollection(['key1' => 'foo', 'key2' => 'bar'])->toList());
+    }
 }

--- a/tests/Doctrine/Tests/Common/Collections/AbstractLazyCollectionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/AbstractLazyCollectionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\Common\Collections;
 
 use Doctrine\Common\Collections\ArrayCollection;

--- a/tests/Doctrine/Tests/Common/Collections/ArrayCollectionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/ArrayCollectionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\Common\Collections;
 
 use Doctrine\Common\Collections\ArrayCollection;

--- a/tests/Doctrine/Tests/Common/Collections/ArrayCollectionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/ArrayCollectionTest.php
@@ -22,7 +22,7 @@ class ArrayCollectionTest extends BaseArrayCollectionTest
     /**
      * @param mixed[] $elements
      *
-     * @return Collection<mixed>
+     * @return ArrayCollection<mixed>
      */
     protected function buildCollection(array $elements = []): Collection
     {
@@ -37,6 +37,12 @@ class ArrayCollectionTest extends BaseArrayCollectionTest
 
         $this->assertIsArray($unserializeCollection->getValues());
         $this->assertCount(0, $unserializeCollection->getValues());
+    }
+
+    public function testToList(): void
+    {
+        $this->assertSame(['foo', 'bar'], $this->buildCollection(['foo', 'bar'])->toList());
+        $this->assertSame(['foo', 'bar'], $this->buildCollection(['key1' => 'foo', 'key2' => 'bar'])->toList());
     }
 }
 

--- a/tests/Doctrine/Tests/Common/Collections/ArrayCollectionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/ArrayCollectionTest.php
@@ -6,6 +6,11 @@ namespace Doctrine\Tests\Common\Collections;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
+use Serializable;
+use function json_decode;
+use function json_encode;
+use function serialize;
+use function unserialize;
 
 /**
  * Tests for {@see \Doctrine\Common\Collections\ArrayCollection}.
@@ -22,5 +27,34 @@ class ArrayCollectionTest extends BaseArrayCollectionTest
     protected function buildCollection(array $elements = []): Collection
     {
         return new ArrayCollection($elements);
+    }
+
+    public function testUnserializeEmptyArrayCollection() : void
+    {
+        $collection            = new SerializableArrayCollection();
+        $serializeCollection   = serialize($collection);
+        $unserializeCollection = unserialize($serializeCollection);
+
+        $this->assertIsArray($unserializeCollection->getValues());
+        $this->assertCount(0, $unserializeCollection->getValues());
+    }
+}
+
+/**
+ * We can't implement Serializable interface on anonymous class
+ */
+class SerializableArrayCollection extends ArrayCollection implements Serializable
+{
+    public function serialize() : string
+    {
+        return json_encode($this->getKeys());
+    }
+
+    // phpcs:ignore SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingParameterTypeHint
+    public function unserialize($serialized) : void
+    {
+        foreach (json_decode($serialized) as $value) {
+            parent::add($value);
+        }
     }
 }

--- a/tests/Doctrine/Tests/Common/Collections/BaseArrayCollectionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/BaseArrayCollectionTest.php
@@ -95,9 +95,10 @@ abstract class BaseArrayCollectionTest extends TestCase
      */
     public function testNext($elements): void
     {
+        $count = count($elements);
         $collection = $this->buildCollection($elements);
 
-        while (true) {
+        for ($i = 0; $i < $count; $i++) {
             $collectionNext = $collection->next();
             $arrayNext      = next($elements);
 
@@ -109,6 +110,8 @@ abstract class BaseArrayCollectionTest extends TestCase
             self::assertSame(key($elements), $collection->key(), 'Keys not match');
             self::assertSame(current($elements), $collection->current(), 'Current values not match');
         }
+
+        self::assertFalse($collection->next());
     }
 
     /**

--- a/tests/Doctrine/Tests/Common/Collections/BaseArrayCollectionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/BaseArrayCollectionTest.php
@@ -281,22 +281,22 @@ abstract class BaseArrayCollectionTest extends TestCase
         }), 'Element not exists');
     }
 
-    public function testFindOne(): void
+    public function testFindFirst(): void
     {
         $elements   = [1, 'A' => 'a', 2, 'null' => null, 3, 'A2' => 'a', 'zero' => 0];
         $collection = $this->buildCollection($elements);
 
-        self::assertSame('a', $collection->findOne(static function ($key, $element) {
+        self::assertSame('a', $collection->findFirst(static function ($key, $element) {
             return $key === 'A' && $element === 'a';
         }), 'Element exists');
     }
 
-    public function testFindOneNotFound(): void
+    public function testFindFirstNotFound(): void
     {
         $elements   = [1, 'A' => 'a', 2, 'null' => null, 3, 'A2' => 'a', 'zero' => 0];
         $collection = $this->buildCollection($elements);
 
-        self::assertNull($collection->findOne(static function ($key, $element) {
+        self::assertNull($collection->findFirst(static function ($key, $element) {
             return $key === 'non-existent' && $element === 'non-existent';
         }), 'Element does not exists');
     }

--- a/tests/Doctrine/Tests/Common/Collections/BaseArrayCollectionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/BaseArrayCollectionTest.php
@@ -281,6 +281,26 @@ abstract class BaseArrayCollectionTest extends TestCase
         }), 'Element not exists');
     }
 
+    public function testFindOne(): void
+    {
+        $elements   = [1, 'A' => 'a', 2, 'null' => null, 3, 'A2' => 'a', 'zero' => 0];
+        $collection = $this->buildCollection($elements);
+
+        self::assertSame('a', $collection->findOne(static function ($key, $element) {
+            return $key === 'A' && $element === 'a';
+        }), 'Element exists');
+    }
+
+    public function testFindOneNotFound(): void
+    {
+        $elements   = [1, 'A' => 'a', 2, 'null' => null, 3, 'A2' => 'a', 'zero' => 0];
+        $collection = $this->buildCollection($elements);
+
+        self::assertNull($collection->findOne(static function ($key, $element) {
+            return $key === 'non-existent' && $element === 'non-existent';
+        }), 'Element does not exists');
+    }
+
     public function testIndexOf(): void
     {
         $elements   = [1, 'A' => 'a', 2, 'null' => null, 3, 'A2' => 'a', 'zero' => 0];

--- a/tests/Doctrine/Tests/Common/Collections/BaseArrayCollectionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/BaseArrayCollectionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\Common\Collections;
 
 use Doctrine\Common\Collections\Collection;

--- a/tests/Doctrine/Tests/Common/Collections/BaseArrayCollectionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/BaseArrayCollectionTest.php
@@ -95,7 +95,7 @@ abstract class BaseArrayCollectionTest extends TestCase
      */
     public function testNext($elements): void
     {
-        $count = count($elements);
+        $count      = count($elements);
         $collection = $this->buildCollection($elements);
 
         for ($i = 0; $i < $count; $i++) {

--- a/tests/Doctrine/Tests/Common/Collections/BaseCollectionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/BaseCollectionTest.php
@@ -76,6 +76,19 @@ abstract class BaseCollectionTest extends TestCase
         self::assertEquals([2, 4], $res->toArray());
     }
 
+    public function testReduce(): void
+    {
+        $this->collection->add(1);
+        $this->collection->add(2);
+        $this->collection->add(3);
+        $this->collection->add(4);
+
+        $res = $this->collection->reduce(static function ($sum, $e) {
+            return $sum + $e;
+        });
+        self::assertSame(10, $res);
+    }
+
     public function testFilter(): void
     {
         $this->collection->add(1);

--- a/tests/Doctrine/Tests/Common/Collections/BaseCollectionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/BaseCollectionTest.php
@@ -46,6 +46,26 @@ abstract class BaseCollectionTest extends TestCase
         self::assertFalse($exists);
     }
 
+    public function testFindOne(): void
+    {
+        $this->collection->add('one');
+        $this->collection->add('two');
+        $one = $this->collection->findOne(static function ($k, $e) {
+            return $e === 'one';
+        });
+        self::assertSame('one', $one);
+    }
+
+    public function testFindOneNotFound(): void
+    {
+        $this->collection->add('one');
+        $this->collection->add('two');
+        $other = $this->collection->findOne(static function ($k, $e) {
+            return $e === 'other';
+        });
+        self::assertNull($other);
+    }
+
     public function testMap(): void
     {
         $this->collection->add(1);

--- a/tests/Doctrine/Tests/Common/Collections/BaseCollectionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/BaseCollectionTest.php
@@ -46,21 +46,21 @@ abstract class BaseCollectionTest extends TestCase
         self::assertFalse($exists);
     }
 
-    public function testFindOne(): void
+    public function testFindFirst(): void
     {
         $this->collection->add('one');
         $this->collection->add('two');
-        $one = $this->collection->findOne(static function ($k, $e) {
+        $one = $this->collection->findFirst(static function ($k, $e) {
             return $e === 'one';
         });
         self::assertSame('one', $one);
     }
 
-    public function testFindOneNotFound(): void
+    public function testFindFirstNotFound(): void
     {
         $this->collection->add('one');
         $this->collection->add('two');
-        $other = $this->collection->findOne(static function ($k, $e) {
+        $other = $this->collection->findFirst(static function ($k, $e) {
             return $e === 'other';
         });
         self::assertNull($other);

--- a/tests/Doctrine/Tests/Common/Collections/BaseCollectionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/BaseCollectionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\Common\Collections;
 
 use Doctrine\Common\Collections\Collection;

--- a/tests/Doctrine/Tests/Common/Collections/ClosureExpressionVisitorTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/ClosureExpressionVisitorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\Common\Collections;
 
 use ArrayAccess;

--- a/tests/Doctrine/Tests/Common/Collections/CollectionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/CollectionTest.php
@@ -97,6 +97,6 @@ class CollectionTest extends BaseCollectionTest
         self::assertInstanceOf(Collection::class, $col);
         self::assertNotSame($col, $this->collection);
         self::assertEquals(1, count($col));
-        self::assertEquals('baz', $col[0]->foo);
+        self::assertEquals('baz', $col[1]->foo);
     }
 }

--- a/tests/Doctrine/Tests/Common/Collections/CollectionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/CollectionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\Common\Collections;
 
 use Doctrine\Common\Collections\ArrayCollection;

--- a/tests/Doctrine/Tests/Common/Collections/CriteriaTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/CriteriaTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\Common\Collections;
 
 use Doctrine\Common\Collections\Criteria;

--- a/tests/Doctrine/Tests/Common/Collections/DerivedCollectionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/DerivedCollectionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\Common\Collections;
 
 use Doctrine\Common\Collections\Criteria;

--- a/tests/Doctrine/Tests/Common/Collections/Expr/CompositeExpressionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/Expr/CompositeExpressionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\Common\Collections\Expr;
 
 use Doctrine\Common\Collections\Expr\CompositeExpression;

--- a/tests/Doctrine/Tests/Common/Collections/Expr/ValueTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/Expr/ValueTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\Common\Collections\Expr;
 
 use Doctrine\Common\Collections\Expr\ExpressionVisitor;

--- a/tests/Doctrine/Tests/Common/Collections/ExpressionBuilderTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/ExpressionBuilderTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\Common\Collections;
 
 use Doctrine\Common\Collections\Expr\Comparison;

--- a/tests/Doctrine/Tests/DerivedArrayCollection.php
+++ b/tests/Doctrine/Tests/DerivedArrayCollection.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests;
 
 use Doctrine\Common\Collections\ArrayCollection;

--- a/tests/Doctrine/Tests/LazyArrayCollection.php
+++ b/tests/Doctrine/Tests/LazyArrayCollection.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests;
 
 use Doctrine\Common\Collections\AbstractLazyCollection;


### PR DESCRIPTION
Adds `Collection::toList(): list<T>`

In my own projects, I have been having to do the following pattern to make static analysis happy:
```php
/** @var list<T> $list */
$list = $listCollection->toArray();
```
