### PR TITLE
Disable UselessInheritDocComment sniff

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -15,6 +15,7 @@
     <file>tests</file>
 
     <rule ref="Doctrine" >
+        <exclude name="SlevomatCodingStandard.Commenting.UselessInheritDocComment"/>
         <exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint"/>
     </rule>
 


### PR DESCRIPTION
According to a maintainer of `slevomat/coding-standard`, it goes against other sniffs we use in this repository.

See https://github.com/doctrine/collections/pull/381#issuecomment-1745206747