### PR TITLE
Bump dev tools

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -12,4 +12,4 @@ on:
 jobs:
   coding-standards:
     name: "Coding Standards"
-    uses: "doctrine/.github/.github/workflows/coding-standards.yml@7.3.0"
+    uses: "doctrine/.github/.github/workflows/coding-standards.yml@8.0.0"

--- a/.github/workflows/composer-lint.yml
+++ b/.github/workflows/composer-lint.yml
@@ -15,4 +15,4 @@ on:
 jobs:
   composer-lint:
     name: "Composer Lint"
-    uses: "doctrine/.github/.github/workflows/composer-lint.yml@7.3.0"
+    uses: "doctrine/.github/.github/workflows/composer-lint.yml@8.0.0"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -13,8 +13,8 @@ on:
 jobs:
   phpunit:
     name: "PHPUnit"
-    uses: "doctrine/.github/.github/workflows/continuous-integration.yml@7.3.0"
+    uses: "doctrine/.github/.github/workflows/continuous-integration.yml@8.0.0"
     with:
-      php-versions: '["8.1", "8.2", "8.3", "8.4"]'
+      php-versions: '["8.1", "8.2", "8.3", "8.4", "8.5"]'
     secrets:
       CODECOV_TOKEN: "${{ secrets.CODECOV_TOKEN }}"

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -17,4 +17,4 @@ on:
 jobs:
   documentation:
     name: "Documentation"
-    uses: "doctrine/.github/.github/workflows/documentation.yml@7.3.0"
+    uses: "doctrine/.github/.github/workflows/documentation.yml@8.0.0"

--- a/.github/workflows/release-on-milestone-closed.yml
+++ b/.github/workflows/release-on-milestone-closed.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   release:
     name: "Git tag, release & create merge-up PR"
-    uses: "doctrine/.github/.github/workflows/release-on-milestone-closed.yml@7.3.0"
+    uses: "doctrine/.github/.github/workflows/release-on-milestone-closed.yml@8.0.0"
     secrets:
       GIT_AUTHOR_EMAIL: ${{ secrets.GIT_AUTHOR_EMAIL }}
       GIT_AUTHOR_NAME: ${{ secrets.GIT_AUTHOR_NAME }}

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -12,4 +12,4 @@ on:
 jobs:
   static-analysis:
     name: "Static Analysis"
-    uses: "doctrine/.github/.github/workflows/static-analysis.yml@7.3.0"
+    uses: "doctrine/.github/.github/workflows/static-analysis.yml@8.0.0"

--- a/.github/workflows/website-schema.yml
+++ b/.github/workflows/website-schema.yml
@@ -17,4 +17,4 @@ on:
 jobs:
   json-validate:
     name: "Validate JSON schema"
-    uses: "doctrine/.github/.github/workflows/website-schema.yml@7.3.0"
+    uses: "doctrine/.github/.github/workflows/website-schema.yml@8.0.0"

--- a/composer.json
+++ b/composer.json
@@ -39,10 +39,10 @@
     },
     "require-dev": {
         "ext-json": "*",
-        "doctrine/coding-standard": "^12",
-        "phpstan/phpstan": "^1.8",
-        "phpstan/phpstan-phpunit": "^1.0",
-        "phpunit/phpunit": "^10.5"
+        "doctrine/coding-standard": "^14",
+        "phpstan/phpstan": "^2.1.30",
+        "phpstan/phpstan-phpunit": "^2.0.7",
+        "phpunit/phpunit": "^10.5.58 || ^11.5.42 || ^12.4"
     },
     "autoload": {
         "psr-4": {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,6 @@
 parameters:
     level: 8
+    treatPhpDocTypesAsCertain: false
     paths:
         - src
         - tests/StaticAnalysis

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,7 +3,6 @@
      xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
      colors="true"
      beStrictAboutOutputDuringTests="true"
-     beStrictAboutTodoAnnotatedTests="true"
 >
     <testsuites>
         <testsuite name="Doctrine Collections Test Suite">

--- a/tests/AbstractLazyArrayCollectionTest.php
+++ b/tests/AbstractLazyArrayCollectionTest.php
@@ -4,23 +4,20 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\Common\Collections;
 
+use Doctrine\Common\Collections\AbstractLazyCollection;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
+use PHPUnit\Framework\Attributes\CoversClass;
 
 use function assert;
 
 /**
- * Tests for {@see \Doctrine\Common\Collections\AbstractLazyCollection}.
- *
- * @covers \Doctrine\Common\Collections\AbstractLazyCollection
+ * Tests for {@see AbstractLazyCollection}.
  */
+#[CoversClass(AbstractLazyCollection::class)]
 class AbstractLazyArrayCollectionTest extends ArrayCollectionTestCase
 {
-    /**
-     * @param mixed[] $elements
-     *
-     * @return Collection<mixed>
-     */
+    /** @inheritDoc */
     protected function buildCollection(array $elements = []): Collection
     {
         return new LazyArrayCollection(new ArrayCollection($elements));

--- a/tests/AbstractLazyCollectionTest.php
+++ b/tests/AbstractLazyCollectionTest.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\Common\Collections;
 
+use Doctrine\Common\Collections\AbstractLazyCollection;
 use Doctrine\Common\Collections\ArrayCollection;
+use PHPUnit\Framework\Attributes\CoversClass;
 
 use function assert;
 use function is_array;
@@ -12,10 +14,9 @@ use function is_numeric;
 use function is_string;
 
 /**
- * Tests for {@see \Doctrine\Common\Collections\AbstractLazyCollection}.
- *
- * @covers \Doctrine\Common\Collections\AbstractLazyCollection
+ * Tests for {@see AbstractLazyCollection}.
  */
+#[CoversClass(AbstractLazyCollection::class)]
 class AbstractLazyCollectionTest extends CollectionTestCase
 {
     protected function setUp(): void

--- a/tests/ArrayCollectionTest.php
+++ b/tests/ArrayCollectionTest.php
@@ -6,22 +6,18 @@ namespace Doctrine\Tests\Common\Collections;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
+use PHPUnit\Framework\Attributes\CoversClass;
 
 use function serialize;
 use function unserialize;
 
 /**
- * Tests for {@see \Doctrine\Common\Collections\ArrayCollection}.
- *
- * @covers \Doctrine\Common\Collections\ArrayCollection
+ * Tests for {@see ArrayCollection}.
  */
+#[CoversClass(ArrayCollection::class)]
 class ArrayCollectionTest extends ArrayCollectionTestCase
 {
-    /**
-     * @param mixed[] $elements
-     *
-     * @return Collection<mixed>
-     */
+    /** @inheritDoc */
     protected function buildCollection(array $elements = []): Collection
     {
         return new ArrayCollection($elements);

--- a/tests/ArrayCollectionTestCase.php
+++ b/tests/ArrayCollectionTestCase.php
@@ -8,6 +8,7 @@ use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\Common\Collections\Order;
 use Doctrine\Common\Collections\Selectable;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
@@ -26,7 +27,7 @@ abstract class ArrayCollectionTestCase extends TestCase
     /**
      * @param mixed[] $elements
      *
-     * @return Collection<mixed>
+     * @return Collection<array-key, mixed>
      */
     abstract protected function buildCollection(array $elements = []): Collection;
 
@@ -35,11 +36,8 @@ abstract class ArrayCollectionTestCase extends TestCase
         return $obj instanceof Selectable;
     }
 
-    /**
-     * @param array<string|int, string|int> $elements
-     *
-     * @dataProvider provideDifferentElements
-     */
+    /** @param array<string|int, string|int> $elements */
+    #[DataProvider('provideDifferentElements')]
     public function testToArray(array $elements): void
     {
         $collection = $this->buildCollection($elements);
@@ -47,33 +45,24 @@ abstract class ArrayCollectionTestCase extends TestCase
         self::assertSame($elements, $collection->toArray());
     }
 
-    /**
-     * @param array<string|int, string|int> $elements
-     *
-     * @dataProvider provideDifferentElements
-     */
+    /** @param array<string|int, string|int> $elements */
+    #[DataProvider('provideDifferentElements')]
     public function testFirst(array $elements): void
     {
         $collection = $this->buildCollection($elements);
         self::assertSame(reset($elements), $collection->first());
     }
 
-    /**
-     * @param array<string|int, string|int> $elements
-     *
-     * @dataProvider provideDifferentElements
-     */
+    /** @param array<string|int, string|int> $elements */
+    #[DataProvider('provideDifferentElements')]
     public function testLast(array $elements): void
     {
         $collection = $this->buildCollection($elements);
         self::assertSame(end($elements), $collection->last());
     }
 
-    /**
-     * @param array<string|int, string|int> $elements
-     *
-     * @dataProvider provideDifferentElements
-     */
+    /** @param array<string|int, string|int> $elements */
+    #[DataProvider('provideDifferentElements')]
     public function testKey(array $elements): void
     {
         $collection = $this->buildCollection($elements);
@@ -86,11 +75,8 @@ abstract class ArrayCollectionTestCase extends TestCase
         self::assertSame(key($elements), $collection->key());
     }
 
-    /**
-     * @param array<string|int, string|int> $elements
-     *
-     * @dataProvider provideDifferentElements
-     */
+    /** @param array<string|int, string|int> $elements */
+    #[DataProvider('provideDifferentElements')]
     public function testNext(array $elements): void
     {
         $count      = count($elements);
@@ -112,11 +98,8 @@ abstract class ArrayCollectionTestCase extends TestCase
         self::assertFalse($collection->next());
     }
 
-    /**
-     * @param array<string|int, string|int> $elements
-     *
-     * @dataProvider provideDifferentElements
-     */
+    /** @param array<string|int, string|int> $elements */
+    #[DataProvider('provideDifferentElements')]
     public function testCurrent(array $elements): void
     {
         $collection = $this->buildCollection($elements);
@@ -129,11 +112,8 @@ abstract class ArrayCollectionTestCase extends TestCase
         self::assertSame(current($elements), $collection->current());
     }
 
-    /**
-     * @param array<string|int, string|int> $elements
-     *
-     * @dataProvider provideDifferentElements
-     */
+    /** @param array<string|int, string|int> $elements */
+    #[DataProvider('provideDifferentElements')]
     public function testGetKeys(array $elements): void
     {
         $collection = $this->buildCollection($elements);
@@ -141,11 +121,8 @@ abstract class ArrayCollectionTestCase extends TestCase
         self::assertSame(array_keys($elements), $collection->getKeys());
     }
 
-    /**
-     * @param array<string|int, string|int> $elements
-     *
-     * @dataProvider provideDifferentElements
-     */
+    /** @param array<string|int, string|int> $elements */
+    #[DataProvider('provideDifferentElements')]
     public function testGetValues(array $elements): void
     {
         $collection = $this->buildCollection($elements);
@@ -153,11 +130,8 @@ abstract class ArrayCollectionTestCase extends TestCase
         self::assertSame(array_values($elements), $collection->getValues());
     }
 
-    /**
-     * @param array<string|int, string|int> $elements
-     *
-     * @dataProvider provideDifferentElements
-     */
+    /** @param array<string|int, string|int> $elements */
+    #[DataProvider('provideDifferentElements')]
     public function testCount(array $elements): void
     {
         $collection = $this->buildCollection($elements);
@@ -165,11 +139,8 @@ abstract class ArrayCollectionTestCase extends TestCase
         self::assertSame(count($elements), $collection->count());
     }
 
-    /**
-     * @param array<string|int, string|int> $elements
-     *
-     * @dataProvider provideDifferentElements
-     */
+    /** @param array<string|int, string|int> $elements */
+    #[DataProvider('provideDifferentElements')]
     public function testIterator(array $elements): void
     {
         $collection = $this->buildCollection($elements);
@@ -349,9 +320,8 @@ abstract class ArrayCollectionTestCase extends TestCase
     /**
      * @param int[] $array
      * @param int[] $slicedArray
-     *
-     * @dataProvider provideSlices
      */
+    #[DataProvider('provideSlices')]
     public function testMatchingWithSlicingPreserveKeys(array $array, array $slicedArray, int|null $firstResult, int|null $maxResult): void
     {
         $collection = $this->buildCollection($array);

--- a/tests/ClosureExpressionVisitorTest.php
+++ b/tests/ClosureExpressionVisitorTest.php
@@ -10,13 +10,14 @@ use Doctrine\Common\Collections\Expr\ClosureExpressionVisitor;
 use Doctrine\Common\Collections\Expr\Comparison;
 use Doctrine\Common\Collections\Expr\CompositeExpression;
 use Doctrine\Common\Collections\ExpressionBuilder;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 use stdClass;
 
 use function usort;
 
-/** @group DDC-1637 */
+#[Group('DDC-1637')]
 class ClosureExpressionVisitorTest extends TestCase
 {
     private ClosureExpressionVisitor $visitor;

--- a/tests/CollectionTest.php
+++ b/tests/CollectionTest.php
@@ -10,6 +10,7 @@ use Doctrine\Common\Collections\Criteria;
 use Doctrine\Common\Collections\Expr\Expression;
 use Doctrine\Common\Collections\Expr\Value;
 use Doctrine\Common\Collections\Order;
+use PHPUnit\Framework\Attributes\Group;
 use RuntimeException;
 use stdClass;
 
@@ -29,7 +30,7 @@ class CollectionTest extends CollectionTestCase
         self::assertTrue(is_string((string) $this->collection));
     }
 
-    /** @group DDC-1637 */
+    #[Group('DDC-1637')]
     public function testMatching(): void
     {
         $this->fillMatchingFixture();
@@ -68,7 +69,7 @@ class CollectionTest extends CollectionTestCase
         $this->collection->matching(new Criteria($genericExpression));
     }
 
-    /** @group DDC-1637 */
+    #[Group('DDC-1637')]
     public function testMatchingOrdering(): void
     {
         $this->fillMatchingFixture();
@@ -82,7 +83,7 @@ class CollectionTest extends CollectionTestCase
         self::assertEquals('bar', $col->last()->foo);
     }
 
-    /** @group DDC-1637 */
+    #[Group('DDC-1637')]
     public function testMatchingSlice(): void
     {
         $this->fillMatchingFixture();

--- a/tests/Expr/ComparisonTest.php
+++ b/tests/Expr/ComparisonTest.php
@@ -6,12 +6,12 @@ namespace Doctrine\Tests\Common\Collections\Expr;
 
 use Doctrine\Common\Collections\Expr\Comparison;
 use Doctrine\Common\Collections\Expr\ExpressionVisitor;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
-/** @coversDefaultClass \Doctrine\Common\Collections\Expr\Comparison */
+#[CoversClass(Comparison::class)]
 class ComparisonTest extends TestCase
 {
-    /** @covers ::visit */
     public function testVisit(): void
     {
         $callableExpected = static function (): void {

--- a/tests/Expr/CompositeExpressionTest.php
+++ b/tests/Expr/CompositeExpressionTest.php
@@ -8,10 +8,12 @@ use Doctrine\Common\Collections\Expr\CompositeExpression;
 use Doctrine\Common\Collections\Expr\Expression;
 use Doctrine\Common\Collections\Expr\ExpressionVisitor;
 use Doctrine\Common\Collections\Expr\Value;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
-/** @covers  \Doctrine\Common\Collections\Expr\CompositeExpression */
+#[CoversClass(CompositeExpression::class)]
 class CompositeExpressionTest extends TestCase
 {
     /** @return list<array{type:string, expressions: list<mixed>}> */
@@ -30,11 +32,8 @@ class CompositeExpressionTest extends TestCase
         ];
     }
 
-    /**
-     * @param list<mixed> $expressions
-     *
-     * @dataProvider invalidDataProvider
-     */
+    /** @param list<mixed> $expressions */
+    #[DataProvider('invalidDataProvider')]
     public function testExceptions(string $type, array $expressions): void
     {
         $this->expectException(RuntimeException::class);
@@ -72,9 +71,9 @@ class CompositeExpressionTest extends TestCase
     {
         $compositeExpression = $this->createCompositeExpression();
 
-        $visitor = $this->getMockForAbstractClass(ExpressionVisitor::class);
+        $visitor = $this->createMock(ExpressionVisitor::class);
         $visitor
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('walkCompositeExpression');
 
         $compositeExpression->visit($visitor);

--- a/tests/Expr/ValueTest.php
+++ b/tests/Expr/ValueTest.php
@@ -6,9 +6,10 @@ namespace Doctrine\Tests\Common\Collections\Expr;
 
 use Doctrine\Common\Collections\Expr\ExpressionVisitor;
 use Doctrine\Common\Collections\Expr\Value;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
-/** @covers  \Doctrine\Common\Collections\Expr\Value */
+#[CoversClass(Value::class)]
 class ValueTest extends TestCase
 {
     public function testGetter(): void
@@ -23,7 +24,7 @@ class ValueTest extends TestCase
 
     public function testVisitor(): void
     {
-        $visitor = $this->getMockForAbstractClass(ExpressionVisitor::class);
+        $visitor = $this->createMock(ExpressionVisitor::class);
         $visitor
             ->expects($this->once())
             ->method('walkValue');

--- a/tests/ExpressionBuilderTest.php
+++ b/tests/ExpressionBuilderTest.php
@@ -7,10 +7,11 @@ namespace Doctrine\Tests\Common\Collections;
 use Doctrine\Common\Collections\Expr\Comparison;
 use Doctrine\Common\Collections\Expr\CompositeExpression;
 use Doctrine\Common\Collections\ExpressionBuilder;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use TypeError;
 
-/** @group DDC-1637 */
+#[Group('DDC-1637')]
 class ExpressionBuilderTest extends TestCase
 {
     private ExpressionBuilder $builder;


### PR DESCRIPTION
This PR bumps our dev tooling:

* Doctrine CS: 12 => 14
* PHPStan: 1 => 2.1
* PHPUnit 10.5 => 11.5/12.4
* GitHub Workflows: 7.3.0 => 8.0.0

Replaces #468