### PR TITLE
Remove ignore rule for possibly null variable

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -7,9 +7,6 @@ parameters:
         -
             message: '~Parameter #1 \$key of method Doctrine\\Common\\Collections\\ArrayCollection<TKey of \(int\|string\),T>::set\(\) expects TKey of \(int\|string\), int\|string given\.~'
             path: 'src/ArrayCollection.php'
-        -
-            message: '~Cannot call method .* on Doctrine\\Common\\Collections\\Collection<TKey of \(int\|string\), T>\|null\.~'
-            path: 'src/AbstractLazyCollection.php'
 
 includes:
     - vendor/phpstan/phpstan-phpunit/extension.neon


### PR DESCRIPTION
It seems PHPStan is now able to leverage the psalm-assert annotation that was added to exclude null from the possible types.