### PR TITLE
Add toList function

### DIFF
--- a/lib/Doctrine/Common/Collections/AbstractLazyCollection.php
+++ b/lib/Doctrine/Common/Collections/AbstractLazyCollection.php
@@ -158,6 +158,16 @@ abstract class AbstractLazyCollection implements Collection
     }
 
     /**
+     * @return list<T>
+     */
+    public function toList(): array
+    {
+        $this->initialize();
+
+        return $this->collection->toList();
+    }
+
+    /**
      * {@inheritDoc}
      */
     public function first()

--- a/lib/Doctrine/Common/Collections/ArrayCollection.php
+++ b/lib/Doctrine/Common/Collections/ArrayCollection.php
@@ -72,6 +72,17 @@ class ArrayCollection implements Collection, Selectable
     }
 
     /**
+     * @return list<T>
+     */
+    public function toList(): array
+    {
+        if (\PHP_VERSION_ID >= 80100 && \array_is_list($this->elements)) {
+            return $this->elements;
+        }
+        return \array_values($this->elements);
+    }
+
+    /**
      * {@inheritDoc}
      */
     public function first()

--- a/lib/Doctrine/Common/Collections/Collection.php
+++ b/lib/Doctrine/Common/Collections/Collection.php
@@ -28,6 +28,8 @@ use IteratorAggregate;
  * @psalm-template T
  * @template-extends IteratorAggregate<TKey, T>
  * @template-extends ArrayAccess<TKey, T>
+ *
+ * @method array toList()
  */
 interface Collection extends Countable, IteratorAggregate, ArrayAccess
 {
@@ -146,6 +148,13 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
      * @psalm-return array<TKey,T>
      */
     public function toArray();
+
+    ///**
+    // * Gets a native PHP list representation of the collection.
+    // *
+    // * @psalm-return list<T>
+    // */
+    //public function toList(): array;
 
     /**
      * Sets the internal iterator to the first element in the collection and returns this element.

--- a/tests/Doctrine/Tests/Common/Collections/CollectionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/CollectionTest.php
@@ -99,4 +99,19 @@ class CollectionTest extends BaseCollectionTest
         self::assertEquals(1, count($col));
         self::assertEquals('baz', $col[0]->foo);
     }
+
+    public function testToList(): void
+    {
+        $this->assertSame([], $this->collection->toList());
+
+        $this->collection->add('foo');
+        $this->collection->add('bar');
+        $this->assertSame(['foo', 'bar'], $this->collection->toList());
+        $this->collection->clear();
+
+        $this->collection->set('key1', 'foo');
+        $this->collection->set('key2', 'bar');
+        $this->assertSame(['foo', 'bar'], $this->collection->toList());
+        $this->collection->clear();
+    }
 }


### PR DESCRIPTION
Adds `Collection::toList(): list<T>`

In my own projects, I have been having to do the following pattern to make static analysis happy:
```php
/** @var list<T> $list */
$list = $listCollection->toArray();
```

It would be nice not to have to use doc-block annotations.