### PR TITLE
Improve return type for Collection::partition

### DIFF
--- a/src/Collection.php
+++ b/src/Collection.php
@@ -100,4 +100,14 @@ interface Collection extends ReadableCollection, ArrayAccess
      * @psalm-return Collection<TKey, T>
      */
     public function filter(Closure $p);
+
+    /**
+     * {@inheritDoc}
+
+     * @return Collection<mixed>[] An array with two elements. The first element contains the collection
+     *                      of elements where the predicate returned TRUE, the second element
+     *                      contains the collection of elements where the predicate returned FALSE.
+     * @psalm-return array{0: Collection<TKey, T>, 1: Collection<TKey, T>}
+     */
+    public function partition(Closure $p);
 }


### PR DESCRIPTION
Currently when partitioning a Collection-object it will return an array of ReadableCollections unless that return-type is overwritten in the implementation.

This change makes sure that any implementation of a Collection actually returns an array of Collections instead.

This is a follow-up PR to #379 as suggested by @derrabus in https://github.com/doctrine/collections/pull/379#pullrequestreview-1649861837