### PR TITLE
Add `prepend()` to Collection interface

### DIFF
--- a/src/AbstractLazyCollection.php
+++ b/src/AbstractLazyCollection.php
@@ -41,6 +41,13 @@ abstract class AbstractLazyCollection implements Collection
         $this->collection->add($element);
     }
 
+    public function prepend(mixed $element): void
+    {
+        $this->initialize();
+
+        $this->collection->prepend($element);
+    }
+
     public function clear(): void
     {
         $this->initialize();

--- a/src/ArrayCollection.php
+++ b/src/ArrayCollection.php
@@ -18,6 +18,7 @@ use function array_reduce;
 use function array_reverse;
 use function array_search;
 use function array_slice;
+use function array_unshift;
 use function array_values;
 use function count;
 use function current;
@@ -270,6 +271,16 @@ class ArrayCollection implements Collection, Selectable, Stringable
     public function add(mixed $element): void
     {
         $this->elements[] = $element;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @psalm-suppress InvalidPropertyAssignmentValue
+     */
+    public function prepend(mixed $element): void
+    {
+        array_unshift($this->elements, $element);
     }
 
     public function isEmpty(): bool

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -40,6 +40,14 @@ interface Collection extends ReadableCollection, ArrayAccess
     public function add(mixed $element): void;
 
     /**
+     * Adds an element at the beginning of the collection.
+     *
+     * @param mixed $element The element to add.
+     * @psalm-param T $element
+     */
+    public function prepend(mixed $element): void;
+
+    /**
      * Clears the collection, removing all elements.
      */
     public function clear(): void;

--- a/tests/CollectionTestCase.php
+++ b/tests/CollectionTestCase.php
@@ -184,6 +184,14 @@ abstract class CollectionTestCase extends TestCase
         self::assertEquals($partition[1][0], false);
     }
 
+    public function testPrepend(): void
+    {
+        $this->collection->add('one');
+        $this->collection->add('two');
+        $this->collection->prepend('zero');
+        self::assertEquals('zero', $this->collection->get(0));
+    }
+
     public function testClear(): void
     {
         $this->collection[] = 'one';


### PR DESCRIPTION
This is a new attempt to introduce a `prepend()` method to the `Collection` interface, after #162.