### PR TITLE
Add isNotNull to ExpressionBuilder

### DIFF
--- a/docs/en/expression-builder.rst
+++ b/docs/en/expression-builder.rst
@@ -124,6 +124,16 @@ isNull
 
     $collection->matching(new Criteria($expression));
 
+isNotNull
+------
+
+.. code-block:: php
+    $expressionBuilder = Criteria::expr();
+
+    $expression = $expressionBuilder->isNotNull('foo');
+
+    $collection->matching(new Criteria($expression));
+
 in
 ---
 

--- a/docs/en/expression-builder.rst
+++ b/docs/en/expression-builder.rst
@@ -125,7 +125,7 @@ isNull
     $collection->matching(new Criteria($expression));
 
 isNotNull
-------
+---------
 
 .. code-block:: php
     $expressionBuilder = Criteria::expr();

--- a/src/ExpressionBuilder.php
+++ b/src/ExpressionBuilder.php
@@ -77,8 +77,7 @@ class ExpressionBuilder
         return new Comparison($field, Comparison::EQ, new Value(null));
     }
 
-    /** @return Comparison */
-    public function isNotNull(string $field)
+    public function isNotNull(string $field): Comparison
     {
         return new Comparison($field, Comparison::NEQ, new Value(null));
     }

--- a/src/ExpressionBuilder.php
+++ b/src/ExpressionBuilder.php
@@ -77,6 +77,12 @@ class ExpressionBuilder
         return new Comparison($field, Comparison::EQ, new Value(null));
     }
 
+    /** @return Comparison */
+    public function isNotNull(string $field)
+    {
+        return new Comparison($field, Comparison::NEQ, new Value(null));
+    }
+
     /**
      * @param mixed[] $values
      *

--- a/tests/ExpressionBuilderTest.php
+++ b/tests/ExpressionBuilderTest.php
@@ -114,6 +114,14 @@ class ExpressionBuilderTest extends TestCase
         self::assertEquals(Comparison::EQ, $expr->getOperator());
     }
 
+    public function testIsNotNull(): void
+    {
+        $expr = $this->builder->isNotNull('a');
+
+        self::assertInstanceOf(Comparison::class, $expr);
+        self::assertEquals(Comparison::NEQ, $expr->getOperator());
+    }
+
     public function testContains(): void
     {
         $expr = $this->builder->contains('a', 'b');


### PR DESCRIPTION
Currently we have the ``isNull``, but ``isNotNull`` is missing.

I propose to add it.