### PR TITLE
Improve deprecation message for Criteria::orderBy()

### DIFF
--- a/src/Criteria.php
+++ b/src/Criteria.php
@@ -198,8 +198,9 @@ class Criteria
      */
     public function orderBy(array $orderings)
     {
+        $method          = __METHOD__;
         $this->orderings = array_map(
-            static function (string|Order $ordering): Order {
+            static function (string|Order $ordering) use ($method): Order {
                 if ($ordering instanceof Order) {
                     return $ordering;
                 }
@@ -211,7 +212,7 @@ class Criteria
                         'doctrine/collections',
                         'https://github.com/doctrine/collections/pull/389',
                         'Passing non-Order enum values to %s() is deprecated. Pass Order enum values instead.',
-                        __METHOD__,
+                        $method,
                     );
                 }
 


### PR DESCRIPTION
The following deprecation message started to appear in application logs after the 2.2.0 upgrade:

> Passing non-Order enum values to Doctrine\Common\Collections\{closure}() is deprecated. Pass Order enum values instead.

This change hopefully turns this message into something more actionable.