### PR TITLE
Document recommended changes

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -10,36 +10,68 @@ awareness about deprecated code.
 
 ## BC breaking changes
 
-Native parameter and return types were added.
+Native parameter types were added. Native return types will be added in 3.0.x
 As a consequence, some signatures were changed and will have to be adjusted in sub-classes.
 
 Note that in order to keep compatibility with both 1.x and 2.x versions,
-extending code would have to omit the added parameter types and add the return
-types. This would only work in PHP 7.2+ which is the first version featuring
+extending code would have to omit the added parameter types.
+This would only work in PHP 7.2+ which is the first version featuring
 [parameter widening](https://wiki.php.net/rfc/parameter-no-type-variance).
+It is also recommended to add return types according to the tables below
 
 You can find a list of major changes to public API below.
 
 ### Doctrine\Common\Collections\Collection
 
-|             before             |                  after                  |
-|-------------------------------:|:----------------------------------------|
-| add($element)                  | add(mixed $element)                     |
-| contains($element)             | contains(mixed $element)                |
-| removeElement($element)        | removeElement(mixed $element)           |
-| containsKey($key)              | containsKey(string|int $key)            |
-| get()                          | get(string|int $key)                    |
-| set($key, $value)              | set(string|int $key, $value)            |
-| indexOf($element)              | indexOf(mixed $element)                 |
-| slice($offset, $length = null) | slice(int $offset, ?int $length = null) |
-| offsetSet($offset, $value)     | offsetSet(mixed $offset, mixed $value)  |
-| offsetUnset($offset)           | offsetUnset(mixed $offset)              |
-| offsetExists($offset)          | offsetExists(mixed $offset)             |
+|             1.0.x              |                  3.0.x                         |
+|-------------------------------:|:-----------------------------------------------|
+| add($element)                  | add(mixed $element)                            |
+| clear()                        | clear(): void                                  |
+| contains($element)             | contains(mixed $element): bool                 |
+| isEmpty()                      | isEmpty(): bool                                |
+| removeElement($element)        | removeElement(mixed $element): bool            |
+| containsKey($key)              | containsKey(string|int $key): bool             |
+| get()                          | get(string|int $key): mixed                    |
+| getKeys()                      | getKeys(): array                               |
+| getValues()                    | getValues(): array                             |
+| set($key, $value)              | set(string|int $key, $value): void             |
+| toArray()                      | toArray(): array                               |
+| first()                        | first(): mixed                                 |
+| last()                         | last(): mixed                                  |
+| key()                          | key(): int|string|null                         |
+| current()                      | current(): mixed                               |
+| next()                         | next(): mixed                                  |
+| exists(Closure $p)             | exists(Closure $p): bool                       |
+| filter(Closure $p)             | filter(Closure $p): self                       |
+| forAll(Closure $p)             | forAll(Closure $p): bool                       |
+| map(Closure $func)             | map(Closure $func): self                       |
+| partition(Closure $p)          | partition(Closure $p): array                   |
+| indexOf($element)              | indexOf(mixed $element): int|string|false      |
+| slice($offset, $length = null) | slice(int $offset, ?int $length = null): array |
+| count()                        | count(): int                                   |
+| getIterator()                  | getIterator(): \Traversable                    |
+| offsetSet($offset, $value)     | offsetSet(mixed $offset, mixed $value): void   |
+| offsetUnset($offset)           | offsetUnset(mixed $offset): void               |
+| offsetExists($offset)          | offsetExists(mixed $offset): bool              |
 
+### Doctrine\Common\Collections\AbstractLazyCollection
+
+|      1.0.x      |         3.0.x         |
+|----------------:|:----------------------|
+| isInitialized() | isInitialized(): bool |
+| initialize()    | initialize(): void    |
+| doInitialize()  | doInitialize(): void  |
+
+### Doctrine\Common\Collections\ArrayCollection
+
+|            1.0.x            |               3.0.x                 |
+|----------------------------:|:------------------------------------|
+| createFrom(array $elements) | createFrom(array $elements): static |
+| __toString()                | __toString(): string                |
 
 ### Doctrine\Common\Collections\Criteria
 
-|            before                       |               after                       |
+|            1.0.x                        |               3.0.x                       |
 |----------------------------------------:|:------------------------------------------|
 | where(Expression $expression): self     | where(Expression $expression): static     |
 | andWhere(Expression $expression): self  | andWhere(Expression $expression): static  |
@@ -47,3 +79,9 @@ You can find a list of major changes to public API below.
 | orderBy(array $orderings): self         | orderBy(array $orderings): static         |
 | setFirstResult(?int $firstResult): self | setFirstResult(?int $firstResult): static |
 | setMaxResult(?int $maxResults): self    | setMaxResults(?int $maxResults): static   |
+
+### Doctrine\Common\Collections\Selectable
+
+|             1.0.x            |                   3.0.x                  |
+|-----------------------------:|:-----------------------------------------|
+| matching(Criteria $criteria) | matching(Criteria $criteria): Collection |

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -23,65 +23,65 @@ You can find a list of major changes to public API below.
 
 ### Doctrine\Common\Collections\Collection
 
-|             1.0.x              |                  3.0.x                         |
-|-------------------------------:|:-----------------------------------------------|
-| add($element)                  | add(mixed $element)                            |
-| clear()                        | clear(): void                                  |
-| contains($element)             | contains(mixed $element): bool                 |
-| isEmpty()                      | isEmpty(): bool                                |
-| removeElement($element)        | removeElement(mixed $element): bool            |
-| containsKey($key)              | containsKey(string|int $key): bool             |
-| get()                          | get(string|int $key): mixed                    |
-| getKeys()                      | getKeys(): array                               |
-| getValues()                    | getValues(): array                             |
-| set($key, $value)              | set(string|int $key, $value): void             |
-| toArray()                      | toArray(): array                               |
-| first()                        | first(): mixed                                 |
-| last()                         | last(): mixed                                  |
-| key()                          | key(): int|string|null                         |
-| current()                      | current(): mixed                               |
-| next()                         | next(): mixed                                  |
-| exists(Closure $p)             | exists(Closure $p): bool                       |
-| filter(Closure $p)             | filter(Closure $p): self                       |
-| forAll(Closure $p)             | forAll(Closure $p): bool                       |
-| map(Closure $func)             | map(Closure $func): self                       |
-| partition(Closure $p)          | partition(Closure $p): array                   |
-| indexOf($element)              | indexOf(mixed $element): int|string|false      |
-| slice($offset, $length = null) | slice(int $offset, ?int $length = null): array |
-| count()                        | count(): int                                   |
-| getIterator()                  | getIterator(): \Traversable                    |
-| offsetSet($offset, $value)     | offsetSet(mixed $offset, mixed $value): void   |
-| offsetUnset($offset)           | offsetUnset(mixed $offset): void               |
-| offsetExists($offset)          | offsetExists(mixed $offset): bool              |
+|             1.0.x                |                  3.0.x                           |
+|---------------------------------:|:-------------------------------------------------|
+| `add($element)`                  | `add(mixed $element): void`                      |
+| `clear()`                        | `clear(): void`                                  |
+| `contains($element)`             | `contains(mixed $element): bool`                 |
+| `isEmpty()`                      | `isEmpty(): bool`                                |
+| `removeElement($element)`        | `removeElement(mixed $element): bool`            |
+| `containsKey($key)`              | `containsKey(string|int $key): bool`             |
+| `get()`                          | `get(string|int $key): mixed`                    |
+| `getKeys()`                      | `getKeys(): array`                               |
+| `getValues()`                    | `getValues(): array`                             |
+| `set($key, $value)`              | `set(string|int $key, $value): void`             |
+| `toArray()`                      | `toArray(): array`                               |
+| `first()`                        | `first(): mixed`                                 |
+| `last()`                         | `last(): mixed`                                  |
+| `key()`                          | `key(): int|string|null`                         |
+| `current()`                      | `current(): mixed`                               |
+| `next()`                         | `next(): mixed`                                  |
+| `exists(Closure $p)`             | `exists(Closure $p): bool`                       |
+| `filter(Closure $p)`             | `filter(Closure $p): self`                       |
+| `forAll(Closure $p)`             | `forAll(Closure $p): bool`                       |
+| `map(Closure $func)`             | `map(Closure $func): self`                       |
+| `partition(Closure $p)`          | `partition(Closure $p): array`                   |
+| `indexOf($element)`              | `indexOf(mixed $element): int|string|false`      |
+| `slice($offset, $length = null)` | `slice(int $offset, ?int $length = null): array` |
+| `count()`                        | `count(): int`                                   |
+| `getIterator()`                  | `getIterator(): \Traversable`                    |
+| `offsetSet($offset, $value)`     | `offsetSet(mixed $offset, mixed $value): void`   |
+| `offsetUnset($offset)`           | `offsetUnset(mixed $offset): void`               |
+| `offsetExists($offset)`          | `offsetExists(mixed $offset): bool`              |
 
 ### Doctrine\Common\Collections\AbstractLazyCollection
 
-|      1.0.x      |         3.0.x         |
-|----------------:|:----------------------|
-| isInitialized() | isInitialized(): bool |
-| initialize()    | initialize(): void    |
-| doInitialize()  | doInitialize(): void  |
+|      1.0.x        |         3.0.x           |
+|------------------:|:------------------------|
+| `isInitialized()` | `isInitialized(): bool` |
+| `initialize()`    | `initialize(): void`    |
+| `doInitialize()`  | `doInitialize(): void`  |
 
 ### Doctrine\Common\Collections\ArrayCollection
 
-|            1.0.x            |               3.0.x                 |
-|----------------------------:|:------------------------------------|
-| createFrom(array $elements) | createFrom(array $elements): static |
-| __toString()                | __toString(): string                |
+|            1.0.x              |               3.0.x                   |
+|------------------------------:|:--------------------------------------|
+| `createFrom(array $elements)` | `createFrom(array $elements): static` |
+| `__toString()`                | `__toString(): string`                |
 
 ### Doctrine\Common\Collections\Criteria
 
-|            1.0.x                        |               3.0.x                       |
-|----------------------------------------:|:------------------------------------------|
-| where(Expression $expression): self     | where(Expression $expression): static     |
-| andWhere(Expression $expression): self  | andWhere(Expression $expression): static  |
-| orWhere(Expression $expression): self   | orWhere(Expression $expression): static   |
-| orderBy(array $orderings): self         | orderBy(array $orderings): static         |
-| setFirstResult(?int $firstResult): self | setFirstResult(?int $firstResult): static |
-| setMaxResult(?int $maxResults): self    | setMaxResults(?int $maxResults): static   |
+|            1.0.x                          |               3.0.x                         |
+|------------------------------------------:|:--------------------------------------------|
+| `where(Expression $expression): self`     | `where(Expression $expression): static`     |
+| `andWhere(Expression $expression): self`  | `andWhere(Expression $expression): static`  |
+| `orWhere(Expression $expression): self`   | `orWhere(Expression $expression): static`   |
+| `orderBy(array $orderings): self`         | `orderBy(array $orderings): static`         |
+| `setFirstResult(?int $firstResult): self` | `setFirstResult(?int $firstResult): static` |
+| `setMaxResult(?int $maxResults): self`    | `setMaxResults(?int $maxResults): static`   |
 
 ### Doctrine\Common\Collections\Selectable
 
-|             1.0.x            |                   3.0.x                  |
-|-----------------------------:|:-----------------------------------------|
-| matching(Criteria $criteria) | matching(Criteria $criteria): Collection |
+|             1.0.x              |                   3.0.x                    |
+|-------------------------------:|:-------------------------------------------|
+| `matching(Criteria $criteria)` | `matching(Criteria $criteria): Collection` |


### PR DESCRIPTION
We have done the upgrade of types in a 2 step process.
To take the example of the ORM, we should be able to allow
doctrine/collections 2 on the stable branch, and then add both parameter
and return type declarations on the unstable branch in one go. For that
reason, it is a bit more helpful to document the recommended changes
that should be done rather than what changed in 2.0.x