### PR TITLE
Fix redundant usage of stable-slug

### DIFF
--- a/.doctrine-project.json
+++ b/.doctrine-project.json
@@ -25,7 +25,7 @@
         {
             "name": "2.2",
             "branchName": "2.2.x",
-            "slug": "stable",
+            "slug": "2.2",
             "maintained": false
         },
         {


### PR DESCRIPTION
We missed an anomaly in the configuration for the website in #451 that lead to https://github.com/doctrine/doctrine-website/issues/705#issuecomment-2759196460

This should fix it.