### PR TITLE
Make returntypes consistent with implementation

### DIFF
--- a/src/AbstractLazyCollection.php
+++ b/src/AbstractLazyCollection.php
@@ -230,10 +230,7 @@ abstract class AbstractLazyCollection implements Collection
     }
 
     /**
-     * @psalm-param Closure(T, TKey):bool $p
-     *
-     * @return ReadableCollection<mixed>
-     * @psalm-return ReadableCollection<TKey, T>
+     * {@inheritDoc}
      */
     public function filter(Closure $p)
     {
@@ -254,13 +251,6 @@ abstract class AbstractLazyCollection implements Collection
 
     /**
      * {@inheritDoc}
-     *
-     * @psalm-param Closure(T):U $func
-     *
-     * @return ReadableCollection<mixed>
-     * @psalm-return ReadableCollection<TKey, U>
-     *
-     * @psalm-template U
      */
     public function map(Closure $func)
     {

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Common\Collections;
 
 use ArrayAccess;
+use Closure;
 
 /**
  * The missing (SPL) Collection/Array/OrderedMap interface.
@@ -79,4 +80,24 @@ interface Collection extends ReadableCollection, ArrayAccess
      * @return void
      */
     public function set(string|int $key, mixed $value);
+
+    /**
+     * {@inheritDoc}
+     *
+     * @psalm-param Closure(T):U $func
+     *
+     * @return Collection<mixed>
+     * @psalm-return Collection<TKey, U>
+     *
+     * @psalm-template U
+     */
+    public function map(Closure $func);
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return Collection<mixed> A collection with the results of the filter operation.
+     * @psalm-return Collection<TKey, T>
+     */
+    public function filter(Closure $p);
 }


### PR DESCRIPTION
The implementation of filter and map are working on a Collection and not on a ReadableCollection. Therefore they will also return a Collection and not just a ReadableCollection.

Closes https://github.com/doctrine/collections/issues/372