### PR TITLE
Make signature compatible with parent signature

### DIFF
--- a/lib/Doctrine/Common/Collections/ArrayCollection.php
+++ b/lib/Doctrine/Common/Collections/ArrayCollection.php
@@ -340,7 +340,7 @@ class ArrayCollection implements Collection, Selectable
     /**
      * {@inheritDoc}
      *
-     * @psalm-param Closure(T=):U $func
+     * @psalm-param Closure(T):U $func
      *
      * @return static
      * @psalm-return static<TKey, U>


### PR DESCRIPTION
Follow up of #323 , which used a different version of PHPStan