### PR TITLE
Returning null instead of false on failure for first/last/current/next

### DIFF
--- a/src/ArrayCollection.php
+++ b/src/ArrayCollection.php
@@ -76,7 +76,13 @@ class ArrayCollection implements Collection, Selectable, Stringable
 
     public function first(): mixed
     {
-        return reset($this->elements);
+        $element = reset($this->elements);
+
+        if ($element === false) {
+            return null;
+        }
+
+        return $element;
     }
 
     /**
@@ -100,7 +106,13 @@ class ArrayCollection implements Collection, Selectable, Stringable
 
     public function last(): mixed
     {
-        return end($this->elements);
+        $element = end($this->elements);
+
+        if ($element === false) {
+            return null;
+        }
+
+        return $element;
     }
 
     public function key(): int|string|null
@@ -110,12 +122,24 @@ class ArrayCollection implements Collection, Selectable, Stringable
 
     public function next(): mixed
     {
-        return next($this->elements);
+        $element = next($this->elements);
+
+        if ($element === false) {
+            return null;
+        }
+
+        return $element;
     }
 
     public function current(): mixed
     {
-        return current($this->elements);
+        $element = current($this->elements);
+
+        if ($element === false) {
+            return null;
+        }
+
+        return $element;
     }
 
     public function remove(string|int $key): mixed

--- a/src/ReadableCollection.php
+++ b/src/ReadableCollection.php
@@ -86,14 +86,14 @@ interface ReadableCollection extends Countable, IteratorAggregate
     /**
      * Sets the internal iterator to the first element in the collection and returns this element.
      *
-     * @psalm-return T|false
+     * @psalm-return T|null
      */
     public function first(): mixed;
 
     /**
      * Sets the internal iterator to the last element in the collection and returns this element.
      *
-     * @psalm-return T|false
+     * @psalm-return T|null
      */
     public function last(): mixed;
 
@@ -107,14 +107,14 @@ interface ReadableCollection extends Countable, IteratorAggregate
     /**
      * Gets the element of the collection at the current iterator position.
      *
-     * @psalm-return T|false
+     * @psalm-return T|null
      */
     public function current(): mixed;
 
     /**
      * Moves the internal iterator position to the next element and returns this element.
      *
-     * @psalm-return T|false
+     * @psalm-return T|null
      */
     public function next(): mixed;
 

--- a/tests/Common/Collections/BaseArrayCollectionTest.php
+++ b/tests/Common/Collections/BaseArrayCollectionTest.php
@@ -57,6 +57,12 @@ abstract class BaseArrayCollectionTest extends TestCase
         self::assertSame(reset($elements), $collection->first());
     }
 
+    public function testFirstNull(): void
+    {
+        $emptyCollection = $this->buildCollection([]);
+        self::assertNull($emptyCollection->first());
+    }
+
     /**
      * @param array<string|int, string|int> $elements
      *
@@ -66,6 +72,12 @@ abstract class BaseArrayCollectionTest extends TestCase
     {
         $collection = $this->buildCollection($elements);
         self::assertSame(end($elements), $collection->last());
+    }
+
+    public function testLastNull(): void
+    {
+        $collection = $this->buildCollection([]);
+        self::assertNull($collection->last());
     }
 
     /**
@@ -108,7 +120,13 @@ abstract class BaseArrayCollectionTest extends TestCase
             self::assertSame(current($elements), $collection->current(), 'Current values not match');
         }
 
-        self::assertFalse($collection->next());
+        self::assertNull($collection->next());
+    }
+
+    public function testNextNull(): void
+    {
+        $collection = $this->buildCollection([]);
+        self::assertNull($collection->next());
     }
 
     /**
@@ -126,6 +144,13 @@ abstract class BaseArrayCollectionTest extends TestCase
         $collection->next();
 
         self::assertSame(current($elements), $collection->current());
+    }
+
+    public function testCurrentNull(): void
+    {
+        $collection = $this->buildCollection([]);
+
+        self::assertNull($collection->current());
     }
 
     /**


### PR DESCRIPTION
This PR references #190 

The idea is to have the `ReadableCollection` interface and `ArrayCollection` implementation of the method `first`, `last`, `current` and `next` returns `null` instead of `false`.

This way we can use PHP nullsafe operator like this: 
```php
if ($collection?->first()->isActive()) { /* do something */ }
```

Let me know what are the next steps