### PR TITLE
Throw exception if matching() is called on a Collection with scalar items

### DIFF
--- a/src/Expr/ClosureExpressionVisitor.php
+++ b/src/Expr/ClosureExpressionVisitor.php
@@ -6,6 +6,7 @@ namespace Doctrine\Common\Collections\Expr;
 
 use ArrayAccess;
 use Closure;
+use LogicException;
 use RuntimeException;
 
 use function explode;
@@ -34,12 +35,16 @@ class ClosureExpressionVisitor extends ExpressionVisitor
      * directly or indirectly (through an accessor get*, is*, or a magic
      * method, __get, __call).
      *
-     * @param object|mixed[] $object
+     * @param mixed $object
      *
      * @return mixed
      */
-    public static function getObjectFieldValue(object|array $object, string $field)
+    public static function getObjectFieldValue(mixed $object, string $field)
     {
+        if (!is_object($object) && !is_array($object)) {
+            throw new LogicException('The provided Criteria does not support items other than objects or arrays.');
+        }
+
         if (str_contains($field, '.')) {
             [$field, $subField] = explode('.', $field, 2);
             $object             = self::getObjectFieldValue($object, $field);

--- a/tests/CollectionTest.php
+++ b/tests/CollectionTest.php
@@ -10,6 +10,7 @@ use Doctrine\Common\Collections\Criteria;
 use Doctrine\Common\Collections\Expr\Expression;
 use Doctrine\Common\Collections\Expr\Value;
 use Doctrine\Common\Collections\Order;
+use LogicException;
 use RuntimeException;
 use stdClass;
 
@@ -93,5 +94,27 @@ class CollectionTest extends CollectionTestCase
         self::assertNotSame($col, $this->collection);
         self::assertEquals(1, count($col));
         self::assertEquals('baz', $col[1]->foo);
+    }
+
+    public function testOrderingScalarItems(): void
+    {
+        $this->collection[] = 1;
+        $this->collection[] = 2;
+        $this->collection[] = 3;
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('The provided Criteria does not support items other than objects or arrays.');
+        $this->collection->matching(new Criteria(null, ['foo' => Order::Descending]));
+    }
+
+    public function testMatchingScalarItems(): void
+    {
+        $this->collection[] = 1;
+        $this->collection[] = 2;
+        $this->collection[] = 3;
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('The provided Criteria does not support items other than objects or arrays.');
+        $col = $this->collection->matching(new Criteria(Criteria::expr()->eq('foo', 'bar')));
     }
 }


### PR DESCRIPTION
Previously, it would result in an obscure `TypeError`: 

> Doctrine\Common\Collections\Expr\ClosureExpressionVisitor::getObjectFieldValue(): Argument #1 ($object) must be of type object|array, int given, called in /home/priyadi/Projects/rekalogika/collections/src/Expr/ClosureExpressionVisitor.php on line 113