### PR TITLE
Use types declared in doc-block as return type hints

### DIFF
--- a/src/ArrayCollection.php
+++ b/src/ArrayCollection.php
@@ -384,7 +384,7 @@ class ArrayCollection implements Collection, Selectable, Stringable
     }
 
     /** @psalm-return Collection<TKey, T>&Selectable<TKey,T> */
-    public function matching(Criteria $criteria): Collection
+    public function matching(Criteria $criteria): Collection&Selectable
     {
         $expr     = $criteria->getWhereExpression();
         $filtered = $this->elements;

--- a/src/Selectable.php
+++ b/src/Selectable.php
@@ -28,5 +28,5 @@ interface Selectable
      * @return ReadableCollection<mixed>&Selectable<mixed>
      * @psalm-return ReadableCollection<TKey,T>&Selectable<TKey,T>
      */
-    public function matching(Criteria $criteria): ReadableCollection;
+    public function matching(Criteria $criteria): ReadableCollection&Selectable;
 }


### PR DESCRIPTION
I noticed that [intersection types are used as return types in ORM](https://github.com/doctrine/orm/blob/1fe1a6a048dd420d06704f72b296a463237d7603/src/EntityRepository.php#L199), but not in the Collections library.

I have adjusted the two places affected here. 