### PR TITLE
Set label of GH actions dependabot PRs to CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,5 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    labels:
+      - "CI"


### PR DESCRIPTION
People could get confused when seeing such changes under "dependencies" in our CHANGELOG.