### PR TITLE
Stop maintaining 1.x

### DIFF
--- a/.doctrine-project.json
+++ b/.doctrine-project.json
@@ -37,7 +37,8 @@
         {
             "name": "1.8",
             "branchName": "1.8.x",
-            "slug": "1.8"
+            "slug": "1.8",
+            "maintained": false
         },
         {
             "name": "1.7",


### PR DESCRIPTION
[2.x downloads have surpassed 1.x downloads](https://packagist.org/packages/doctrine/collections/stats). Let us drop support for 1.x.