### PR TITLE
Use more precise return type for count method

### DIFF
--- a/src/ArrayCollection.php
+++ b/src/ArrayCollection.php
@@ -296,7 +296,9 @@ class ArrayCollection implements Collection, Selectable, Stringable
         return array_values($this->elements);
     }
 
-    /** @return int */
+    /**
+     * {@inheritDoc}
+     */
     #[ReturnTypeWillChange]
     public function count()
     {

--- a/src/ArrayCollection.php
+++ b/src/ArrayCollection.php
@@ -298,6 +298,8 @@ class ArrayCollection implements Collection, Selectable, Stringable
 
     /**
      * {@inheritDoc}
+     *
+     * @return int<0, max>
      */
     #[ReturnTypeWillChange]
     public function count()


### PR DESCRIPTION
Countable is supposed to return
```
@return int<0, max>
```
(https://github.com/vimeo/psalm/pull/8861)

So I would say it's better to rely on inherit doc rather than overriding the return tag ?
@greg0ire 

