### PR TITLE
#460 Array Collection merge

### DIFF
--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -311,6 +311,24 @@ Extracts a slice of $length elements starting at position $offset from the Colle
 
     $slice = $collection->slice(1, 2); // [1, 2]
 
+
+merge
+^^^^^
+
+Merges the elements of one or more Array Collections together so that the values of one are appended to the end of the previous one. It returns the resulting Array Collection.
+
+If the input  Array Collections have the same string keys, then the later value for that key will overwrite the previous one. If, however, the Array Collections contain numeric keys, the later value will not overwrite the original value, but will be appended.
+
+
+
+.. code-block:: php
+        $collectionA    = new ArrayCollection([1, 2, 3, 'sd' => 'a2222212']);
+        $collectionB    = new ArrayCollection(['aa' => 12, 'sd' => 'b2212']);
+        $collectionC    = new ArrayCollection(['cc' => 122, 'sd' => 'c3111212']);
+       
+        $merged = $arrayCollectionA->merge($arrayCollectionB, $arrayCollectionC);  
+        
+        
 toArray
 ^^^^^^^
 

--- a/src/ArrayCollection.php
+++ b/src/ArrayCollection.php
@@ -18,11 +18,13 @@ use function array_find;
 use function array_key_exists;
 use function array_keys;
 use function array_map;
+use function array_merge;
 use function array_reduce;
 use function array_reverse;
 use function array_search;
 use function array_slice;
 use function array_values;
+use function array_walk;
 use function count;
 use function current;
 use function end;
@@ -445,6 +447,31 @@ class ArrayCollection implements Collection, Selectable, Stringable
     public function slice(int $offset, int|null $length = null)
     {
         return array_slice($this->elements, $offset, $length, true);
+    }
+
+    /**
+     * Merge
+     *
+     * @param array<self> $arrayCollectionArr array of arrayCollections or on item
+     */
+    public function merge(self ...$arrayCollectionArr): self
+    {
+        $arraysToMerge =  array_map(
+            static function (self $arrayCollection) {
+                return $arrayCollection->toArray();
+            },
+            $arrayCollectionArr,
+        );
+
+        $merged = $this->toArray();
+        array_walk(
+            $arrayCollectionArr,
+            static function (self $arrayCollection) use (&$merged) {
+                $merged = array_merge($merged, $arrayCollection->toArray());
+            },
+        );
+
+        return new self($merged);
     }
 
     /** @phpstan-return Collection<TKey, T>&Selectable<TKey,T> */

--- a/tests/ArrayCollectionTest.php
+++ b/tests/ArrayCollectionTest.php
@@ -7,6 +7,7 @@ namespace Doctrine\Tests\Common\Collections;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 
+use function array_merge;
 use function serialize;
 use function unserialize;
 
@@ -35,6 +36,28 @@ class ArrayCollectionTest extends ArrayCollectionTestCase
 
         $this->assertIsArray($unserializeCollection->getValues());
         $this->assertCount(0, $unserializeCollection->getValues());
+    }
+
+    public function testMerge(): void
+    {
+        $a        = [1, 2, 3, 'sd' => 'a2222212'];
+        $b        = ['aa' => 12, 'sd' => 'b2212'];
+        $c        = ['cc' => 122, 'sd' => 'c3111212'];
+        $expected = array_merge($a, $b);
+
+        // Merge one collection
+        $arrayCollectionA = new ArrayCollection($a);
+        $arrayCollectionB = new ArrayCollection($b);
+        $arrayCollectionC = new ArrayCollection($c);
+        $merged           = $arrayCollectionA->merge($arrayCollectionB);
+        $this->assertEquals($expected, $merged->toArray());
+
+        // Merge two collections
+        unset($arrayCollectionA);
+        $arrayCollectionA = new ArrayCollection($a);
+        $expected         = array_merge($a, $b, $c);
+        $merged           = $arrayCollectionA->merge($arrayCollectionB, $arrayCollectionC);
+        $this->assertEquals($expected, $merged->toArray());
     }
 }
 


### PR DESCRIPTION
After the issue 
[https://github.com/doctrine/collections/issues/460](https://github.com/doctrine/collections/issues/460)
I made this solotution, which works like php array_merge.

See how it works 
find merge in
[https://github.com/demotuulia/doctrine_collections/blob/460/docs/en/index.rst](https://github.com/demotuulia/doctrine_collections/blob/460/docs/en/index.rst)
and in the test
[https://github.com/demotuulia/doctrine_collections/blob/eb577dc91f3cfd910b79e7c20d72630e37615a3c/tests/ArrayCollectionTest.php#L41](https://github.com/demotuulia/doctrine_collections/blob/eb577dc91f3cfd910b79e7c20d72630e37615a3c/tests/ArrayCollectionTest.php#L41)