### PR TITLE
Update branch metadata

### DIFF
--- a/.doctrine-project.json
+++ b/.doctrine-project.json
@@ -14,13 +14,13 @@
             "name": "1.8",
             "branchName": "1.8.x",
             "slug": "1.8",
-            "upcoming": true
+            "current": true
         },
         {
             "name": "1.7",
             "branchName": "1.7.x",
             "slug": "1.7",
-            "current": true
+            "maintained": false
         },
         {
             "name": "1.6",


### PR DESCRIPTION
This is supposed to be the last 1.x minor branch, hence why 1.9.x is not created.