### PR TITLE
Repeat closure type in Collection

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -2,6 +2,7 @@ parameters:
     level: 8
     paths:
         - src
+        - tests/StaticAnalysis
 
     ignoreErrors:
         -

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -9,6 +9,7 @@
 >
     <projectFiles>
         <directory name="src" />
+        <directory name="tests/StaticAnalysis" />
         <ignoreFiles>
             <directory name="vendor" />
             <directory name="src/Expr"/>

--- a/src/ArrayCollection.php
+++ b/src/ArrayCollection.php
@@ -371,6 +371,8 @@ class ArrayCollection implements Collection, Selectable, Stringable
     /**
      * {@inheritDoc}
      *
+     * @psalm-param Closure(T, TKey):bool $p
+     *
      * @return static
      * @psalm-return static<TKey,T>
      */

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -96,6 +96,8 @@ interface Collection extends ReadableCollection, ArrayAccess
     /**
      * {@inheritDoc}
      *
+     * @psalm-param Closure(T, TKey):bool $p
+     *
      * @return Collection<mixed> A collection with the results of the filter operation.
      * @psalm-return Collection<TKey, T>
      */
@@ -103,7 +105,9 @@ interface Collection extends ReadableCollection, ArrayAccess
 
     /**
      * {@inheritDoc}
-
+     *
+     * @psalm-param Closure(TKey, T):bool $p
+     *
      * @return Collection<mixed>[] An array with two elements. The first element contains the collection
      *                      of elements where the predicate returned TRUE, the second element
      *                      contains the collection of elements where the predicate returned FALSE.

--- a/tests/StaticAnalysis/CustomCollection.php
+++ b/tests/StaticAnalysis/CustomCollection.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Common\Collections\StaticAnalysis;
+
+use Closure;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+
+/**
+ * @phpstan-template TKey of array-key
+ * @phpstan-template T of object
+ * @phpstan-implements Collection<TKey, T>
+ */
+abstract class CustomCollection implements Collection
+{
+    /** @var ArrayCollection<TKey, T> */
+    private ArrayCollection $collection;
+
+    /** @param ArrayCollection<TKey, T> $arrayCollection */
+    public function __construct(ArrayCollection $arrayCollection)
+    {
+        $this->collection = $arrayCollection;
+    }
+
+    /**
+     * @psalm-param Closure(T, TKey):bool $p
+     *
+     * @return Collection<TKey, T>
+     */
+    public function filter(Closure $p)
+    {
+        return $this->collection->filter($p);
+    }
+
+    /**
+     * @psalm-param Closure(TKey, T):bool $p
+     *
+     * @psalm-return array{0: Collection<TKey, T>, 1: Collection<TKey, T>}
+     */
+    public function partition(Closure $p)
+    {
+        return $this->collection->partition($p);
+    }
+}


### PR DESCRIPTION
Hi, @greg0ire @derrabus 

`psalm` is loosing the other param type when half of the phpdoc is repeated.
Cf https://github.com/vimeo/psalm/issues/5776

So we have to repeat the whole phpdoc to get the Closure analysis.