### PR TITLE
Value Object comparison operations

### DIFF
--- a/src/Expr/ClosureExpressionVisitor.php
+++ b/src/Expr/ClosureExpressionVisitor.php
@@ -127,8 +127,16 @@ class ClosureExpressionVisitor extends ExpressionVisitor
         $value = $comparison->getValue()->getValue();
 
         return match ($comparison->getOperator()) {
-            Comparison::EQ => static fn ($object): bool => self::getObjectFieldValue($object, $field) === $value,
-            Comparison::NEQ => static fn ($object): bool => self::getObjectFieldValue($object, $field) !== $value,
+            Comparison::EQ => static function ($object) use ($field, $value): bool {
+                $fieldValue = ClosureExpressionVisitor::getObjectFieldValue($object, $field);
+
+                return is_scalar($fieldValue) ? $fieldValue === $value : $fieldValue == $value;
+            },
+            Comparison::NEQ => static function ($object) use ($field, $value): bool {
+                $fieldValue = ClosureExpressionVisitor::getObjectFieldValue($object, $field);
+
+                return is_scalar($fieldValue) ? $fieldValue !== $value : $fieldValue != $value;
+            },
             Comparison::LT => static fn ($object): bool => self::getObjectFieldValue($object, $field) < $value,
             Comparison::LTE => static fn ($object): bool => self::getObjectFieldValue($object, $field) <= $value,
             Comparison::GT => static fn ($object): bool => self::getObjectFieldValue($object, $field) > $value,

--- a/tests/Common/Collections/ClosureExpressionVisitorTest.php
+++ b/tests/Common/Collections/ClosureExpressionVisitorTest.php
@@ -128,12 +128,28 @@ class ClosureExpressionVisitorTest extends TestCase
         self::assertFalse($closure(new TestObject(2)));
     }
 
+    public function testWalkObjectsEqualsComparison(): void
+    {
+        $closure = $this->visitor->walkComparison($this->builder->eq('foo', new TestObject(1)));
+
+        self::assertTrue($closure(new TestObject(new TestObject(1))));
+        self::assertFalse($closure(new TestObject(new TestObject(2))));
+    }
+
     public function testWalkNotEqualsComparison(): void
     {
         $closure = $this->visitor->walkComparison($this->builder->neq('foo', 1));
 
         self::assertFalse($closure(new TestObject(1)));
         self::assertTrue($closure(new TestObject(2)));
+    }
+
+    public function testWalkObjectsNotEqualsComparison(): void
+    {
+        $closure = $this->visitor->walkComparison($this->builder->neq('foo', new TestObject(1)));
+
+        self::assertFalse($closure(new TestObject(new TestObject(1))));
+        self::assertTrue($closure(new TestObject(new TestObject(2))));
     }
 
     public function testWalkLessThanComparison(): void


### PR DESCRIPTION
Improvements for working with Value Object comporation. Value Object not necessarily being the same object for being equal.

> In [computer science](https://en.wikipedia.org/wiki/Computer_science), a value object is a small [object](https://en.wikipedia.org/wiki/Object_(computer_science)) that represents a simple [entity](https://en.wikipedia.org/wiki/Entity) whose equality is not based on [identity](https://en.wikipedia.org/wiki/Identity_(object-oriented_programming)): i.e. two value objects are equal when they have the same value, not necessarily being the same object.

https://en.wikipedia.org/wiki/Value_object