### PR TITLE
Update branch metadata

### DIFF
--- a/.doctrine-project.json
+++ b/.doctrine-project.json
@@ -11,16 +11,22 @@
             "upcoming": true
         },
         {
+            "name": "1.8",
+            "branchName": "1.8.x",
+            "slug": "1.8",
+            "upcoming": true
+        },
+        {
             "name": "1.7",
             "branchName": "1.7.x",
             "slug": "1.7",
-            "upcoming": true
+            "current": true
         },
         {
             "name": "1.6",
             "branchName": "1.6.x",
             "slug": "1.6",
-            "current": true
+            "maintained": false
         }
     ]
 }


### PR DESCRIPTION
I noticed that branches prior to 1.6.x don't exist. Should we delete 1.6.x?