### PR TITLE
Utilizing Expression::visit method instead of match true

### DIFF
--- a/src/Expr/ExpressionVisitor.php
+++ b/src/Expr/ExpressionVisitor.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\Common\Collections\Expr;
 
-use RuntimeException;
-
 /**
  * An Expression visitor walks a graph of expressions and turns them into a
  * query for the underlying implementation.
@@ -37,16 +35,9 @@ abstract class ExpressionVisitor
      * Dispatches walking an expression to the appropriate handler.
      *
      * @return mixed
-     *
-     * @throws RuntimeException
      */
     public function dispatch(Expression $expr)
     {
-        return match (true) {
-            $expr instanceof Comparison => $this->walkComparison($expr),
-            $expr instanceof Value => $this->walkValue($expr),
-            $expr instanceof CompositeExpression => $this->walkCompositeExpression($expr),
-            default => throw new RuntimeException('Unknown Expression ' . $expr::class),
-        };
+        return $expr->visit($this);
     }
 }

--- a/tests/CollectionTest.php
+++ b/tests/CollectionTest.php
@@ -7,10 +7,8 @@ namespace Doctrine\Tests\Common\Collections;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Collections\Criteria;
-use Doctrine\Common\Collections\Expr\Expression;
 use Doctrine\Common\Collections\Expr\Value;
 use Doctrine\Common\Collections\Order;
-use RuntimeException;
 use stdClass;
 
 use function count;
@@ -54,18 +52,6 @@ class CollectionTest extends CollectionTestCase
         self::assertInstanceOf(Collection::class, $col);
         self::assertNotSame($col, $this->collection);
         self::assertEquals(1, count($col));
-    }
-
-    public function testMatchingUnknownThrowException(): void
-    {
-        self::expectException(RuntimeException::class);
-        self::expectExceptionMessage('Unknown Expression GenericExpression');
-
-        $genericExpression = $this->getMockBuilder(Expression::class)
-            ->setMockClassName('GenericExpression')
-            ->getMock();
-
-        $this->collection->matching(new Criteria($genericExpression));
     }
 
     /** @group DDC-1637 */


### PR DESCRIPTION
A rebased on 2.4.x version of this PR https://github.com/doctrine/collections/pull/230