### PR TITLE
Leverage new array functions

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
+/stubs export-ignore
 /tests export-ignore
 /.github export-ignore
 .doctrine-project.json export-ignore

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,8 @@
     "homepage": "https://www.doctrine-project.org/projects/collections.html",
     "require": {
         "php": "^8.1",
-        "doctrine/deprecations": "^1"
+        "doctrine/deprecations": "^1",
+        "symfony/polyfill-php84": "^1.30"
     },
     "require-dev": {
         "ext-json": "*",

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -16,6 +16,10 @@
         </ignoreFiles>
     </projectFiles>
 
+    <stubs>
+        <file name="stubs/array_find.phpstub" />
+    </stubs>
+
     <issueHandlers>
         <MixedArgument errorLevel="info" />
         <MixedArgumentTypeCoercion errorLevel="info" />
@@ -39,6 +43,12 @@
                 <referencedFunction name="Doctrine\Common\Collections\Collection::offsetSet" />
             </errorLevel>
         </PossiblyNullArgument>
+
+        <RedundantCastGivenDocblockType>
+            <errorLevel type="suppress">
+                <file name="src/ArrayCollection.php"/>
+            </errorLevel>
+        </RedundantCastGivenDocblockType>
 
         <UnsafeGenericInstantiation>
             <errorLevel type="suppress">

--- a/src/ArrayCollection.php
+++ b/src/ArrayCollection.php
@@ -11,7 +11,10 @@ use ReturnTypeWillChange;
 use Stringable;
 use Traversable;
 
+use function array_all;
+use function array_any;
 use function array_filter;
+use function array_find;
 use function array_key_exists;
 use function array_keys;
 use function array_map;
@@ -245,13 +248,10 @@ class ArrayCollection implements Collection, Selectable, Stringable
      */
     public function exists(Closure $p)
     {
-        foreach ($this->elements as $key => $element) {
-            if ($p($key, $element)) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any(
+            $this->elements,
+            static fn (mixed $element, mixed $key): bool => (bool) $p($key, $element),
+        );
     }
 
     /**
@@ -386,13 +386,10 @@ class ArrayCollection implements Collection, Selectable, Stringable
      */
     public function findFirst(Closure $p)
     {
-        foreach ($this->elements as $key => $element) {
-            if ($p($key, $element)) {
-                return $element;
-            }
-        }
-
-        return null;
+        return array_find(
+            $this->elements,
+            static fn (mixed $element, mixed $key): bool => (bool) $p($key, $element),
+        );
     }
 
     /**
@@ -400,13 +397,10 @@ class ArrayCollection implements Collection, Selectable, Stringable
      */
     public function forAll(Closure $p)
     {
-        foreach ($this->elements as $key => $element) {
-            if (! $p($key, $element)) {
-                return false;
-            }
-        }
-
-        return true;
+        return array_all(
+            $this->elements,
+            static fn (mixed $element, mixed $key): bool => (bool) $p($key, $element),
+        );
     }
 
     /**

--- a/src/Expr/ClosureExpressionVisitor.php
+++ b/src/Expr/ClosureExpressionVisitor.php
@@ -8,6 +8,8 @@ use ArrayAccess;
 use Closure;
 use RuntimeException;
 
+use function array_all;
+use function array_any;
 use function explode;
 use function in_array;
 use function is_array;
@@ -189,29 +191,19 @@ class ClosureExpressionVisitor extends ExpressionVisitor
     /** @param callable[] $expressions */
     private function andExpressions(array $expressions): Closure
     {
-        return static function ($object) use ($expressions): bool {
-            foreach ($expressions as $expression) {
-                if (! $expression($object)) {
-                    return false;
-                }
-            }
-
-            return true;
-        };
+        return static fn ($object): bool => array_all(
+            $expressions,
+            static fn (callable $expression): bool => (bool) $expression($object),
+        );
     }
 
     /** @param callable[] $expressions */
     private function orExpressions(array $expressions): Closure
     {
-        return static function ($object) use ($expressions): bool {
-            foreach ($expressions as $expression) {
-                if ($expression($object)) {
-                    return true;
-                }
-            }
-
-            return false;
-        };
+        return static fn ($object): bool => array_any(
+            $expressions,
+            static fn (callable $expression): bool => (bool) $expression($object),
+        );
     }
 
     /** @param callable[] $expressions */

--- a/stubs/array_find.phpstub
+++ b/stubs/array_find.phpstub
@@ -1,0 +1,12 @@
+<?php
+
+/**
+ * @param array<TKey, TValue>                      $array
+ * @param callable(TValue $value, TKey $key): bool $callback
+ *
+ * @return TValue|null
+ *
+ * @template TKey of array-key
+ * @template TValue
+ */
+function array_find(array $array, callable $callback): mixed {}


### PR DESCRIPTION
PHP 8.4 will add a couple of array functions that we can make use of:

https://wiki.php.net/rfc/array_find

I'm using Symfony's polyfill to make sure the functions are always available. If we don't want to add that dependency, we could also work with a PHP version check inside the methods I've changed.