### PR TITLE
Add psalm-assert-if-true to `AbstractLazyCollection::isInitialized`

### DIFF
--- a/lib/Doctrine/Common/Collections/AbstractLazyCollection.php
+++ b/lib/Doctrine/Common/Collections/AbstractLazyCollection.php
@@ -347,6 +347,8 @@ abstract class AbstractLazyCollection implements Collection
      * Is the lazy collection already initialized?
      *
      * @return bool
+     *
+     * @psalm-assert-if-true Collection<TKey,T> $this->collection
      */
     public function isInitialized()
     {


### PR DESCRIPTION
Related to https://github.com/doctrine/collections/pull/313 @derrabus 

It should solve some of PossiblyNull issues of doctrine/orm https://github.com/doctrine/orm/runs/7947119203?check_suite_focus=true