### PR TITLE
Run Rector

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -13,29 +13,39 @@ awareness about deprecated code.
 Native parameter and return types were added.
 As a consequence, some signatures were changed and will have to be adjusted in sub-classes.
 
-Note that in order to keep compatibility with both 1.x and 2.x versions, extending code would have to omit the added parameter types and add the return types. This would only work in PHP 7.2+ which is the first version featuring [parameter widening](https://wiki.php.net/rfc/parameter-no-type-variance).
+Note that in order to keep compatibility with both 1.x and 2.x versions,
+extending code would have to omit the added parameter types and add the return
+types. This would only work in PHP 7.2+ which is the first version featuring
+[parameter widening](https://wiki.php.net/rfc/parameter-no-type-variance).
 
 You can find a list of major changes to public API below.
 
-#### Doctrine\Common\Collections\Collection
+### Doctrine\Common\Collections\Collection
 
 |             before             |                  after                         |
 |-------------------------------:|:-----------------------------------------------|
-| add($element)                  | add($element): bool                            |
+| add($element)                  | add(mixed $element): bool                      |
 | clear()                        | clear(): void                                  |
-| contains($element)             | contains($element): bool                       |
+| contains($element)             | contains(mixed $element): bool                 |
 | isEmpty()                      | isEmpty(): bool                                |
-| removeElement($element)        | removeElement($element): bool                  |
-| containsKey($key)              | containsKey($key): bool                        |
+| removeElement($element)        | removeElement(mixed $element): bool            |
+| containsKey($key)              | containsKey(string|int $key): bool             |
+| get()                          | get(string|int $key): mixed                    |
 | getKeys()                      | getKeys(): array                               |
 | getValues()                    | getValues(): array                             |
-| set($key, $value)              | set($key, $value): void                        |
+| set($key, $value)              | set(string|int $key, $value): void             |
 | toArray()                      | toArray(): array                               |
+| first()                        | first(): mixed                                 |
+| last()                         | last(): mixed                                  |
+| key()                          | key(): int|string|null                         |
+| current()                      | current(): mixed                               |
+| next()                         | next(): mixed                                  |
 | exists(Closure $p)             | exists(Closure $p): bool                       |
 | filter(Closure $p)             | filter(Closure $p): self                       |
 | forAll(Closure $p)             | forAll(Closure $p): bool                       |
 | map(Closure $func)             | map(Closure $func): self                       |
 | partition(Closure $p)          | partition(Closure $p): array                   |
+| indexOf(mixed $element)        | indexOf(mixed $element): int|string|false      |
 | slice($offset, $length = null) | slice(int $offset, ?int $length = null): array |
 | count()                        | count(): int                                   |
 | getIterator()                  | getIterator(): \Traversable                    |
@@ -43,7 +53,7 @@ You can find a list of major changes to public API below.
 | offsetUnset($offset)           | offsetUnset($offset): void                     |
 | offsetExists($offset)          | offsetExists($offset): bool                    |
 
-#### Doctrine\Common\Collections\AbstractLazyCollection
+### Doctrine\Common\Collections\AbstractLazyCollection
 
 |      before     |         after         |
 |----------------:|:----------------------|
@@ -51,14 +61,14 @@ You can find a list of major changes to public API below.
 | initialize()    | initialize(): void    |
 | doInitialize()  | doInitialize(): void  |
 
-#### Doctrine\Common\Collections\ArrayCollection
+### Doctrine\Common\Collections\ArrayCollection
 
-|            before           |               after               |
-|----------------------------:|:----------------------------------|
-| createFrom(array $elements) | createFrom(array $elements): self |
-| __toString()                | __toString(): string              |
+|            before           |               after                 |
+|----------------------------:|:------------------------------------|
+| createFrom(array $elements) | createFrom(array $elements): static |
+| __toString()                | __toString(): string                |
 
-#### Doctrine\Common\Collections\Selectable
+### Doctrine\Common\Collections\Selectable
 
 |             before           |                   after                  |
 |-----------------------------:|:-----------------------------------------|

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -68,6 +68,17 @@ You can find a list of major changes to public API below.
 | createFrom(array $elements) | createFrom(array $elements): static |
 | __toString()                | __toString(): string                |
 
+### Doctrine\Common\Collections\Criteria
+
+|            before                       |               after                       |
+|----------------------------------------:|:------------------------------------------|
+| where(Expression $expression): self     | where(Expression $expression): static     |
+| andWhere(Expression $expression): self  | andWhere(Expression $expression): static  |
+| orWhere(Expression $expression): self   | orWhere(Expression $expression): static   |
+| orderBy(array $orderings): self         | orderBy(array $orderings): static         |
+| setFirstResult(?int $firstResult): self | setFirstResult(?int $firstResult): static |
+| setMaxResult(?int $maxResults): self    | setMaxResults(?int $maxResults): static   |
+
 ### Doctrine\Common\Collections\Selectable
 
 |             before           |                   after                  |

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,12 @@
-Upgrading from 1.x to 2.0
-=========================
+Note about upgrading: Doctrine uses static and runtime mechanisms to raise
+awareness about deprecated code.
+
+- Use of `@deprecated` docblock that is detected by IDEs (like PHPStorm) or
+  Static Analysis tools (like Psalm, phpstan)
+- Use of our low-overhead runtime deprecation API, details:
+  https://github.com/doctrine/deprecations/
+
+# Upgrade to 2.0
 
 ## BC breaking changes
 

--- a/lib/Doctrine/Common/Collections/ArrayCollection.php
+++ b/lib/Doctrine/Common/Collections/ArrayCollection.php
@@ -7,6 +7,7 @@ namespace Doctrine\Common\Collections;
 use ArrayIterator;
 use Closure;
 use Doctrine\Common\Collections\Expr\ClosureExpressionVisitor;
+use Stringable;
 use Traversable;
 
 use function array_filter;
@@ -44,7 +45,7 @@ use const ARRAY_FILTER_USE_BOTH;
  * @template-implements Selectable<TKey,T>
  * @psalm-consistent-constructor
  */
-class ArrayCollection implements Collection, Selectable
+class ArrayCollection implements Collection, Selectable, Stringable
 {
     /**
      * An array containing the entries of this collection.
@@ -87,7 +88,6 @@ class ArrayCollection implements Collection, Selectable
      * @param array $elements Elements.
      * @psalm-param array<K,V> $elements
      *
-     * @return static
      * @psalm-return static<K,V>
      *
      * @psalm-template K of array-key

--- a/lib/Doctrine/Common/Collections/Criteria.php
+++ b/lib/Doctrine/Common/Collections/Criteria.php
@@ -17,26 +17,21 @@ use function strtoupper;
  */
 class Criteria
 {
-    public const ASC  = 'ASC';
-    public const DESC = 'DESC';
+    final public const ASC  = 'ASC';
+    final public const DESC = 'DESC';
 
     private static ?ExpressionBuilder $expressionBuilder = null;
-
-    private ?Expression $expression = null;
 
     /** @var array<string, string> */
     private array $orderings = [];
 
     private ?int $firstResult = null;
-
-    private ?int $maxResults = null;
+    private ?int $maxResults  = null;
 
     /**
      * Creates an instance of the class.
-     *
-     * @return Criteria
      */
-    public static function create(): self
+    public static function create(): static
     {
         return new static();
     }
@@ -58,10 +53,12 @@ class Criteria
      *
      * @param array<string, string>|null $orderings
      */
-    public function __construct(?Expression $expression = null, ?array $orderings = null, ?int $firstResult = null, ?int $maxResults = null)
-    {
-        $this->expression = $expression;
-
+    public function __construct(
+        private ?Expression $expression = null,
+        ?array $orderings = null,
+        ?int $firstResult = null,
+        ?int $maxResults = null,
+    ) {
         $this->setFirstResult($firstResult);
         $this->setMaxResults($maxResults);
 
@@ -157,9 +154,7 @@ class Criteria
     public function orderBy(array $orderings): self
     {
         $this->orderings = array_map(
-            static function (string $ordering): string {
-                return strtoupper($ordering) === Criteria::ASC ? Criteria::ASC : Criteria::DESC;
-            },
+            static fn (string $ordering): string => strtoupper($ordering) === self::ASC ? self::ASC : self::DESC,
             $orderings
         );
 

--- a/lib/Doctrine/Common/Collections/Criteria.php
+++ b/lib/Doctrine/Common/Collections/Criteria.php
@@ -74,7 +74,7 @@ class Criteria
      *
      * @return $this
      */
-    public function where(Expression $expression): self
+    public function where(Expression $expression): static
     {
         $this->expression = $expression;
 
@@ -87,7 +87,7 @@ class Criteria
      *
      * @return $this
      */
-    public function andWhere(Expression $expression): self
+    public function andWhere(Expression $expression): static
     {
         if ($this->expression === null) {
             return $this->where($expression);
@@ -107,7 +107,7 @@ class Criteria
      *
      * @return $this
      */
-    public function orWhere(Expression $expression): self
+    public function orWhere(Expression $expression): static
     {
         if ($this->expression === null) {
             return $this->where($expression);
@@ -151,7 +151,7 @@ class Criteria
      *
      * @return $this
      */
-    public function orderBy(array $orderings): self
+    public function orderBy(array $orderings): static
     {
         $this->orderings = array_map(
             static fn (string $ordering): string => strtoupper($ordering) === self::ASC ? self::ASC : self::DESC,
@@ -176,7 +176,7 @@ class Criteria
      *
      * @return $this
      */
-    public function setFirstResult(?int $firstResult): self
+    public function setFirstResult(?int $firstResult): static
     {
         $this->firstResult = $firstResult;
 
@@ -198,7 +198,7 @@ class Criteria
      *
      * @return $this
      */
-    public function setMaxResults(?int $maxResults): self
+    public function setMaxResults(?int $maxResults): static
     {
         $this->maxResults = $maxResults;
 

--- a/lib/Doctrine/Common/Collections/Expr/ClosureExpressionVisitor.php
+++ b/lib/Doctrine/Common/Collections/Expr/ClosureExpressionVisitor.php
@@ -157,7 +157,7 @@ class ClosureExpressionVisitor extends ExpressionVisitor
         return $value->getValue();
     }
 
-    public function walkCompositeExpression(CompositeExpression $expr): callable
+    public function walkCompositeExpression(CompositeExpression $expr): Closure
     {
         $expressionList = [];
 

--- a/lib/Doctrine/Common/Collections/Expr/Comparison.php
+++ b/lib/Doctrine/Common/Collections/Expr/Comparison.php
@@ -9,34 +9,28 @@ namespace Doctrine\Common\Collections\Expr;
  */
 class Comparison implements Expression
 {
-    public const EQ          = '=';
-    public const NEQ         = '<>';
-    public const LT          = '<';
-    public const LTE         = '<=';
-    public const GT          = '>';
-    public const GTE         = '>=';
-    public const IS          = '='; // no difference with EQ
-    public const IN          = 'IN';
-    public const NIN         = 'NIN';
-    public const CONTAINS    = 'CONTAINS';
-    public const MEMBER_OF   = 'MEMBER_OF';
-    public const STARTS_WITH = 'STARTS_WITH';
-    public const ENDS_WITH   = 'ENDS_WITH';
+    final public const EQ          = '=';
+    final public const NEQ         = '<>';
+    final public const LT          = '<';
+    final public const LTE         = '<=';
+    final public const GT          = '>';
+    final public const GTE         = '>=';
+    final public const IS          = '='; // no difference with EQ
+    final public const IN          = 'IN';
+    final public const NIN         = 'NIN';
+    final public const CONTAINS    = 'CONTAINS';
+    final public const MEMBER_OF   = 'MEMBER_OF';
+    final public const STARTS_WITH = 'STARTS_WITH';
+    final public const ENDS_WITH   = 'ENDS_WITH';
 
-    private string $field;
+    private readonly Value $value;
 
-    private string $op;
-
-    private Value $value;
-
-    public function __construct(string $field, string $operator, mixed $value)
+    public function __construct(private readonly string $field, private readonly string $op, mixed $value)
     {
         if (! ($value instanceof Value)) {
             $value = new Value($value);
         }
 
-        $this->field = $field;
-        $this->op    = $operator;
         $this->value = $value;
     }
 

--- a/lib/Doctrine/Common/Collections/Expr/CompositeExpression.php
+++ b/lib/Doctrine/Common/Collections/Expr/CompositeExpression.php
@@ -11,23 +11,19 @@ use RuntimeException;
  */
 class CompositeExpression implements Expression
 {
-    public const TYPE_AND = 'AND';
-    public const TYPE_OR  = 'OR';
-
-    private string $type;
+    final public const TYPE_AND = 'AND';
+    final public const TYPE_OR  = 'OR';
 
     /** @var list<Expression> */
-    private $expressions = [];
+    private array $expressions = [];
 
     /**
      * @param Expression[] $expressions
      *
      * @throws RuntimeException
      */
-    public function __construct(string $type, array $expressions)
+    public function __construct(private readonly string $type, array $expressions)
     {
-        $this->type = $type;
-
         foreach ($expressions as $expr) {
             if ($expr instanceof Value) {
                 throw new RuntimeException('Values are not supported expressions as children of and/or expressions.');

--- a/lib/Doctrine/Common/Collections/Expr/ExpressionVisitor.php
+++ b/lib/Doctrine/Common/Collections/Expr/ExpressionVisitor.php
@@ -34,18 +34,11 @@ abstract class ExpressionVisitor
      */
     public function dispatch(Expression $expr): mixed
     {
-        switch (true) {
-            case $expr instanceof Comparison:
-                return $this->walkComparison($expr);
-
-            case $expr instanceof Value:
-                return $this->walkValue($expr);
-
-            case $expr instanceof CompositeExpression:
-                return $this->walkCompositeExpression($expr);
-
-            default:
-                throw new RuntimeException('Unknown Expression ' . $expr::class);
-        }
+        return match (true) {
+            $expr instanceof Comparison => $this->walkComparison($expr),
+            $expr instanceof Value => $this->walkValue($expr),
+            $expr instanceof CompositeExpression => $this->walkCompositeExpression($expr),
+            default => throw new RuntimeException('Unknown Expression ' . $expr::class),
+        };
     }
 }

--- a/lib/Doctrine/Common/Collections/Expr/Value.php
+++ b/lib/Doctrine/Common/Collections/Expr/Value.php
@@ -6,11 +6,8 @@ namespace Doctrine\Common\Collections\Expr;
 
 class Value implements Expression
 {
-    private mixed $value;
-
-    public function __construct(mixed $value)
+    public function __construct(private readonly mixed $value)
     {
-        $this->value = $value;
     }
 
     public function getValue(): mixed

--- a/tests/Doctrine/Tests/Common/Collections/AbstractLazyCollectionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/AbstractLazyCollectionTest.php
@@ -48,9 +48,7 @@ class AbstractLazyCollectionTest extends BaseCollectionTest
         $collection = $this->buildCollection([1, 'foo', 3]);
         assert($collection instanceof LazyArrayCollection);
 
-        $res = $collection->filter(static function ($value) {
-            return is_numeric($value);
-        });
+        $res = $collection->filter(static fn ($value) => is_numeric($value));
 
         self::assertEquals([0 => 1, 2 => 3], $res->toArray());
     }
@@ -59,31 +57,23 @@ class AbstractLazyCollectionTest extends BaseCollectionTest
     {
         $collection = $this->buildCollection(['foo', 'bar']);
 
-        self::assertEquals($collection->forAll(static function ($k, $e) {
-            return is_string($e);
-        }), true);
+        self::assertEquals($collection->forAll(static fn ($k, $e) => is_string($e)), true);
 
-        self::assertEquals($collection->forAll(static function ($k, $e) {
-            return is_array($e);
-        }), false);
+        self::assertEquals($collection->forAll(static fn ($k, $e) => is_array($e)), false);
     }
 
     public function testMapInitializes(): void
     {
         $collection = $this->buildCollection([1, 2]);
 
-        $res = $collection->map(static function ($e) {
-            return $e * 2;
-        });
+        $res = $collection->map(static fn ($e) => $e * 2);
         self::assertEquals([2, 4], $res->toArray());
     }
 
     public function testPartitionInitializes(): void
     {
         $collection = $this->buildCollection([true, false]);
-        $partition  = $collection->partition(static function ($k, $e) {
-            return $e === true;
-        });
+        $partition  = $collection->partition(static fn ($k, $e) => $e === true);
         self::assertEquals($partition[0][0], true);
         self::assertEquals($partition[1][0], false);
     }

--- a/tests/Doctrine/Tests/Common/Collections/ArrayCollectionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/ArrayCollectionTest.php
@@ -13,6 +13,8 @@ use function json_encode;
 use function serialize;
 use function unserialize;
 
+use const JSON_THROW_ON_ERROR;
+
 /**
  * Tests for {@see \Doctrine\Common\Collections\ArrayCollection}.
  *
@@ -48,13 +50,12 @@ class SerializableArrayCollection extends ArrayCollection implements Serializabl
 {
     public function serialize(): string
     {
-        return json_encode($this->getKeys());
+        return json_encode($this->getKeys(), JSON_THROW_ON_ERROR);
     }
 
-    // phpcs:ignore SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingAnyTypeHint
-    public function unserialize($serialized): void
+    public function unserialize(string $serialized): void
     {
-        foreach (json_decode($serialized) as $value) {
+        foreach (json_decode(json: $serialized, flags: JSON_THROW_ON_ERROR) as $value) {
             parent::add($value);
         }
     }

--- a/tests/Doctrine/Tests/Common/Collections/BaseArrayCollectionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/BaseArrayCollectionTest.php
@@ -269,13 +269,9 @@ abstract class BaseArrayCollectionTest extends TestCase
         $elements   = [1, 'A' => 'a', 2, 'null' => null, 3, 'A2' => 'a', 'zero' => 0];
         $collection = $this->buildCollection($elements);
 
-        self::assertTrue($collection->exists(static function ($key, $element) {
-            return $key === 'A' && $element === 'a';
-        }), 'Element exists');
+        self::assertTrue($collection->exists(static fn ($key, $element) => $key === 'A' && $element === 'a'), 'Element exists');
 
-        self::assertFalse($collection->exists(static function ($key, $element) {
-            return $key === 'non-existent' && $element === 'non-existent';
-        }), 'Element not exists');
+        self::assertFalse($collection->exists(static fn ($key, $element) => $key === 'non-existent' && $element === 'non-existent'), 'Element not exists');
     }
 
     public function testFindFirst(): void
@@ -283,9 +279,7 @@ abstract class BaseArrayCollectionTest extends TestCase
         $elements   = [1, 'A' => 'a', 2, 'null' => null, 3, 'A2' => 'a', 'zero' => 0];
         $collection = $this->buildCollection($elements);
 
-        self::assertSame('a', $collection->findFirst(static function ($key, $element) {
-            return $key === 'A' && $element === 'a';
-        }), 'Element exists');
+        self::assertSame('a', $collection->findFirst(static fn ($key, $element) => $key === 'A' && $element === 'a'), 'Element exists');
     }
 
     public function testFindFirstNotFound(): void
@@ -293,9 +287,7 @@ abstract class BaseArrayCollectionTest extends TestCase
         $elements   = [1, 'A' => 'a', 2, 'null' => null, 3, 'A2' => 'a', 'zero' => 0];
         $collection = $this->buildCollection($elements);
 
-        self::assertNull($collection->findFirst(static function ($key, $element) {
-            return $key === 'non-existent' && $element === 'non-existent';
-        }), 'Element does not exists');
+        self::assertNull($collection->findFirst(static fn ($key, $element) => $key === 'non-existent' && $element === 'non-existent'), 'Element does not exists');
     }
 
     public function testIndexOf(): void

--- a/tests/Doctrine/Tests/Common/Collections/BaseCollectionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/BaseCollectionTest.php
@@ -36,13 +36,9 @@ abstract class BaseCollectionTest extends TestCase
     {
         $this->collection->add('one');
         $this->collection->add('two');
-        $exists = $this->collection->exists(static function ($k, $e) {
-            return $e === 'one';
-        });
+        $exists = $this->collection->exists(static fn ($k, $e) => $e === 'one');
         self::assertTrue($exists);
-        $exists = $this->collection->exists(static function ($k, $e) {
-            return $e === 'other';
-        });
+        $exists = $this->collection->exists(static fn ($k, $e) => $e === 'other');
         self::assertFalse($exists);
     }
 
@@ -50,9 +46,7 @@ abstract class BaseCollectionTest extends TestCase
     {
         $this->collection->add('one');
         $this->collection->add('two');
-        $one = $this->collection->findFirst(static function ($k, $e) {
-            return $e === 'one';
-        });
+        $one = $this->collection->findFirst(static fn ($k, $e) => $e === 'one');
         self::assertSame('one', $one);
     }
 
@@ -60,9 +54,7 @@ abstract class BaseCollectionTest extends TestCase
     {
         $this->collection->add('one');
         $this->collection->add('two');
-        $other = $this->collection->findFirst(static function ($k, $e) {
-            return $e === 'other';
-        });
+        $other = $this->collection->findFirst(static fn ($k, $e) => $e === 'other');
         self::assertNull($other);
     }
 
@@ -70,9 +62,7 @@ abstract class BaseCollectionTest extends TestCase
     {
         $this->collection->add(1);
         $this->collection->add(2);
-        $res = $this->collection->map(static function ($e) {
-            return $e * 2;
-        });
+        $res = $this->collection->map(static fn ($e) => $e * 2);
         self::assertEquals([2, 4], $res->toArray());
     }
 
@@ -83,9 +73,7 @@ abstract class BaseCollectionTest extends TestCase
         $this->collection->add(3);
         $this->collection->add(4);
 
-        $res = $this->collection->reduce(static function ($sum, $e) {
-            return $sum + $e;
-        });
+        $res = $this->collection->reduce(static fn ($sum, $e) => $sum + $e);
         self::assertSame(10, $res);
     }
 
@@ -94,9 +82,7 @@ abstract class BaseCollectionTest extends TestCase
         $this->collection->add(1);
         $this->collection->add('foo');
         $this->collection->add(3);
-        $res = $this->collection->filter(static function ($e) {
-            return is_numeric($e);
-        });
+        $res = $this->collection->filter(static fn ($e) => is_numeric($e));
         self::assertEquals([0 => 1, 2 => 3], $res->toArray());
     }
 
@@ -107,9 +93,7 @@ abstract class BaseCollectionTest extends TestCase
         $this->collection->add(3);
         $this->collection->add(4);
         $this->collection->add(5);
-        $res = $this->collection->filter(static function ($v, $k) {
-            return is_numeric($v) && $k % 2 === 0;
-        });
+        $res = $this->collection->filter(static fn ($v, $k) => is_numeric($v) && $k % 2 === 0);
         self::assertSame([0 => 1, 2 => 3, 4 => 5], $res->toArray());
     }
 
@@ -184,21 +168,15 @@ abstract class BaseCollectionTest extends TestCase
     {
         $this->collection[] = 'one';
         $this->collection[] = 'two';
-        self::assertEquals($this->collection->forAll(static function ($k, $e) {
-            return is_string($e);
-        }), true);
-        self::assertEquals($this->collection->forAll(static function ($k, $e) {
-            return is_array($e);
-        }), false);
+        self::assertEquals($this->collection->forAll(static fn ($k, $e) => is_string($e)), true);
+        self::assertEquals($this->collection->forAll(static fn ($k, $e) => is_array($e)), false);
     }
 
     public function testPartition(): void
     {
         $this->collection[] = true;
         $this->collection[] = false;
-        $partition          = $this->collection->partition(static function ($k, $e) {
-            return $e === true;
-        });
+        $partition          = $this->collection->partition(static fn ($k, $e) => $e === true);
         self::assertEquals($partition[0][0], true);
         self::assertEquals($partition[1][0], false);
     }

--- a/tests/Doctrine/Tests/Common/Collections/ClosureExpressionVisitorTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/ClosureExpressionVisitorTest.php
@@ -412,20 +412,12 @@ class ClosureExpressionVisitorTest extends TestCase
 
 class TestObject
 {
-    private mixed $foo;
-
-    private mixed $bar;
-
-    private mixed $baz;
-
-    private mixed $qux;
-
-    public function __construct(mixed $foo = null, mixed $bar = null, mixed $baz = null, mixed $qux = null)
-    {
-        $this->foo = $foo;
-        $this->bar = $bar;
-        $this->baz = $baz;
-        $this->qux = $qux;
+    public function __construct(
+        private readonly mixed $foo = null,
+        private readonly mixed $bar = null,
+        private readonly mixed $baz = null,
+        private readonly mixed $qux = null,
+    ) {
     }
 
     /**
@@ -456,11 +448,8 @@ class TestObject
 
 class TestObjectNotCamelCase
 {
-    private ?int $foo_bar = null;
-
-    public function __construct(?int $foo_bar)
+    public function __construct(private readonly ?int $foo_bar)
     {
-        $this->foo_bar = $foo_bar;
     }
 
     public function getFooBar(): ?int
@@ -471,14 +460,8 @@ class TestObjectNotCamelCase
 
 class TestObjectBothCamelCaseAndUnderscore
 {
-    private ?int $foo_bar = null;
-
-    private ?int $fooBar = null;
-
-    public function __construct(?int $foo_bar = null, ?int $fooBar = null)
+    public function __construct(private readonly ?int $foo_bar = null, private readonly ?int $fooBar = null)
     {
-        $this->foo_bar = $foo_bar;
-        $this->fooBar  = $fooBar;
     }
 
     public function getFooBar(): ?int
@@ -489,14 +472,8 @@ class TestObjectBothCamelCaseAndUnderscore
 
 class TestObjectPublicCamelCaseAndPrivateUnderscore
 {
-    private ?int $foo_bar = null;
-
-    public ?int $fooBar = null;
-
-    public function __construct(?int $foo_bar = null, ?int $fooBar = null)
+    public function __construct(private readonly ?int $foo_bar = null, public ?int $fooBar = null)
     {
-        $this->foo_bar = $foo_bar;
-        $this->fooBar  = $fooBar;
     }
 
     public function getFooBar(): ?int
@@ -507,14 +484,8 @@ class TestObjectPublicCamelCaseAndPrivateUnderscore
 
 class TestObjectBothPublic
 {
-    public mixed $foo_bar;
-
-    public mixed $fooBar;
-
-    public function __construct(mixed $foo_bar = null, mixed $fooBar = null)
+    public function __construct(public mixed $foo_bar = null, public mixed $fooBar = null)
     {
-        $this->foo_bar = $foo_bar;
-        $this->fooBar  = $fooBar;
     }
 
     public function getFooBar(): mixed
@@ -525,11 +496,8 @@ class TestObjectBothPublic
 
 class TestObjectBlankGetter
 {
-    public ?int $fooBar = null;
-
-    public function __construct(?int $fooBar = null)
+    public function __construct(public ?int $fooBar = null)
     {
-        $this->fooBar = $fooBar;
     }
 
     public function fooBar(): ?int

--- a/tests/Doctrine/Tests/Common/Collections/CollectionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/CollectionTest.php
@@ -48,9 +48,7 @@ class CollectionTest extends BaseCollectionTest
 
         $col = $this->collection->matching(
             new Criteria(
-                new Value(static function (stdClass $test): bool {
-                    return $test->foo === 1;
-                })
+                new Value(static fn (stdClass $test): bool => $test->foo === 1)
             )
         );
 

--- a/tests/Doctrine/Tests/Common/Collections/DerivedCollectionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/DerivedCollectionTest.php
@@ -18,9 +18,7 @@ class DerivedCollectionTest extends TestCase
     public function testDerivedClassCreation(): void
     {
         $collection = new DerivedArrayCollection(new stdClass());
-        $closure    = static function () {
-            return $allMatches = false;
-        };
+        $closure    = static fn () => $allMatches = false;
 
         self::assertInstanceOf(DerivedArrayCollection::class, $collection->map($closure));
         self::assertInstanceOf(DerivedArrayCollection::class, $collection->filter($closure));

--- a/tests/Doctrine/Tests/DerivedArrayCollection.php
+++ b/tests/Doctrine/Tests/DerivedArrayCollection.php
@@ -12,15 +12,11 @@ use stdClass;
  */
 final class DerivedArrayCollection extends ArrayCollection
 {
-    private stdClass $foo;
-
     /**
      * @param mixed[] $elements
      */
-    public function __construct(stdClass $foo, array $elements = [])
+    public function __construct(private readonly stdClass $foo, array $elements = [])
     {
-        $this->foo = $foo;
-
         parent::__construct($elements);
     }
 

--- a/tests/Doctrine/Tests/LazyArrayCollection.php
+++ b/tests/Doctrine/Tests/LazyArrayCollection.php
@@ -13,18 +13,11 @@ use Doctrine\Common\Collections\Collection;
 class LazyArrayCollection extends AbstractLazyCollection
 {
     /**
-     * Apply the collection only in method doInitialize
-     *
-     * @var Collection<mixed>
+     * @param Collection<mixed> $collectionOnInitialization Apply the collection only in method doInitialize
      */
-    private Collection $collectionOnInitialization;
-
-    /**
-     * @param Collection<mixed> $collection
-     */
-    public function __construct(Collection $collection)
-    {
-        $this->collectionOnInitialization = $collection;
+    public function __construct(
+        private readonly Collection $collectionOnInitialization
+    ) {
     }
 
     /**


### PR DESCRIPTION
This is what happens when you run rector with the following configuration:

```php
<?php

declare(strict_types=1);

use Rector\Config\RectorConfig;
use Rector\Php71\Rector\FuncCall\CountOnNullRector;
use Rector\Set\ValueObject\LevelSetList;
use Rector\TypeDeclaration\Rector\FunctionLike\ParamTypeDeclarationRector;
use Rector\TypeDeclaration\Rector\FunctionLike\ReturnTypeDeclarationRector;

return static function (RectorConfig $rectorConfig): void {
    $rectorConfig->paths([
        __DIR__ . '/lib',
        __DIR__ . '/tests',
    ]);

    $rectorConfig->sets([
        LevelSetList::UP_TO_PHP_81,
    ]);

    $rectorConfig->rule(ParamTypeDeclarationRector::class);
    $rectorConfig->rule(ReturnTypeDeclarationRector::class);

    $rectorConfig->importNames();
    $rectorConfig->skip([
        CountOnNullRector::class, // I haven't reevaluated this rule
    ]);
};
```

I made some manual tweaks, for instance for CPP, I moved / will move phpdoc comments to `@param` rather than `@var` on properties.