### PR TITLE
Make Selectable template covariant

### DIFF
--- a/lib/Doctrine/Common/Collections/Selectable.php
+++ b/lib/Doctrine/Common/Collections/Selectable.php
@@ -17,7 +17,7 @@ namespace Doctrine\Common\Collections;
  * EntityManager or Repositories.
  *
  * @psalm-template TKey as array-key
- * @psalm-template T
+ * @psalm-template-covariant T
  */
 interface Selectable
 {
@@ -25,8 +25,8 @@ interface Selectable
      * Selects all elements from a selectable that match the expression and
      * returns a new collection containing these elements and preserved keys.
      *
-     * @return Collection<mixed>&Selectable<mixed>
-     * @psalm-return Collection<TKey,T>&Selectable<TKey,T>
+     * @return ReadableCollection<mixed>&Selectable<mixed>
+     * @psalm-return ReadableCollection<TKey,T>&Selectable<TKey,T>
      */
-    public function matching(Criteria $criteria): Collection;
+    public function matching(Criteria $criteria): ReadableCollection;
 }


### PR DESCRIPTION
With this, we express that one cannot use matching() to alter the templated type of a Selectable, which means that it is OK to pass a Selectable of a type to a method that accepts a Selectable of a parent type.

The drawback is that it is no longer possible to use methods defined in Collection on an object that is returned by matching().