### PR TITLE
Add missing upgrade note

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -85,3 +85,12 @@ You can find a list of major changes to public API below.
 |             1.0.x              |                   3.0.x                    |
 |-------------------------------:|:-------------------------------------------|
 | `matching(Criteria $criteria)` | `matching(Criteria $criteria): Collection` |
+
+# Upgrade to 1.7
+
+## Deprecated null first result
+
+Passing null as `$firstResult` to
+`Doctrine\Common\Collections\Criteria::__construct()` and to
+`Doctrine\Common\Collections\Criteria::setFirstResult()` is deprecated.
+Use `0` instead.


### PR DESCRIPTION
It was forgotten in https://github.com/doctrine/collections/pull/311, and we forgot to do the cleanup before releasing 2.0.0 :see_no_evil: 