### PR TITLE
Postpone return type additions to 3.0

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -22,51 +22,20 @@ You can find a list of major changes to public API below.
 
 ### Doctrine\Common\Collections\Collection
 
-|             before             |                  after                         |
-|-------------------------------:|:-----------------------------------------------|
-| add($element)                  | add(mixed $element)                            |
-| clear()                        | clear(): void                                  |
-| contains($element)             | contains(mixed $element): bool                 |
-| isEmpty()                      | isEmpty(): bool                                |
-| removeElement($element)        | removeElement(mixed $element): bool            |
-| containsKey($key)              | containsKey(string|int $key): bool             |
-| get()                          | get(string|int $key): mixed                    |
-| getKeys()                      | getKeys(): array                               |
-| getValues()                    | getValues(): array                             |
-| set($key, $value)              | set(string|int $key, $value): void             |
-| toArray()                      | toArray(): array                               |
-| first()                        | first(): mixed                                 |
-| last()                         | last(): mixed                                  |
-| key()                          | key(): int|string|null                         |
-| current()                      | current(): mixed                               |
-| next()                         | next(): mixed                                  |
-| exists(Closure $p)             | exists(Closure $p): bool                       |
-| filter(Closure $p)             | filter(Closure $p): self                       |
-| forAll(Closure $p)             | forAll(Closure $p): bool                       |
-| map(Closure $func)             | map(Closure $func): self                       |
-| partition(Closure $p)          | partition(Closure $p): array                   |
-| indexOf($element)              | indexOf(mixed $element): int|string|false      |
-| slice($offset, $length = null) | slice(int $offset, ?int $length = null): array |
-| count()                        | count(): int                                   |
-| getIterator()                  | getIterator(): \Traversable                    |
-| offsetSet($offset, $value)     | offsetSet(mixed $offset, mixed $value): void   |
-| offsetUnset($offset)           | offsetUnset(mixed $offset): void               |
-| offsetExists($offset)          | offsetExists(mixed $offset): bool              |
+|             before             |                  after                  |
+|-------------------------------:|:----------------------------------------|
+| add($element)                  | add(mixed $element)                     |
+| contains($element)             | contains(mixed $element)                |
+| removeElement($element)        | removeElement(mixed $element)           |
+| containsKey($key)              | containsKey(string|int $key)            |
+| get()                          | get(string|int $key)                    |
+| set($key, $value)              | set(string|int $key, $value)            |
+| indexOf($element)              | indexOf(mixed $element)                 |
+| slice($offset, $length = null) | slice(int $offset, ?int $length = null) |
+| offsetSet($offset, $value)     | offsetSet(mixed $offset, mixed $value)  |
+| offsetUnset($offset)           | offsetUnset(mixed $offset)              |
+| offsetExists($offset)          | offsetExists(mixed $offset)             |
 
-### Doctrine\Common\Collections\AbstractLazyCollection
-
-|      before     |         after         |
-|----------------:|:----------------------|
-| isInitialized() | isInitialized(): bool |
-| initialize()    | initialize(): void    |
-| doInitialize()  | doInitialize(): void  |
-
-### Doctrine\Common\Collections\ArrayCollection
-
-|            before           |               after                 |
-|----------------------------:|:------------------------------------|
-| createFrom(array $elements) | createFrom(array $elements): static |
-| __toString()                | __toString(): string                |
 
 ### Doctrine\Common\Collections\Criteria
 
@@ -78,9 +47,3 @@ You can find a list of major changes to public API below.
 | orderBy(array $orderings): self         | orderBy(array $orderings): static         |
 | setFirstResult(?int $firstResult): self | setFirstResult(?int $firstResult): static |
 | setMaxResult(?int $maxResults): self    | setMaxResults(?int $maxResults): static   |
-
-### Doctrine\Common\Collections\Selectable
-
-|             before           |                   after                  |
-|-----------------------------:|:-----------------------------------------|
-| matching(Criteria $criteria) | matching(Criteria $criteria): Collection |

--- a/lib/Doctrine/Common/Collections/AbstractLazyCollection.php
+++ b/lib/Doctrine/Common/Collections/AbstractLazyCollection.php
@@ -6,6 +6,7 @@ namespace Doctrine\Common\Collections;
 
 use Closure;
 use LogicException;
+use ReturnTypeWillChange;
 use Traversable;
 
 /**
@@ -27,13 +28,20 @@ abstract class AbstractLazyCollection implements Collection
 
     protected bool $initialized = false;
 
-    public function count(): int
+    /**
+     * {@inheritDoc}
+     */
+    #[ReturnTypeWillChange]
+    public function count()
     {
         $this->initialize();
 
         return $this->collection->count();
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function add(mixed $element)
     {
         $this->initialize();
@@ -41,7 +49,10 @@ abstract class AbstractLazyCollection implements Collection
         $this->collection->add($element);
     }
 
-    public function clear(): void
+    /**
+     * {@inheritDoc}
+     */
+    public function clear()
     {
         $this->initialize();
         $this->collection->clear();
@@ -52,42 +63,57 @@ abstract class AbstractLazyCollection implements Collection
      *
      * @template TMaybeContained
      */
-    public function contains(mixed $element): bool
+    public function contains(mixed $element)
     {
         $this->initialize();
 
         return $this->collection->contains($element);
     }
 
-    public function isEmpty(): bool
+    /**
+     * {@inheritDoc}
+     */
+    public function isEmpty()
     {
         $this->initialize();
 
         return $this->collection->isEmpty();
     }
 
-    public function remove(string|int $key): mixed
+    /**
+     * {@inheritDoc}
+     */
+    public function remove(string|int $key)
     {
         $this->initialize();
 
         return $this->collection->remove($key);
     }
 
-    public function removeElement(mixed $element): bool
+    /**
+     * {@inheritDoc}
+     */
+    public function removeElement(mixed $element)
     {
         $this->initialize();
 
         return $this->collection->removeElement($element);
     }
 
-    public function containsKey(string|int $key): bool
+    /**
+     * {@inheritDoc}
+     */
+    public function containsKey(string|int $key)
     {
         $this->initialize();
 
         return $this->collection->containsKey($key);
     }
 
-    public function get(string|int $key): mixed
+    /**
+     * {@inheritDoc}
+     */
+    public function get(string|int $key)
     {
         $this->initialize();
 
@@ -97,7 +123,7 @@ abstract class AbstractLazyCollection implements Collection
     /**
      * {@inheritDoc}
      */
-    public function getKeys(): array
+    public function getKeys()
     {
         $this->initialize();
 
@@ -107,7 +133,7 @@ abstract class AbstractLazyCollection implements Collection
     /**
      * {@inheritDoc}
      */
-    public function getValues(): array
+    public function getValues()
     {
         $this->initialize();
 
@@ -117,7 +143,7 @@ abstract class AbstractLazyCollection implements Collection
     /**
      * {@inheritDoc}
      */
-    public function set($key, $value): void
+    public function set(string|int $key, mixed $value)
     {
         $this->initialize();
         $this->collection->set($key, $value);
@@ -126,56 +152,77 @@ abstract class AbstractLazyCollection implements Collection
     /**
      * {@inheritDoc}
      */
-    public function toArray(): array
+    public function toArray()
     {
         $this->initialize();
 
         return $this->collection->toArray();
     }
 
-    public function first(): mixed
+    /**
+     * {@inheritDoc}
+     */
+    public function first()
     {
         $this->initialize();
 
         return $this->collection->first();
     }
 
-    public function last(): mixed
+    /**
+     * {@inheritDoc}
+     */
+    public function last()
     {
         $this->initialize();
 
         return $this->collection->last();
     }
 
-    public function key(): string|int|null
+    /**
+     * {@inheritDoc}
+     */
+    public function key()
     {
         $this->initialize();
 
         return $this->collection->key();
     }
 
-    public function current(): mixed
+    /**
+     * {@inheritDoc}
+     */
+    public function current()
     {
         $this->initialize();
 
         return $this->collection->current();
     }
 
-    public function next(): mixed
+    /**
+     * {@inheritDoc}
+     */
+    public function next()
     {
         $this->initialize();
 
         return $this->collection->next();
     }
 
-    public function exists(Closure $p): bool
+    /**
+     * {@inheritDoc}
+     */
+    public function exists(Closure $p)
     {
         $this->initialize();
 
         return $this->collection->exists($p);
     }
 
-    public function findFirst(Closure $p): mixed
+    /**
+     * {@inheritDoc}
+     */
+    public function findFirst(Closure $p)
     {
         $this->initialize();
 
@@ -188,14 +235,17 @@ abstract class AbstractLazyCollection implements Collection
      * @return ReadableCollection<mixed>
      * @psalm-return ReadableCollection<TKey, T>
      */
-    public function filter(Closure $p): ReadableCollection
+    public function filter(Closure $p)
     {
         $this->initialize();
 
         return $this->collection->filter($p);
     }
 
-    public function forAll(Closure $p): bool
+    /**
+     * {@inheritDoc}
+     */
+    public function forAll(Closure $p)
     {
         $this->initialize();
 
@@ -203,6 +253,8 @@ abstract class AbstractLazyCollection implements Collection
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @psalm-param Closure(T):U $func
      *
      * @return ReadableCollection<mixed>
@@ -210,7 +262,7 @@ abstract class AbstractLazyCollection implements Collection
      *
      * @psalm-template U
      */
-    public function map(Closure $func): ReadableCollection
+    public function map(Closure $func)
     {
         $this->initialize();
 
@@ -220,7 +272,7 @@ abstract class AbstractLazyCollection implements Collection
     /**
      * {@inheritDoc}
      */
-    public function reduce(Closure $func, $initial = null): mixed
+    public function reduce(Closure $func, mixed $initial = null)
     {
         $this->initialize();
 
@@ -230,7 +282,7 @@ abstract class AbstractLazyCollection implements Collection
     /**
      * {@inheritDoc}
      */
-    public function partition(Closure $p): array
+    public function partition(Closure $p)
     {
         $this->initialize();
 
@@ -242,7 +294,7 @@ abstract class AbstractLazyCollection implements Collection
      *
      * @template TMaybeContained
      */
-    public function indexOf($element): string|int|false
+    public function indexOf(mixed $element)
     {
         $this->initialize();
 
@@ -252,7 +304,7 @@ abstract class AbstractLazyCollection implements Collection
     /**
      * {@inheritDoc}
      */
-    public function slice(int $offset, int|null $length = null): array
+    public function slice(int $offset, int|null $length = null)
     {
         $this->initialize();
 
@@ -260,26 +312,39 @@ abstract class AbstractLazyCollection implements Collection
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @return Traversable<int|string, mixed>
      * @psalm-return Traversable<TKey,T>
      */
-    public function getIterator(): Traversable
+    #[ReturnTypeWillChange]
+    public function getIterator()
     {
         $this->initialize();
 
         return $this->collection->getIterator();
     }
 
-    /** @param TKey $offset */
-    public function offsetExists($offset): bool
+    /**
+     * {@inheritDoc}
+     *
+     * @param TKey $offset
+     */
+    #[ReturnTypeWillChange]
+    public function offsetExists(mixed $offset)
     {
         $this->initialize();
 
         return $this->collection->offsetExists($offset);
     }
 
-    /** @param TKey $offset */
-    public function offsetGet(mixed $offset): mixed
+    /**
+     * {@inheritDoc}
+     *
+     * @param TKey $offset
+     */
+    #[ReturnTypeWillChange]
+    public function offsetGet(mixed $offset)
     {
         $this->initialize();
 
@@ -287,17 +352,21 @@ abstract class AbstractLazyCollection implements Collection
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @param TKey|null $offset
      * @param T         $value
      */
-    public function offsetSet(mixed $offset, mixed $value): void
+    #[ReturnTypeWillChange]
+    public function offsetSet(mixed $offset, mixed $value)
     {
         $this->initialize();
         $this->collection->offsetSet($offset, $value);
     }
 
     /** @param TKey $offset */
-    public function offsetUnset(mixed $offset): void
+    #[ReturnTypeWillChange]
+    public function offsetUnset(mixed $offset)
     {
         $this->initialize();
         $this->collection->offsetUnset($offset);
@@ -306,9 +375,11 @@ abstract class AbstractLazyCollection implements Collection
     /**
      * Is the lazy collection already initialized?
      *
+     * @return bool
+     *
      * @psalm-assert-if-true Collection<TKey,T> $this->collection
      */
-    public function isInitialized(): bool
+    public function isInitialized()
     {
         return $this->initialized;
     }
@@ -316,9 +387,11 @@ abstract class AbstractLazyCollection implements Collection
     /**
      * Initialize the collection
      *
+     * @return void
+     *
      * @psalm-assert Collection<TKey,T> $this->collection
      */
-    protected function initialize(): void
+    protected function initialize()
     {
         if ($this->initialized) {
             return;
@@ -334,6 +407,8 @@ abstract class AbstractLazyCollection implements Collection
 
     /**
      * Do the initialization logic
+     *
+     * @return void
      */
-    abstract protected function doInitialize(): void;
+    abstract protected function doInitialize();
 }

--- a/lib/Doctrine/Common/Collections/ArrayCollection.php
+++ b/lib/Doctrine/Common/Collections/ArrayCollection.php
@@ -7,6 +7,7 @@ namespace Doctrine\Common\Collections;
 use ArrayIterator;
 use Closure;
 use Doctrine\Common\Collections\Expr\ClosureExpressionVisitor;
+use ReturnTypeWillChange;
 use Stringable;
 use Traversable;
 
@@ -69,12 +70,15 @@ class ArrayCollection implements Collection, Selectable, Stringable
     /**
      * {@inheritDoc}
      */
-    public function toArray(): array
+    public function toArray()
     {
         return $this->elements;
     }
 
-    public function first(): mixed
+    /**
+     * {@inheritDoc}
+     */
+    public function first()
     {
         return reset($this->elements);
     }
@@ -88,37 +92,53 @@ class ArrayCollection implements Collection, Selectable, Stringable
      * @param array $elements Elements.
      * @psalm-param array<K,V> $elements
      *
+     * @return static
      * @psalm-return static<K,V>
      *
      * @psalm-template K of array-key
      * @psalm-template V
      */
-    protected function createFrom(array $elements): static
+    protected function createFrom(array $elements)
     {
         return new static($elements);
     }
 
-    public function last(): mixed
+    /**
+     * {@inheritDoc}
+     */
+    public function last()
     {
         return end($this->elements);
     }
 
-    public function key(): int|string|null
+    /**
+     * {@inheritDoc}
+     */
+    public function key()
     {
         return key($this->elements);
     }
 
-    public function next(): mixed
+    /**
+     * {@inheritDoc}
+     */
+    public function next()
     {
         return next($this->elements);
     }
 
-    public function current(): mixed
+    /**
+     * {@inheritDoc}
+     */
+    public function current()
     {
         return current($this->elements);
     }
 
-    public function remove(string|int $key): mixed
+    /**
+     * {@inheritDoc}
+     */
+    public function remove(string|int $key)
     {
         if (! isset($this->elements[$key]) && ! array_key_exists($key, $this->elements)) {
             return null;
@@ -130,7 +150,10 @@ class ArrayCollection implements Collection, Selectable, Stringable
         return $removed;
     }
 
-    public function removeElement(mixed $element): bool
+    /**
+     * {@inheritDoc}
+     */
+    public function removeElement(mixed $element)
     {
         $key = array_search($element, $this->elements, true);
 
@@ -147,8 +170,10 @@ class ArrayCollection implements Collection, Selectable, Stringable
      * Required by interface ArrayAccess.
      *
      * @param TKey $offset
+     * {@inheritDoc}
      */
-    public function offsetExists($offset): bool
+    #[ReturnTypeWillChange]
+    public function offsetExists(mixed $offset)
     {
         return $this->containsKey($offset);
     }
@@ -157,8 +182,10 @@ class ArrayCollection implements Collection, Selectable, Stringable
      * Required by interface ArrayAccess.
      *
      * @param TKey $offset
+     * {@inheritDoc}
      */
-    public function offsetGet(mixed $offset): mixed
+    #[ReturnTypeWillChange]
+    public function offsetGet(mixed $offset)
     {
         return $this->get($offset);
     }
@@ -168,8 +195,10 @@ class ArrayCollection implements Collection, Selectable, Stringable
      *
      * @param TKey|null $offset
      * @param T         $value
+     * {@inheritDoc}
      */
-    public function offsetSet(mixed $offset, mixed $value): void
+    #[ReturnTypeWillChange]
+    public function offsetSet(mixed $offset, mixed $value)
     {
         if ($offset === null) {
             $this->add($value);
@@ -184,13 +213,18 @@ class ArrayCollection implements Collection, Selectable, Stringable
      * Required by interface ArrayAccess.
      *
      * @param TKey $offset
+     * {@inheritDoc}
      */
-    public function offsetUnset(mixed $offset): void
+    #[ReturnTypeWillChange]
+    public function offsetUnset(mixed $offset)
     {
         $this->remove($offset);
     }
 
-    public function containsKey(string|int $key): bool
+    /**
+     * {@inheritDoc}
+     */
+    public function containsKey(string|int $key)
     {
         return isset($this->elements[$key]) || array_key_exists($key, $this->elements);
     }
@@ -200,12 +234,15 @@ class ArrayCollection implements Collection, Selectable, Stringable
      *
      * @template TMaybeContained
      */
-    public function contains(mixed $element): bool
+    public function contains(mixed $element)
     {
         return in_array($element, $this->elements, true);
     }
 
-    public function exists(Closure $p): bool
+    /**
+     * {@inheritDoc}
+     */
+    public function exists(Closure $p)
     {
         foreach ($this->elements as $key => $element) {
             if ($p($key, $element)) {
@@ -221,16 +258,20 @@ class ArrayCollection implements Collection, Selectable, Stringable
      *
      * @psalm-param TMaybeContained $element
      *
+     * @return int|string|false
      * @psalm-return (TMaybeContained is T ? TKey|false : false)
      *
      * @template TMaybeContained
      */
-    public function indexOf($element): int|string|false
+    public function indexOf($element)
     {
         return array_search($element, $this->elements, true);
     }
 
-    public function get(string|int $key): mixed
+    /**
+     * {@inheritDoc}
+     */
+    public function get(string|int $key)
     {
         return $this->elements[$key] ?? null;
     }
@@ -238,7 +279,7 @@ class ArrayCollection implements Collection, Selectable, Stringable
     /**
      * {@inheritDoc}
      */
-    public function getKeys(): array
+    public function getKeys()
     {
         return array_keys($this->elements);
     }
@@ -246,12 +287,16 @@ class ArrayCollection implements Collection, Selectable, Stringable
     /**
      * {@inheritDoc}
      */
-    public function getValues(): array
+    public function getValues()
     {
         return array_values($this->elements);
     }
 
-    public function count(): int
+    /**
+     * {@inheritDoc}
+     */
+    #[ReturnTypeWillChange]
+    public function count()
     {
         return count($this->elements);
     }
@@ -259,7 +304,7 @@ class ArrayCollection implements Collection, Selectable, Stringable
     /**
      * {@inheritDoc}
      */
-    public function set($key, $value): void
+    public function set(string|int $key, mixed $value)
     {
         $this->elements[$key] = $value;
     }
@@ -277,7 +322,10 @@ class ArrayCollection implements Collection, Selectable, Stringable
         $this->elements[] = $element;
     }
 
-    public function isEmpty(): bool
+    /**
+     * {@inheritDoc}
+     */
+    public function isEmpty()
     {
         return empty($this->elements);
     }
@@ -288,7 +336,8 @@ class ArrayCollection implements Collection, Selectable, Stringable
      * @return Traversable<int|string, mixed>
      * @psalm-return Traversable<TKey, T>
      */
-    public function getIterator(): Traversable
+    #[ReturnTypeWillChange]
+    public function getIterator()
     {
         return new ArrayIterator($this->elements);
     }
@@ -303,7 +352,7 @@ class ArrayCollection implements Collection, Selectable, Stringable
      *
      * @psalm-template U
      */
-    public function map(Closure $func): Collection
+    public function map(Closure $func)
     {
         return $this->createFrom(array_map($func, $this->elements));
     }
@@ -311,7 +360,7 @@ class ArrayCollection implements Collection, Selectable, Stringable
     /**
      * {@inheritDoc}
      */
-    public function reduce(Closure $func, $initial = null): mixed
+    public function reduce(Closure $func, $initial = null)
     {
         return array_reduce($this->elements, $func, $initial);
     }
@@ -322,12 +371,15 @@ class ArrayCollection implements Collection, Selectable, Stringable
      * @return static
      * @psalm-return static<TKey,T>
      */
-    public function filter(Closure $p): Collection
+    public function filter(Closure $p)
     {
         return $this->createFrom(array_filter($this->elements, $p, ARRAY_FILTER_USE_BOTH));
     }
 
-    public function findFirst(Closure $p): mixed
+    /**
+     * {@inheritDoc}
+     */
+    public function findFirst(Closure $p)
     {
         foreach ($this->elements as $key => $element) {
             if ($p($key, $element)) {
@@ -338,7 +390,10 @@ class ArrayCollection implements Collection, Selectable, Stringable
         return null;
     }
 
-    public function forAll(Closure $p): bool
+    /**
+     * {@inheritDoc}
+     */
+    public function forAll(Closure $p)
     {
         foreach ($this->elements as $key => $element) {
             if (! $p($key, $element)) {
@@ -352,7 +407,7 @@ class ArrayCollection implements Collection, Selectable, Stringable
     /**
      * {@inheritDoc}
      */
-    public function partition(Closure $p): array
+    public function partition(Closure $p)
     {
         $matches = $noMatches = [];
 
@@ -369,13 +424,17 @@ class ArrayCollection implements Collection, Selectable, Stringable
 
     /**
      * Returns a string representation of this object.
+     * {@inheritDoc}
      */
-    public function __toString(): string
+    public function __toString()
     {
         return self::class . '@' . spl_object_hash($this);
     }
 
-    public function clear(): void
+    /**
+     * {@inheritDoc}
+     */
+    public function clear()
     {
         $this->elements = [];
     }
@@ -383,13 +442,13 @@ class ArrayCollection implements Collection, Selectable, Stringable
     /**
      * {@inheritDoc}
      */
-    public function slice(int $offset, int|null $length = null): array
+    public function slice(int $offset, int|null $length = null)
     {
         return array_slice($this->elements, $offset, $length, true);
     }
 
     /** @psalm-return Collection<TKey, T>&Selectable<TKey,T> */
-    public function matching(Criteria $criteria): Collection
+    public function matching(Criteria $criteria)
     {
         $expr     = $criteria->getWhereExpression();
         $filtered = $this->elements;

--- a/lib/Doctrine/Common/Collections/Collection.php
+++ b/lib/Doctrine/Common/Collections/Collection.php
@@ -42,8 +42,10 @@ interface Collection extends ReadableCollection, ArrayAccess
 
     /**
      * Clears the collection, removing all elements.
+     *
+     * @return void
      */
-    public function clear(): void;
+    public function clear();
 
     /**
      * Removes the element at the specified index from the collection.
@@ -54,7 +56,7 @@ interface Collection extends ReadableCollection, ArrayAccess
      * @return mixed The removed element or NULL, if the collection did not contain the element.
      * @psalm-return T|null
      */
-    public function remove(string|int $key): mixed;
+    public function remove(string|int $key);
 
     /**
      * Removes the specified element from the collection, if it is found.
@@ -64,7 +66,7 @@ interface Collection extends ReadableCollection, ArrayAccess
      *
      * @return bool TRUE if this collection contained the specified element, FALSE otherwise.
      */
-    public function removeElement(mixed $element): bool;
+    public function removeElement(mixed $element);
 
     /**
      * Sets an element in the collection at the specified key/index.
@@ -73,6 +75,8 @@ interface Collection extends ReadableCollection, ArrayAccess
      * @param mixed      $value The element to set.
      * @psalm-param TKey $key
      * @psalm-param T $value
+     *
+     * @return void
      */
-    public function set(string|int $key, mixed $value): void;
+    public function set(string|int $key, mixed $value);
 }

--- a/lib/Doctrine/Common/Collections/Criteria.php
+++ b/lib/Doctrine/Common/Collections/Criteria.php
@@ -32,16 +32,20 @@ class Criteria
 
     /**
      * Creates an instance of the class.
+     *
+     * @return static
      */
-    public static function create(): static
+    public static function create()
     {
         return new static();
     }
 
     /**
      * Returns the expression builder.
+     *
+     * @return ExpressionBuilder
      */
-    public static function expr(): ExpressionBuilder
+    public static function expr()
     {
         if (self::$expressionBuilder === null) {
             self::$expressionBuilder = new ExpressionBuilder();
@@ -87,7 +91,7 @@ class Criteria
      *
      * @return $this
      */
-    public function where(Expression $expression): static
+    public function where(Expression $expression)
     {
         $this->expression = $expression;
 
@@ -100,7 +104,7 @@ class Criteria
      *
      * @return $this
      */
-    public function andWhere(Expression $expression): static
+    public function andWhere(Expression $expression)
     {
         if ($this->expression === null) {
             return $this->where($expression);
@@ -120,7 +124,7 @@ class Criteria
      *
      * @return $this
      */
-    public function orWhere(Expression $expression): static
+    public function orWhere(Expression $expression)
     {
         if ($this->expression === null) {
             return $this->where($expression);
@@ -136,8 +140,10 @@ class Criteria
 
     /**
      * Gets the expression attached to this Criteria.
+     *
+     * @return Expression|null
      */
-    public function getWhereExpression(): Expression|null
+    public function getWhereExpression()
     {
         return $this->expression;
     }
@@ -147,7 +153,7 @@ class Criteria
      *
      * @return array<string, string>
      */
-    public function getOrderings(): array
+    public function getOrderings()
     {
         return $this->orderings;
     }
@@ -164,7 +170,7 @@ class Criteria
      *
      * @return $this
      */
-    public function orderBy(array $orderings): static
+    public function orderBy(array $orderings)
     {
         $this->orderings = array_map(
             static fn (string $ordering): string => strtoupper($ordering) === self::ASC ? self::ASC : self::DESC,
@@ -176,8 +182,10 @@ class Criteria
 
     /**
      * Gets the current first result option of this Criteria.
+     *
+     * @return int|null
      */
-    public function getFirstResult(): int|null
+    public function getFirstResult()
     {
         return $this->firstResult;
     }
@@ -189,7 +197,7 @@ class Criteria
      *
      * @return $this
      */
-    public function setFirstResult(int|null $firstResult): static
+    public function setFirstResult(int|null $firstResult)
     {
         if ($firstResult === null) {
             Deprecation::triggerIfCalledFromOutside(
@@ -207,8 +215,10 @@ class Criteria
 
     /**
      * Gets maxResults.
+     *
+     * @return int|null
      */
-    public function getMaxResults(): int|null
+    public function getMaxResults()
     {
         return $this->maxResults;
     }
@@ -220,7 +230,7 @@ class Criteria
      *
      * @return $this
      */
-    public function setMaxResults(int|null $maxResults): static
+    public function setMaxResults(int|null $maxResults)
     {
         $this->maxResults = $maxResults;
 

--- a/lib/Doctrine/Common/Collections/Expr/ClosureExpressionVisitor.php
+++ b/lib/Doctrine/Common/Collections/Expr/ClosureExpressionVisitor.php
@@ -35,8 +35,10 @@ class ClosureExpressionVisitor extends ExpressionVisitor
      * method, __get, __call).
      *
      * @param object|mixed[] $object
+     *
+     * @return mixed
      */
-    public static function getObjectFieldValue(object|array $object, string $field): mixed
+    public static function getObjectFieldValue(object|array $object, string $field)
     {
         if (str_contains($field, '.')) {
             [$field, $subField] = explode('.', $field, 2);
@@ -94,8 +96,10 @@ class ClosureExpressionVisitor extends ExpressionVisitor
 
     /**
      * Helper for sorting arrays of objects based on multiple fields + orientations.
+     *
+     * @return Closure
      */
-    public static function sortByField(string $name, int $orientation = 1, Closure|null $next = null): Closure
+    public static function sortByField(string $name, int $orientation = 1, Closure|null $next = null)
     {
         if (! $next) {
             $next = static fn (): int => 0;
@@ -114,7 +118,10 @@ class ClosureExpressionVisitor extends ExpressionVisitor
         };
     }
 
-    public function walkComparison(Comparison $comparison): Closure
+    /**
+     * {@inheritDoc}
+     */
+    public function walkComparison(Comparison $comparison)
     {
         $field = $comparison->getField();
         $value = $comparison->getValue()->getValue();
@@ -152,12 +159,18 @@ class ClosureExpressionVisitor extends ExpressionVisitor
         };
     }
 
-    public function walkValue(Value $value): mixed
+    /**
+     * {@inheritDoc}
+     */
+    public function walkValue(Value $value)
     {
         return $value->getValue();
     }
 
-    public function walkCompositeExpression(CompositeExpression $expr): Closure
+    /**
+     * {@inheritDoc}
+     */
+    public function walkCompositeExpression(CompositeExpression $expr)
     {
         $expressionList = [];
 

--- a/lib/Doctrine/Common/Collections/Expr/Comparison.php
+++ b/lib/Doctrine/Common/Collections/Expr/Comparison.php
@@ -34,22 +34,28 @@ class Comparison implements Expression
         $this->value = $value;
     }
 
-    public function getField(): string
+    /** @return string */
+    public function getField()
     {
         return $this->field;
     }
 
-    public function getValue(): Value
+    /** @return Value */
+    public function getValue()
     {
         return $this->value;
     }
 
-    public function getOperator(): string
+    /** @return string */
+    public function getOperator()
     {
         return $this->op;
     }
 
-    public function visit(ExpressionVisitor $visitor): mixed
+    /**
+     * {@inheritDoc}
+     */
+    public function visit(ExpressionVisitor $visitor)
     {
         return $visitor->walkComparison($this);
     }

--- a/lib/Doctrine/Common/Collections/Expr/CompositeExpression.php
+++ b/lib/Doctrine/Common/Collections/Expr/CompositeExpression.php
@@ -42,17 +42,21 @@ class CompositeExpression implements Expression
      *
      * @return list<Expression>
      */
-    public function getExpressionList(): array
+    public function getExpressionList()
     {
         return $this->expressions;
     }
 
-    public function getType(): string
+    /** @return string */
+    public function getType()
     {
         return $this->type;
     }
 
-    public function visit(ExpressionVisitor $visitor): mixed
+    /**
+     * {@inheritDoc}
+     */
+    public function visit(ExpressionVisitor $visitor)
     {
         return $visitor->walkCompositeExpression($this);
     }

--- a/lib/Doctrine/Common/Collections/Expr/Expression.php
+++ b/lib/Doctrine/Common/Collections/Expr/Expression.php
@@ -9,5 +9,6 @@ namespace Doctrine\Common\Collections\Expr;
  */
 interface Expression
 {
-    public function visit(ExpressionVisitor $visitor): mixed;
+    /** @return mixed */
+    public function visit(ExpressionVisitor $visitor);
 }

--- a/lib/Doctrine/Common/Collections/Expr/ExpressionVisitor.php
+++ b/lib/Doctrine/Common/Collections/Expr/ExpressionVisitor.php
@@ -14,25 +14,33 @@ abstract class ExpressionVisitor
 {
     /**
      * Converts a comparison expression into the target query language output.
+     *
+     * @return mixed
      */
-    abstract public function walkComparison(Comparison $comparison): mixed;
+    abstract public function walkComparison(Comparison $comparison);
 
     /**
      * Converts a value expression into the target query language part.
+     *
+     * @return mixed
      */
-    abstract public function walkValue(Value $value): mixed;
+    abstract public function walkValue(Value $value);
 
     /**
      * Converts a composite expression into the target query language output.
+     *
+     * @return mixed
      */
-    abstract public function walkCompositeExpression(CompositeExpression $expr): mixed;
+    abstract public function walkCompositeExpression(CompositeExpression $expr);
 
     /**
      * Dispatches walking an expression to the appropriate handler.
      *
+     * @return mixed
+     *
      * @throws RuntimeException
      */
-    public function dispatch(Expression $expr): mixed
+    public function dispatch(Expression $expr)
     {
         return match (true) {
             $expr instanceof Comparison => $this->walkComparison($expr),

--- a/lib/Doctrine/Common/Collections/Expr/Value.php
+++ b/lib/Doctrine/Common/Collections/Expr/Value.php
@@ -10,12 +10,16 @@ class Value implements Expression
     {
     }
 
-    public function getValue(): mixed
+    /** @return mixed */
+    public function getValue()
     {
         return $this->value;
     }
 
-    public function visit(ExpressionVisitor $visitor): mixed
+    /**
+     * {@inheritDoc}
+     */
+    public function visit(ExpressionVisitor $visitor)
     {
         return $visitor->walkValue($this);
     }

--- a/lib/Doctrine/Common/Collections/ExpressionBuilder.php
+++ b/lib/Doctrine/Common/Collections/ExpressionBuilder.php
@@ -18,79 +18,100 @@ use Doctrine\Common\Collections\Expr\Value;
  */
 class ExpressionBuilder
 {
-    public function andX(Expression ...$expressions): CompositeExpression
+    /** @return CompositeExpression */
+    public function andX(Expression ...$expressions)
     {
         return new CompositeExpression(CompositeExpression::TYPE_AND, $expressions);
     }
 
-    public function orX(Expression ...$expressions): CompositeExpression
+    /** @return CompositeExpression */
+    public function orX(Expression ...$expressions)
     {
         return new CompositeExpression(CompositeExpression::TYPE_OR, $expressions);
     }
 
-    public function eq(string $field, mixed $value): Comparison
+    /** @return Comparison */
+    public function eq(string $field, mixed $value)
     {
         return new Comparison($field, Comparison::EQ, new Value($value));
     }
 
-    public function gt(string $field, mixed $value): Comparison
+    /** @return Comparison */
+    public function gt(string $field, mixed $value)
     {
         return new Comparison($field, Comparison::GT, new Value($value));
     }
 
-    public function lt(string $field, mixed $value): Comparison
+    /** @return Comparison */
+    public function lt(string $field, mixed $value)
     {
         return new Comparison($field, Comparison::LT, new Value($value));
     }
 
-    public function gte(string $field, mixed $value): Comparison
+    /** @return Comparison */
+    public function gte(string $field, mixed $value)
     {
         return new Comparison($field, Comparison::GTE, new Value($value));
     }
 
-    public function lte(string $field, mixed $value): Comparison
+    /** @return Comparison */
+    public function lte(string $field, mixed $value)
     {
         return new Comparison($field, Comparison::LTE, new Value($value));
     }
 
-    public function neq(string $field, mixed $value): Comparison
+    /** @return Comparison */
+    public function neq(string $field, mixed $value)
     {
         return new Comparison($field, Comparison::NEQ, new Value($value));
     }
 
-    public function isNull(string $field): Comparison
+    /** @return Comparison */
+    public function isNull(string $field)
     {
         return new Comparison($field, Comparison::EQ, new Value(null));
     }
 
-    /** @param mixed[] $values */
-    public function in(string $field, array $values): Comparison
+    /**
+     * @param mixed[] $values
+     *
+     * @return Comparison
+     */
+    public function in(string $field, array $values)
     {
         return new Comparison($field, Comparison::IN, new Value($values));
     }
 
-    /** @param mixed[] $values */
-    public function notIn(string $field, array $values): Comparison
+    /**
+     * @param mixed[] $values
+     *
+     * @return Comparison
+     */
+    public function notIn(string $field, array $values)
     {
         return new Comparison($field, Comparison::NIN, new Value($values));
     }
 
-    public function contains(string $field, mixed $value): Comparison
+    /** @return Comparison */
+    public function contains(string $field, mixed $value)
     {
         return new Comparison($field, Comparison::CONTAINS, new Value($value));
     }
 
-    public function memberOf(string $field, mixed $value): Comparison
+    /** @return Comparison */
+    public function memberOf(string $field, mixed $value)
     {
         return new Comparison($field, Comparison::MEMBER_OF, new Value($value));
     }
 
-    public function startsWith(string $field, mixed $value): Comparison
+    /** @return Comparison */
+    public function startsWith(string $field, mixed $value)
     {
         return new Comparison($field, Comparison::STARTS_WITH, new Value($value));
     }
 
-    public function endsWith(string $field, mixed $value): Comparison
+    /** @return Comparison */
+    public function endsWith(string $field, mixed $value)
     {
         return new Comparison($field, Comparison::ENDS_WITH, new Value($value));
     }

--- a/lib/Doctrine/Common/Collections/ReadableCollection.php
+++ b/lib/Doctrine/Common/Collections/ReadableCollection.php
@@ -27,14 +27,14 @@ interface ReadableCollection extends Countable, IteratorAggregate
      *
      * @template TMaybeContained
      */
-    public function contains(mixed $element): bool;
+    public function contains(mixed $element);
 
     /**
      * Checks whether the collection is empty (contains no elements).
      *
      * @return bool TRUE if the collection is empty, FALSE otherwise.
      */
-    public function isEmpty(): bool;
+    public function isEmpty();
 
     /**
      * Checks whether the collection contains an element with the specified key/index.
@@ -45,7 +45,7 @@ interface ReadableCollection extends Countable, IteratorAggregate
      * @return bool TRUE if the collection contains an element with the specified key/index,
      *              FALSE otherwise.
      */
-    public function containsKey(string|int $key): bool;
+    public function containsKey(string|int $key);
 
     /**
      * Gets the element at the specified key/index.
@@ -53,9 +53,10 @@ interface ReadableCollection extends Countable, IteratorAggregate
      * @param string|int $key The key/index of the element to retrieve.
      * @psalm-param TKey $key
      *
+     * @return mixed
      * @psalm-return T|null
      */
-    public function get(string|int $key): mixed;
+    public function get(string|int $key);
 
     /**
      * Gets all keys/indices of the collection.
@@ -64,7 +65,7 @@ interface ReadableCollection extends Countable, IteratorAggregate
      *               elements in the collection.
      * @psalm-return list<TKey>
      */
-    public function getKeys(): array;
+    public function getKeys();
 
     /**
      * Gets all values of the collection.
@@ -73,7 +74,7 @@ interface ReadableCollection extends Countable, IteratorAggregate
      *                 order they appear in the collection.
      * @psalm-return list<T>
      */
-    public function getValues(): array;
+    public function getValues();
 
     /**
      * Gets a native PHP array representation of the collection.
@@ -81,42 +82,47 @@ interface ReadableCollection extends Countable, IteratorAggregate
      * @return mixed[]
      * @psalm-return array<TKey,T>
      */
-    public function toArray(): array;
+    public function toArray();
 
     /**
      * Sets the internal iterator to the first element in the collection and returns this element.
      *
+     * @return mixed
      * @psalm-return T|false
      */
-    public function first(): mixed;
+    public function first();
 
     /**
      * Sets the internal iterator to the last element in the collection and returns this element.
      *
+     * @return mixed
      * @psalm-return T|false
      */
-    public function last(): mixed;
+    public function last();
 
     /**
      * Gets the key/index of the element at the current iterator position.
      *
+     * @return int|string|null
      * @psalm-return TKey|null
      */
-    public function key(): int|string|null;
+    public function key();
 
     /**
      * Gets the element of the collection at the current iterator position.
      *
+     * @return mixed
      * @psalm-return T|false
      */
-    public function current(): mixed;
+    public function current();
 
     /**
      * Moves the internal iterator position to the next element and returns this element.
      *
+     * @return mixed
      * @psalm-return T|false
      */
-    public function next(): mixed;
+    public function next();
 
     /**
      * Extracts a slice of $length elements starting at position $offset from the Collection.
@@ -131,7 +137,7 @@ interface ReadableCollection extends Countable, IteratorAggregate
      * @return mixed[]
      * @psalm-return array<TKey,T>
      */
-    public function slice(int $offset, int|null $length = null): array;
+    public function slice(int $offset, int|null $length = null);
 
     /**
      * Tests for the existence of an element that satisfies the given predicate.
@@ -141,7 +147,7 @@ interface ReadableCollection extends Countable, IteratorAggregate
      *
      * @return bool TRUE if the predicate is TRUE for at least one element, FALSE otherwise.
      */
-    public function exists(Closure $p): bool;
+    public function exists(Closure $p);
 
     /**
      * Returns all the elements of this collection that satisfy the predicate p.
@@ -153,7 +159,7 @@ interface ReadableCollection extends Countable, IteratorAggregate
      * @return ReadableCollection<mixed> A collection with the results of the filter operation.
      * @psalm-return ReadableCollection<TKey, T>
      */
-    public function filter(Closure $p): self;
+    public function filter(Closure $p);
 
     /**
      * Applies the given function to each element in the collection and returns
@@ -166,7 +172,7 @@ interface ReadableCollection extends Countable, IteratorAggregate
      *
      * @psalm-template U
      */
-    public function map(Closure $func): self;
+    public function map(Closure $func);
 
     /**
      * Partitions this collection in two collections according to a predicate.
@@ -180,7 +186,7 @@ interface ReadableCollection extends Countable, IteratorAggregate
      *                      contains the collection of elements where the predicate returned FALSE.
      * @psalm-return array{0: ReadableCollection<TKey, T>, 1: ReadableCollection<TKey, T>}
      */
-    public function partition(Closure $p): array;
+    public function partition(Closure $p);
 
     /**
      * Tests whether the given predicate p holds for all elements of this collection.
@@ -190,7 +196,7 @@ interface ReadableCollection extends Countable, IteratorAggregate
      *
      * @return bool TRUE, if the predicate yields TRUE for all elements, FALSE otherwise.
      */
-    public function forAll(Closure $p): bool;
+    public function forAll(Closure $p);
 
     /**
      * Gets the index/key of a given element. The comparison of two elements is strict,
@@ -205,7 +211,7 @@ interface ReadableCollection extends Countable, IteratorAggregate
      *
      * @template TMaybeContained
      */
-    public function indexOf(mixed $element): int|string|false;
+    public function indexOf(mixed $element);
 
     /**
      * Returns the first element of this collection that satisfies the predicate p.
@@ -217,7 +223,7 @@ interface ReadableCollection extends Countable, IteratorAggregate
      *               null if no element respects the predicate.
      * @psalm-return T|null
      */
-    public function findFirst(Closure $p): mixed;
+    public function findFirst(Closure $p);
 
     /**
      * Applies iteratively the given function to each element in the collection,
@@ -226,10 +232,11 @@ interface ReadableCollection extends Countable, IteratorAggregate
      * @psalm-param Closure(TReturn|TInitial|null, T):(TInitial|TReturn) $func
      * @psalm-param TInitial|null $initial
      *
+     * @return mixed
      * @psalm-return TReturn|TInitial|null
      *
      * @psalm-template TReturn
      * @psalm-template TInitial
      */
-    public function reduce(Closure $func, mixed $initial = null): mixed;
+    public function reduce(Closure $func, mixed $initial = null);
 }

--- a/lib/Doctrine/Common/Collections/Selectable.php
+++ b/lib/Doctrine/Common/Collections/Selectable.php
@@ -28,5 +28,5 @@ interface Selectable
      * @return ReadableCollection<mixed>&Selectable<mixed>
      * @psalm-return ReadableCollection<TKey,T>&Selectable<TKey,T>
      */
-    public function matching(Criteria $criteria): ReadableCollection;
+    public function matching(Criteria $criteria);
 }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -14,7 +14,9 @@
     <file>lib</file>
     <file>tests</file>
 
-    <rule ref="Doctrine" />
+    <rule ref="Doctrine" >
+        <exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint"/>
+    </rule>
 
     <rule ref="PSR1.Classes.ClassDeclaration.MultipleClasses">
         <exclude-pattern>tests/*</exclude-pattern>

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -4,10 +4,6 @@ parameters:
         - lib
 
     ignoreErrors:
-        # https://github.com/phpstan/phpstan-src/pull/1289
-        -
-            message: '~PHPDoc tag @return with type Doctrine\\Common\\Collections\\ArrayCollection.* is incompatible with native type static.*~'
-            path: 'lib/Doctrine/Common/Collections/ArrayCollection.php'
         -
             message: '~Parameter #1 \$key of method Doctrine\\Common\\Collections\\ArrayCollection<TKey of \(int\|string\),T>::set\(\) expects TKey of \(int\|string\), int\|string given\.~'
             path: 'lib/Doctrine/Common/Collections/ArrayCollection.php'


### PR DESCRIPTION
They prevent writing compatibility layers that would work with version 1 and 2 easily.

Prompted by https://github.com/doctrine/orm/pull/10070

It might be interesting to review the new diff with the stable branch: https://github.com/doctrine/collections/compare/1.7.x...greg0ire:collections:revert-return-type-additions