### PR TITLE
Deprecate passing null as offset

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,8 @@
     ],
     "homepage": "https://www.doctrine-project.org/projects/collections.html",
     "require": {
-        "php": "^7.1.3 || ^8.0"
+        "php": "^7.1.3 || ^8.0",
+        "doctrine/deprecations": "^0.5.3 || ^1"
     },
     "require-dev": {
         "doctrine/coding-standard": "^9.0",

--- a/lib/Doctrine/Common/Collections/Criteria.php
+++ b/lib/Doctrine/Common/Collections/Criteria.php
@@ -4,8 +4,10 @@ namespace Doctrine\Common\Collections;
 
 use Doctrine\Common\Collections\Expr\CompositeExpression;
 use Doctrine\Common\Collections\Expr\Expression;
+use Doctrine\Deprecations\Deprecation;
 
 use function array_map;
+use function func_num_args;
 use function strtoupper;
 
 /**
@@ -68,6 +70,15 @@ class Criteria
     public function __construct(?Expression $expression = null, ?array $orderings = null, $firstResult = null, $maxResults = null)
     {
         $this->expression = $expression;
+
+        if ($firstResult === null && func_num_args() > 2) {
+            Deprecation::trigger(
+                'doctrine/collections',
+                'https://github.com/doctrine/collections/pull/311',
+                'Passing null as $firstResult to the constructor of %s is deprecated. Pass 0 instead or omit the argument.',
+                self::class
+            );
+        }
 
         $this->setFirstResult($firstResult);
         $this->setMaxResults($maxResults);
@@ -194,6 +205,15 @@ class Criteria
      */
     public function setFirstResult($firstResult)
     {
+        if ($firstResult === null) {
+            Deprecation::triggerIfCalledFromOutside(
+                'doctrine/collections',
+                'https://github.com/doctrine/collections/pull/311',
+                'Passing null to %s() is deprecated, pass 0 instead.',
+                __METHOD__
+            );
+        }
+
         $this->firstResult = $firstResult;
 
         return $this;

--- a/tests/Doctrine/Tests/Common/Collections/CriteriaTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/CriteriaTest.php
@@ -6,10 +6,13 @@ use Doctrine\Common\Collections\Criteria;
 use Doctrine\Common\Collections\Expr\Comparison;
 use Doctrine\Common\Collections\Expr\CompositeExpression;
 use Doctrine\Common\Collections\ExpressionBuilder;
+use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use PHPUnit\Framework\TestCase;
 
 class CriteriaTest extends TestCase
 {
+    use VerifyDeprecations;
+
     public function testCreate(): void
     {
         $criteria = Criteria::create();
@@ -23,9 +26,33 @@ class CriteriaTest extends TestCase
         $criteria = new Criteria($expr, ['foo' => 'ASC'], 10, 20);
 
         self::assertSame($expr, $criteria->getWhereExpression());
-        self::assertEquals(['foo' => 'ASC'], $criteria->getOrderings());
-        self::assertEquals(10, $criteria->getFirstResult());
-        self::assertEquals(20, $criteria->getMaxResults());
+        self::assertSame(['foo' => 'ASC'], $criteria->getOrderings());
+        self::assertSame(10, $criteria->getFirstResult());
+        self::assertSame(20, $criteria->getMaxResults());
+    }
+
+    public function testDeprecatedNullOffset(): void
+    {
+        $expr = new Comparison('field', '=', 'value');
+
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/collections/pull/311');
+        $criteria = new Criteria($expr, ['foo' => 'ASC'], null, 20);
+
+        self::assertSame($expr, $criteria->getWhereExpression());
+        self::assertSame(['foo' => 'ASC'], $criteria->getOrderings());
+        self::assertNull($criteria->getFirstResult());
+        self::assertSame(20, $criteria->getMaxResults());
+    }
+
+    public function testDefaultConstructor(): void
+    {
+        $this->expectNoDeprecationWithIdentifier('https://github.com/doctrine/collections/pull/311');
+        $criteria = new Criteria();
+
+        self::assertNull($criteria->getWhereExpression());
+        self::assertSame([], $criteria->getOrderings());
+        self::assertNull($criteria->getFirstResult());
+        self::assertNull($criteria->getMaxResults());
     }
 
     public function testWhere(): void


### PR DESCRIPTION
In order to be able to narrow down parameter and return types for 2.0, I think we should disallow using `null` as offset for `Criteria` instances. We've applied similar changes to DBAL and ORM already.