### PR TITLE
fix: use @psalm-template annotation to avoid clashes

### DIFF
--- a/lib/Doctrine/Common/Collections/AbstractLazyCollection.php
+++ b/lib/Doctrine/Common/Collections/AbstractLazyCollection.php
@@ -62,7 +62,7 @@ abstract class AbstractLazyCollection implements Collection
     /**
      * {@inheritDoc}
      *
-     * @template TMaybeContained
+     * @psalm-template TMaybeContained
      */
     public function contains($element)
     {
@@ -263,7 +263,7 @@ abstract class AbstractLazyCollection implements Collection
     /**
      * {@inheritDoc}
      *
-     * @template TMaybeContained
+     * @psalm-template TMaybeContained
      */
     public function indexOf($element)
     {

--- a/lib/Doctrine/Common/Collections/ArrayCollection.php
+++ b/lib/Doctrine/Common/Collections/ArrayCollection.php
@@ -232,7 +232,7 @@ class ArrayCollection implements Collection, Selectable
     /**
      * {@inheritDoc}
      *
-     * @template TMaybeContained
+     * @psalm-template TMaybeContained
      */
     public function contains($element)
     {
@@ -260,7 +260,7 @@ class ArrayCollection implements Collection, Selectable
      *
      * @psalm-return (TMaybeContained is T ? TKey|false : false)
      *
-     * @template TMaybeContained
+     * @psalm-template TMaybeContained
      */
     public function indexOf($element)
     {

--- a/lib/Doctrine/Common/Collections/ReadableCollection.php
+++ b/lib/Doctrine/Common/Collections/ReadableCollection.php
@@ -23,7 +23,7 @@ interface ReadableCollection extends Countable, IteratorAggregate
      * @return bool TRUE if the collection contains the element, FALSE otherwise.
      * @psalm-return (TMaybeContained is T ? bool : false)
      *
-     * @template TMaybeContained
+     * @psalm-template TMaybeContained
      */
     public function contains($element);
 
@@ -207,7 +207,7 @@ interface ReadableCollection extends Countable, IteratorAggregate
      * @return int|string|bool The key/index of the element or FALSE if the element was not found.
      * @psalm-return (TMaybeContained is T ? TKey|false : false)
      *
-     * @template TMaybeContained
+     * @psalm-template TMaybeContained
      */
     public function indexOf($element);
 }


### PR DESCRIPTION
`[Semantical Error] The annotation "@template" in method Doctrine\Common\Collections\ArrayCollection::contains() was never imported. Did you maybe forget to add a "use" statement for this annotation?`

This is an issue since https://github.com/doctrine/collections/compare/1.7.3...1.8.0.

See https://github.com/doctrine/collections/pull/186. History repeating itself I think 🙂