### PR TITLE
Make `Selectable#matching` return `Collection`

### DIFF
--- a/lib/Doctrine/Common/Collections/Selectable.php
+++ b/lib/Doctrine/Common/Collections/Selectable.php
@@ -23,8 +23,8 @@ interface Selectable
      * Selects all elements from a selectable that match the expression and
      * returns a new collection containing these elements.
      *
-     * @return Collection<mixed>
-     * @psalm-return Collection<TKey,T>
+     * @return Collection<mixed>&Selectable<mixed>
+     * @psalm-return Collection<TKey,T>&Selectable<TKey,T>
      */
     public function matching(Criteria $criteria);
 }

--- a/tests/Doctrine/Tests/Common/Collections/BaseCollectionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/BaseCollectionTest.php
@@ -3,6 +3,8 @@
 namespace Doctrine\Tests\Common\Collections;
 
 use Doctrine\Common\Collections\Collection;
+use Doctrine\Common\Collections\Criteria;
+use Doctrine\Common\Collections\Selectable;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
@@ -10,6 +12,7 @@ use function count;
 use function is_array;
 use function is_numeric;
 use function is_string;
+use function sprintf;
 
 abstract class BaseCollectionTest extends TestCase
 {
@@ -236,5 +239,17 @@ abstract class BaseCollectionTest extends TestCase
     {
         $this->collection->set('key', null);
         self::assertTrue($this->collection->containsKey('key'));
+    }
+
+    public function testMatchingAlwaysReturnsCollection(): void
+    {
+        if (! $this->collection instanceof Selectable) {
+            self::markTestSkipped(sprintf('Collection does not implement %s', Selectable::class));
+        }
+
+        $criteria = Criteria::create();
+
+        self::assertInstanceOf(Collection::class, $this->collection->matching($criteria));
+        self::assertInstanceOf(Selectable::class, $this->collection->matching($criteria));
     }
 }


### PR DESCRIPTION
Hey there,

as stated in #291, `Selectable#matching` always returns a `Collection` which is also `Selectable`.
Ping @greg0ire @AndrolGenhald

Happy to get feedback here. 
Since we do not change any code here but adding an additional return value (which is already the case in almost every implementation), I've targeted 1.6.x rather than 1.7.x

Let me know if this should be released in a new minor instead, so I can rebase the branch appropriately.

Thanks!