### PR TITLE
Adding flatMap

### DIFF
--- a/src/ArrayCollection.php
+++ b/src/ArrayCollection.php
@@ -359,6 +359,32 @@ class ArrayCollection implements Collection, Selectable, Stringable
     }
 
     /**
+     * Applies the given function to each element in the collection and flattens the results.
+     * The function should return an array or single element for each element, which will be
+     * flattened into a single array.
+     *
+     * @phpstan-param Closure(T):array<U>|U $func
+     *
+     * @return static
+     * @phpstan-return static<int, U>
+     *
+     * @phpstan-template U
+     */
+    public function flatMap(Closure $func)
+    {
+        $result = [];
+        foreach ($this->elements as $element) {
+            $mapped = $func($element);
+            if (is_array($mapped)) {
+                $result = array_merge($result, $mapped);
+            } else {
+                $result[] = $mapped;
+            }
+        }
+        return $this->createFrom($result);
+    }
+
+    /**
      * {@inheritDoc}
      */
     public function reduce(Closure $func, $initial = null)

--- a/tests/ArrayCollectionTest.php
+++ b/tests/ArrayCollectionTest.php
@@ -36,6 +36,67 @@ class ArrayCollectionTest extends ArrayCollectionTestCase
         $this->assertIsArray($unserializeCollection->getValues());
         $this->assertCount(0, $unserializeCollection->getValues());
     }
+
+    public function testFlatMap(): void
+    {
+        $collection = new ArrayCollection([
+            'a' => [1, 2, 3],
+            'b' => [4, 5, 6],
+            'c' => [7, 8, 9]
+        ]);
+
+        $result = $collection->flatMap(static fn ($item) => $item);
+        $this->assertSame([1, 2, 3, 4, 5, 6, 7, 8, 9], $result->toArray());
+    }
+
+    public function testFlatMapWithEmptyArrays(): void
+    {
+        $collection = new ArrayCollection([
+            'a' => [1, 2],
+            'b' => [],
+            'c' => [3, 4]
+        ]);
+
+        $result = $collection->flatMap(static fn ($item) => $item);
+        $this->assertSame([1, 2, 3, 4], $result->toArray());
+    }
+
+    public function testFlatMapWithTransformation(): void
+    {
+        $collection = new ArrayCollection([1, 2, 3]);
+
+        $result = $collection->flatMap(static fn ($item) => [$item, $item * 2]);
+        $this->assertSame([1, 2, 2, 4, 3, 6], $result->toArray());
+    }
+
+    public function testFlatMapWithNonArrayReturns(): void
+    {
+        $collection = new ArrayCollection([1, 2, 3]);
+
+        $result = $collection->flatMap(static fn ($item) => $item * 2);
+        $this->assertSame([2, 4, 6], $result->toArray());
+    }
+
+    public function testFlatMapWithMixedReturns(): void
+    {
+        $collection = new ArrayCollection([1, 2, 3]);
+
+        $result = $collection->flatMap(static function ($item) {
+            if ($item % 2 === 0) {
+                return [$item, $item * 2]; // Return array for even numbers
+            }
+            return $item * 3; // Return scalar for odd numbers
+        });
+        $this->assertSame([3, 2, 4, 9], $result->toArray());
+    }
+
+    public function testFlatMapWithNullReturns(): void
+    {
+        $collection = new ArrayCollection([1, 2, 3]);
+
+        $result = $collection->flatMap(static fn ($item) => null);
+        $this->assertSame([null, null, null], $result->toArray());
+    }
 }
 
 /**


### PR DESCRIPTION
I've run into use-cases where something like `flatMap`/`SelectMany` would be rad. for example, we currently resort to somersaults like this:

```php
return new ArrayCollection(
    array_merge(
        ...$this->someCollection->map(fn(Thing $o) => $o->getSomeOtherCollection())->toArray()
    )
);
```

wouldn't it be lovely to simply:

```php
return $this->someCollection->flatMap(fn(Thing $o) => $o->getSomeOtherCollection());
```

this PR adds an implementation of `flatMap` that matches the behavior of JavaScript, in that elements which AREN'T arrays are just kinda' included, for example, in JS:

`[ [1, 2, 3], 4, [5, 6, 7] ].flatMap(x => x)` yields `[ 1, 2, 3, 4, 5, 6, 7 ]`

personally I find this a little surprising - it feels a little too loosely-typed for my liking - but as PHP is ultimately a loosely-typed language, and Doctrine Collection methods are using the same names as the JS methods, and PHP & JS are often used in combination, I thought it would be appropriate to match the JS `flatMap` behavior. but I don't feel strongly about it, and am happy to change it.

I'm also happy to add `flat`, if it feels odd to add `flatMap` without `flat`.