### PR TITLE
Mark closure arguments as always-provided

### DIFF
--- a/src/ReadableCollection.php
+++ b/src/ReadableCollection.php
@@ -217,7 +217,7 @@ interface ReadableCollection extends Countable, IteratorAggregate
      * Returns the first element of this collection that satisfies the predicate p.
      *
      * @param Closure $p The predicate.
-     * @psalm-param Closure(TKey=, T=):bool $p
+     * @psalm-param Closure(TKey, T):bool $p
      *
      * @return mixed The first element respecting the predicate,
      *               null if no element respects the predicate.


### PR DESCRIPTION
Follow up of 4e5e58f48879ba4bf40f1080c7508a0c1ea1cd7b .
That method is only present on 2.0.x hence why it was missed.