### PR TITLE
Allow to treat `DateTimeInterface` instances as scalar values when comparing or sorting

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -44,4 +44,12 @@
         <exclude-pattern>src/ArrayCollection.php</exclude-pattern>
         <exclude-pattern>src/Collection.php</exclude-pattern>
     </rule>
+
+    <rule ref="SlevomatCodingStandard.Operators.DisallowEqualOperators.DisallowedEqualOperator">
+        <exclude-pattern>src/Expr/ClosureExpressionVisitor.php</exclude-pattern>
+    </rule>
+
+    <rule ref="SlevomatCodingStandard.Operators.DisallowEqualOperators.DisallowedNotEqualOperator">
+        <exclude-pattern>src/Expr/ClosureExpressionVisitor.php</exclude-pattern>
+    </rule>
 </ruleset>

--- a/src/ArrayCollection.php
+++ b/src/ArrayCollection.php
@@ -450,11 +450,12 @@ class ArrayCollection implements Collection, Selectable, Stringable
     /** @phpstan-return Collection<TKey, T>&Selectable<TKey,T> */
     public function matching(Criteria $criteria)
     {
-        $expr     = $criteria->getWhereExpression();
-        $filtered = $this->elements;
+        $treatDateTimeAsScalar = $criteria->getTreatDateTimeAsScalar();
+        $expr                  = $criteria->getWhereExpression();
+        $filtered              = $this->elements;
 
         if ($expr) {
-            $visitor  = new ClosureExpressionVisitor();
+            $visitor  = new ClosureExpressionVisitor($treatDateTimeAsScalar);
             $filter   = $visitor->dispatch($expr);
             $filtered = array_filter($filtered, $filter);
         }
@@ -464,7 +465,7 @@ class ArrayCollection implements Collection, Selectable, Stringable
         if ($orderings) {
             $next = null;
             foreach (array_reverse($orderings) as $field => $ordering) {
-                $next = ClosureExpressionVisitor::sortByField($field, $ordering === Order::Descending ? -1 : 1, $next);
+                $next = ClosureExpressionVisitor::sortByField($field, $ordering === Order::Descending ? -1 : 1, $next, $treatDateTimeAsScalar);
             }
 
             uasort($filtered, $next);

--- a/src/Criteria.php
+++ b/src/Criteria.php
@@ -30,6 +30,8 @@ class Criteria
     /** @var array<string, Order> */
     private array $orderings = [];
 
+    private bool $treatDateTimeAsScalar = false;
+
     private int|null $firstResult = null;
     private int|null $maxResults  = null;
 
@@ -224,6 +226,18 @@ class Criteria
         );
 
         return $this;
+    }
+
+    public function treatDateTimeAsScalar(): self
+    {
+        $this->treatDateTimeAsScalar = true;
+
+        return $this;
+    }
+
+    public function getTreatDateTimeAsScalar(): bool
+    {
+        return $this->treatDateTimeAsScalar;
     }
 
     /**

--- a/src/Expr/ClosureExpressionVisitor.php
+++ b/src/Expr/ClosureExpressionVisitor.php
@@ -6,11 +6,13 @@ namespace Doctrine\Common\Collections\Expr;
 
 use ArrayAccess;
 use Closure;
+use DateTimeInterface;
 use RuntimeException;
 
 use function array_all;
 use function array_any;
 use function explode;
+use function func_get_args;
 use function in_array;
 use function is_array;
 use function is_scalar;
@@ -31,6 +33,10 @@ use function strtoupper;
  */
 class ClosureExpressionVisitor extends ExpressionVisitor
 {
+    public function __construct(private readonly bool $treatDateTimeAsScalar = false)
+    {
+    }
+
     /**
      * Accesses the field of a given object. This field has to be public
      * directly or indirectly (through an accessor get*, is*, or a magic
@@ -103,16 +109,22 @@ class ClosureExpressionVisitor extends ExpressionVisitor
      */
     public static function sortByField(string $name, int $orientation = 1, Closure|null $next = null)
     {
+        if (isset(func_get_args()[3])) {
+            $orderDateTimeAsScalar = (bool) func_get_args()[3];
+        } else {
+            $orderDateTimeAsScalar = false;
+        }
+
         if (! $next) {
             $next = static fn (): int => 0;
         }
 
-        return static function ($a, $b) use ($name, $next, $orientation): int {
+        return static function ($a, $b) use ($name, $next, $orientation, $orderDateTimeAsScalar): int {
             $aValue = ClosureExpressionVisitor::getObjectFieldValue($a, $name);
 
             $bValue = ClosureExpressionVisitor::getObjectFieldValue($b, $name);
 
-            if ($aValue === $bValue) {
+            if ($aValue === $bValue || ($orderDateTimeAsScalar && $aValue instanceof DateTimeInterface && $bValue instanceof DateTimeInterface && $aValue == $bValue)) {
                 return $next($a, $b);
             }
 
@@ -129,8 +141,24 @@ class ClosureExpressionVisitor extends ExpressionVisitor
         $value = $comparison->getValue()->getValue();
 
         return match ($comparison->getOperator()) {
-            Comparison::EQ => static fn ($object): bool => self::getObjectFieldValue($object, $field) === $value,
-            Comparison::NEQ => static fn ($object): bool => self::getObjectFieldValue($object, $field) !== $value,
+            Comparison::EQ => function ($object) use ($field, $value): bool {
+                $fieldValue = self::getObjectFieldValue($object, $field);
+
+                if ($this->treatDateTimeAsScalar && $fieldValue instanceof DateTimeInterface) {
+                    return $fieldValue == $value;
+                }
+
+                return $fieldValue === $value;
+            },
+            Comparison::NEQ => function ($object) use ($field, $value): bool {
+                $fieldValue = self::getObjectFieldValue($object, $field);
+
+                if ($this->treatDateTimeAsScalar && $fieldValue instanceof DateTimeInterface) {
+                    return $fieldValue != $value;
+                }
+
+                return $fieldValue !== $value;
+            },
             Comparison::LT => static fn ($object): bool => self::getObjectFieldValue($object, $field) < $value,
             Comparison::LTE => static fn ($object): bool => self::getObjectFieldValue($object, $field) <= $value,
             Comparison::GT => static fn ($object): bool => self::getObjectFieldValue($object, $field) > $value,

--- a/src/Expr/ClosureExpressionVisitor.php
+++ b/src/Expr/ClosureExpressionVisitor.php
@@ -109,11 +109,7 @@ class ClosureExpressionVisitor extends ExpressionVisitor
      */
     public static function sortByField(string $name, int $orientation = 1, Closure|null $next = null)
     {
-        if (isset(func_get_args()[3])) {
-            $orderDateTimeAsScalar = (bool) func_get_args()[3];
-        } else {
-            $orderDateTimeAsScalar = false;
-        }
+        $orderDateTimeAsScalar = (bool) (func_get_args()[3] ?? false);
 
         if (! $next) {
             $next = static fn (): int => 0;

--- a/tests/ArrayCollectionTestCase.php
+++ b/tests/ArrayCollectionTestCase.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\Common\Collections;
 
+use DateTimeImmutable;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\Common\Collections\Order;
@@ -456,5 +457,49 @@ abstract class ArrayCollectionTestCase extends TestCase
                 ->matching(new Criteria(null, ['foo' => Order::Descending, 'bar' => Order::Descending]))
                 ->toArray(),
         );
+    }
+
+    public function testMultiColumnSortAppliesAllSortsAndTreatsDateTimeInstancesAsValues(): void
+    {
+        $collection = $this->buildCollection([
+            ['foo' => new DateTimeImmutable('2025-01-01 12:00:00'), 'bar' => new DateTimeImmutable('2025-01-02 12:00:00')],
+            ['foo' => new DateTimeImmutable('2025-01-01 12:00:00'), 'bar' => new DateTimeImmutable('2025-01-04 12:00:00')],
+            ['foo' => new DateTimeImmutable('2025-01-01 12:00:00'), 'bar' => new DateTimeImmutable('2025-01-03 12:00:00')],
+            ['foo' => new DateTimeImmutable('2025-01-02 12:00:00'), 'bar' => new DateTimeImmutable('2025-01-05 12:00:00')],
+        ]);
+
+        $expected = [
+            3 => ['foo' => new DateTimeImmutable('2025-01-02 12:00:00'), 'bar' => new DateTimeImmutable('2025-01-05 12:00:00')],
+            0 => ['foo' => new DateTimeImmutable('2025-01-01 12:00:00'), 'bar' => new DateTimeImmutable('2025-01-02 12:00:00')],
+            2 => ['foo' => new DateTimeImmutable('2025-01-01 12:00:00'), 'bar' => new DateTimeImmutable('2025-01-03 12:00:00')],
+            1 => ['foo' => new DateTimeImmutable('2025-01-01 12:00:00'), 'bar' => new DateTimeImmutable('2025-01-04 12:00:00')],
+        ];
+
+        if (! $this->isSelectable($collection)) {
+            $this->markTestSkipped('Collection does not support Selectable interface');
+        }
+
+        $actual = $collection
+            ->matching((new Criteria(null, ['foo' => Order::Descending, 'bar' => Order::Ascending]))->treatDateTimeAsScalar())
+            ->toArray();
+
+        self::assertEquals($expected, $actual); // does not check array key order
+        self::assertSame(array_keys($expected), array_keys($actual));
+    }
+
+    public function testMatchingDateTimeEqualityAsScalar(): void
+    {
+        $collection = $this->buildCollection([
+            ['foo' => new DateTimeImmutable('2025-01-01 12:00:00')],
+            ['foo' => new DateTimeImmutable('2025-01-02 12:00:00')],
+        ]);
+
+        if (! $this->isSelectable($collection)) {
+            $this->markTestSkipped('Collection does not support Selectable interface');
+        }
+
+        $actual = $collection->matching((new Criteria(Criteria::expr()->eq('foo', new DateTimeImmutable('2025-01-02 12:00:00'))))->treatDateTimeAsScalar());
+
+        self::assertCount(1, $actual);
     }
 }

--- a/tests/ClosureExpressionVisitorTest.php
+++ b/tests/ClosureExpressionVisitorTest.php
@@ -6,6 +6,7 @@ namespace Doctrine\Tests\Common\Collections;
 
 use ArrayAccess;
 use ArrayIterator;
+use DateTimeImmutable;
 use Doctrine\Common\Collections\Expr\ClosureExpressionVisitor;
 use Doctrine\Common\Collections\Expr\Comparison;
 use Doctrine\Common\Collections\Expr\CompositeExpression;
@@ -128,12 +129,42 @@ class ClosureExpressionVisitorTest extends TestCase
         self::assertFalse($closure(new TestObject(2)));
     }
 
+    public function testWalkEqualsComparisonDateTimeNotAsScalar(): void
+    {
+        $closure = $this->visitor->walkComparison($this->builder->eq('foo', new DateTimeImmutable('2025-03-01')));
+
+        self::assertFalse($closure(new TestObject(new DateTimeImmutable('2025-03-01'))));
+    }
+
+    public function testWalkEqualsComparisonDateTimeAsScalar(): void
+    {
+        $this->visitor = new ClosureExpressionVisitor(true);
+        $closure       = $this->visitor->walkComparison($this->builder->eq('foo', new DateTimeImmutable('2025-03-01')));
+
+        self::assertTrue($closure(new TestObject(new DateTimeImmutable('2025-03-01'))));
+    }
+
     public function testWalkNotEqualsComparison(): void
     {
         $closure = $this->visitor->walkComparison($this->builder->neq('foo', 1));
 
         self::assertFalse($closure(new TestObject(1)));
         self::assertTrue($closure(new TestObject(2)));
+    }
+
+    public function testWalkNotEqualsComparisonDateTimeNotAsScalar(): void
+    {
+        $closure = $this->visitor->walkComparison($this->builder->neq('foo', new DateTimeImmutable('2025-03-01')));
+
+        self::assertTrue($closure(new TestObject(new DateTimeImmutable('2025-03-01'))));
+    }
+
+    public function testWalkNotEqualsComparisonDateTimeAsScalar(): void
+    {
+        $this->visitor = new ClosureExpressionVisitor(true);
+        $closure       = $this->visitor->walkComparison($this->builder->neq('foo', new DateTimeImmutable('2025-03-01')));
+
+        self::assertFalse($closure(new TestObject(new DateTimeImmutable('2025-03-01'))));
     }
 
     public function testWalkLessThanComparison(): void
@@ -193,6 +224,15 @@ class ClosureExpressionVisitorTest extends TestCase
         self::assertFalse($closure(new TestObject(new TestObject('baz'))));
     }
 
+    public function testWalkInComparisonNeverStrictOnDateTime(): void
+    {
+        // basically covered by testWalkInComparisonObjects already, but this makes it more explicit
+
+        $closure = $this->visitor->walkComparison($this->builder->in('foo', [new DateTimeImmutable('2025-03-01')]));
+
+        self::assertTrue($closure(new TestObject(new DateTimeImmutable('2025-03-01'))));
+    }
+
     public function testWalkNotInComparison(): void
     {
         $closure = $this->visitor->walkComparison($this->builder->notIn('foo', [1, 2, 3, '04']));
@@ -213,6 +253,15 @@ class ClosureExpressionVisitorTest extends TestCase
         self::assertTrue($closure(new TestObject(new TestObject(0))));
         self::assertFalse($closure(new TestObject(new TestObject(4))));
         self::assertTrue($closure(new TestObject(new TestObject('baz'))));
+    }
+
+    public function testWalkNotInComparisonNeverStrictOnDateTime(): void
+    {
+        // basically covered by testWalkNotInComparisonObjects already, but this makes it more explicit
+
+        $closure = $this->visitor->walkComparison($this->builder->notIn('foo', [new DateTimeImmutable('2025-03-01')]));
+
+        self::assertFalse($closure(new TestObject(new DateTimeImmutable('2025-03-01'))));
     }
 
     public function testWalkContainsComparison(): void


### PR DESCRIPTION
The `ClosureExpressionVisitor::walkComparison()` method uses strict comparison checks for the `EQ` and `NEQ` operations. Since 4b1d1b57445b28362744448e8ded24474ba00e26, the `IN` and `NIN` checks _don't_ use strict checks when objects are concerned. Less/greater [equal] than checks don't even have the concept of strict checking in PHP.

Similarly, `ClosureExpressionVisitor::sortByField()` implements multi-field sorting in a way that considers the "next" sort field only when there is _strict_ equality on the values of the previous field.

This can be very surprising when using the collection filtering API (i. e. `Selectable`) on collections in Doctrine ORM to filter or sort fields that are represented by `DateTime` or `DateTimeImmutable`.

As long as the collection has not been initialized, a database-level filter or sort is applied, which effectively makes date/time data behave as a value (or scalar).

Once the collection has been initialized, in-memory comparisons will give different results. Depending on how new entities are created, they might actually use the _same_ DateTime instances. Once they have been hydrated by the ORM, most probably they never do.

This means collection filtering for date/time values does not work predictably for `EQ`/`NEQ`, whilst the other comparisons behave as one would expect.

Sorting through the API will effectively stop multi-field sort orderings at the first date/time field involved (reported as #361).

I think we should consider instances of `DateTimeInterface` as values, not applying strict comparisons to them.

Of course, doing so would be a BC break with regard to filtering and sorting. Thus, this PR adds a new `Criteria::treatDateTimeAsScalar()` method that flips `Criteria` instances into the new mode of operation. That flag is passed on later to `ClosureExpressionVisitor` where the actual comparisons take place.

We could discuss whether not using the new mode should raise a deprecation warning. For now, however, I think we could go ahead with just adding it as a feature flag.

#### Related

Other issues about values, especially `DateTime` not being comparable as one would expect:

* #136 
* #361 
* #437
* #68 