### PR TITLE
Remove override of template type for contains(): causing psalm errors

### DIFF
--- a/src/AbstractLazyCollection.php
+++ b/src/AbstractLazyCollection.php
@@ -62,8 +62,6 @@ abstract class AbstractLazyCollection implements Collection
 
     /**
      * {@inheritDoc}
-     *
-     * @template TMaybeContained
      */
     public function contains(mixed $element)
     {

--- a/src/ArrayCollection.php
+++ b/src/ArrayCollection.php
@@ -235,8 +235,6 @@ class ArrayCollection implements Collection, Selectable, Stringable
 
     /**
      * {@inheritDoc}
-     *
-     * @template TMaybeContained
      */
     public function contains(mixed $element)
     {


### PR DESCRIPTION
The override of this template type causes Psalm to throw an error whenever contains is called: https://psalm.dev/r/a2f9439bd2

Removing the extra type works as expected: https://psalm.dev/r/de5f58d52f

Fixes #368