### PR TITLE
Transition to using reflection-based, direct field access only

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -6,6 +6,18 @@ awareness about deprecated code.
 - Use of our low-overhead runtime deprecation API, details:
   https://github.com/doctrine/deprecations/
 
+# Upgrade to 2.4
+
+## Deprecated accessing fields through other means than raw field access when using the criteria filtering API (the `Doctrine\Common\Collections\Selectable` interface)
+
+Starting with the next major version, the only way to access data when using the criteria filtering 
+API is through direct (reflection-based) access at properties directly, also bypassing property hooks.
+This is to ensure consistency with how the ORM/ODM work. See https://github.com/doctrine/collections/pull/472 for
+the full motivation.
+
+To opt-in to the new behaviour, pass `true` for the `$accessRawFieldValues` parameter when creating a `Criteria`
+object through either `Doctrine\Common\Collections\Criteria::create()` or when calling the `Doctrine\Common\Collections\Criteria` constructor. 
+
 # Upgrade to 2.2
 
 ## Deprecated string representation of sort order

--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -364,11 +364,14 @@ You can read more about expressions :ref:`here <expressions>`.
 .. note::
 
     For collections that contain objects, the field name given to ``Comparison`` will
-    lead to various access methods being tried in sequence. For the exact implementation,
-    refer to the ``ClosureExpressionVisitor::getObjectFieldValue()`` method.
+    lead to various access methods being tried in sequence. This behavior is deprecated
+    as of v2.4.0. Set the ``$accessRawFieldValues`` parameter in the ``Criteria`` constructor
+    to ``true`` to opt-in to the new behaviour of using direct (reflection-based) field access only.
+    This will be the only option in the next major version.
 
-    Roughly speaking, for a field named ``field``, the following things will be tried
-    in order:
+    Unless you opt in, refer to the ``ClosureExpressionVisitor::getObjectFieldValue()`` method
+    for the exact order of accessors tried. Roughly speaking, for a field named ``field``,
+    the following things will be tried in order:
 
     1. ``getField()``, ``isField()`` and ``field()`` as getter methods
     2. When the object implements a ``__call`` magic method, invoke it

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -44,4 +44,14 @@
         <exclude-pattern>src/ArrayCollection.php</exclude-pattern>
         <exclude-pattern>src/Collection.php</exclude-pattern>
     </rule>
+
+    <rule ref="PSR2.Classes.PropertyDeclaration.Multiple">
+        <!-- https://github.com/doctrine/collections/pull/472#issuecomment-3384164908 -->
+        <exclude-pattern>tests/TestObjectPropertyHook.php</exclude-pattern>
+    </rule>
+
+    <rule ref="PSR2.Classes.PropertyDeclaration.ScopeMissing">
+        <!-- https://github.com/doctrine/collections/pull/472#issuecomment-3384164908 -->
+        <exclude-pattern>tests/TestObjectPropertyHook.php</exclude-pattern>
+    </rule>
 </ruleset>

--- a/src/ArrayCollection.php
+++ b/src/ArrayCollection.php
@@ -450,11 +450,13 @@ class ArrayCollection implements Collection, Selectable, Stringable
     /** @phpstan-return Collection<TKey, T>&Selectable<TKey,T> */
     public function matching(Criteria $criteria)
     {
+        $accessRawFieldValues = $criteria->isRawFieldValueAccessEnabled();
+
         $expr     = $criteria->getWhereExpression();
         $filtered = $this->elements;
 
         if ($expr) {
-            $visitor  = new ClosureExpressionVisitor();
+            $visitor  = new ClosureExpressionVisitor($accessRawFieldValues);
             $filter   = $visitor->dispatch($expr);
             $filtered = array_filter($filtered, $filter);
         }
@@ -464,7 +466,7 @@ class ArrayCollection implements Collection, Selectable, Stringable
         if ($orderings) {
             $next = null;
             foreach (array_reverse($orderings) as $field => $ordering) {
-                $next = ClosureExpressionVisitor::sortByField($field, $ordering === Order::Descending ? -1 : 1, $next);
+                $next = ClosureExpressionVisitor::sortByField($field, $ordering === Order::Descending ? -1 : 1, $next, $accessRawFieldValues);
             }
 
             uasort($filtered, $next);

--- a/src/Criteria.php
+++ b/src/Criteria.php
@@ -9,6 +9,7 @@ use Doctrine\Common\Collections\Expr\Expression;
 use Doctrine\Deprecations\Deprecation;
 
 use function array_map;
+use function func_get_arg;
 use function func_num_args;
 use function strtoupper;
 
@@ -38,9 +39,11 @@ class Criteria
      *
      * @return static
      */
-    public static function create()
+    public static function create(/* bool $accessRawFieldValues = false */): self
     {
-        return new static();
+        $accessRawFieldValues = 0 < func_num_args() ? func_get_arg(0) : false;
+
+        return new static(firstResult: 0, accessRawFieldValues: $accessRawFieldValues);
     }
 
     /**
@@ -67,8 +70,16 @@ class Criteria
         array|null $orderings = null,
         int|null $firstResult = null,
         int|null $maxResults = null,
+        private bool $accessRawFieldValues = false,
     ) {
-        $this->expression = $expression;
+        if (! $accessRawFieldValues) {
+            Deprecation::trigger(
+                'doctrine/collections',
+                'https://github.com/doctrine/collections/pull/472',
+                'Not enabling raw field value access for the Criteria matching API in %s is deprecated. Raw field access will be the only supported method in 3.0',
+                self::class,
+            );
+        }
 
         if ($firstResult === null && func_num_args() > 2) {
             Deprecation::trigger(
@@ -281,5 +292,11 @@ class Criteria
         $this->maxResults = $maxResults;
 
         return $this;
+    }
+
+    /** @internal */
+    public function isRawFieldValueAccessEnabled(): bool
+    {
+        return $this->accessRawFieldValues;
     }
 }

--- a/src/Expr/ClosureExpressionVisitor.php
+++ b/src/Expr/ClosureExpressionVisitor.php
@@ -6,11 +6,15 @@ namespace Doctrine\Common\Collections\Expr;
 
 use ArrayAccess;
 use Closure;
+use Doctrine\Deprecations\Deprecation;
+use ReflectionClass;
 use RuntimeException;
 
 use function array_all;
 use function array_any;
 use function explode;
+use function func_get_arg;
+use function func_num_args;
 use function in_array;
 use function is_array;
 use function is_scalar;
@@ -18,10 +22,13 @@ use function iterator_to_array;
 use function method_exists;
 use function preg_match;
 use function preg_replace_callback;
+use function sprintf;
 use function str_contains;
 use function str_ends_with;
 use function str_starts_with;
 use function strtoupper;
+
+use const PHP_VERSION_ID;
 
 /**
  * Walks an expression graph and turns it into a PHP closure.
@@ -31,6 +38,11 @@ use function strtoupper;
  */
 class ClosureExpressionVisitor extends ExpressionVisitor
 {
+    public function __construct(
+        private readonly bool $accessRawFieldValues = false,
+    ) {
+    }
+
     /**
      * Accesses the field of a given object. This field has to be public
      * directly or indirectly (through an accessor get*, is*, or a magic
@@ -40,18 +52,31 @@ class ClosureExpressionVisitor extends ExpressionVisitor
      *
      * @return mixed
      */
-    public static function getObjectFieldValue(object|array $object, string $field)
+    public static function getObjectFieldValue(object|array $object, string $field, /* bool $accessRawFieldValues = false */)
     {
+        $accessRawFieldValues = 3 <= func_num_args() ? func_get_arg(2) : false;
+
         if (str_contains($field, '.')) {
             [$field, $subField] = explode('.', $field, 2);
-            $object             = self::getObjectFieldValue($object, $field);
+            $object             = self::getObjectFieldValue($object, $field, $accessRawFieldValues);
 
-            return self::getObjectFieldValue($object, $subField);
+            return self::getObjectFieldValue($object, $subField, $accessRawFieldValues);
         }
 
         if (is_array($object)) {
             return $object[$field];
         }
+
+        if ($accessRawFieldValues) {
+            return self::getNearestFieldValue($object, $field);
+        }
+
+        Deprecation::trigger(
+            'doctrine/collections',
+            'https://github.com/doctrine/collections/pull/472',
+            'Not enabling raw field value access for %s is deprecated. Raw field access will be the only supported method in 3.0',
+            __METHOD__,
+        );
 
         $accessors = ['get', 'is', ''];
 
@@ -96,21 +121,52 @@ class ClosureExpressionVisitor extends ExpressionVisitor
         return $object->$field;
     }
 
+    private static function getNearestFieldValue(object $object, string $field): mixed
+    {
+        $reflectionClass = new ReflectionClass($object);
+
+        while ($reflectionClass && ! $reflectionClass->hasProperty($field)) {
+            $reflectionClass = $reflectionClass->getParentClass();
+        }
+
+        if ($reflectionClass === false) {
+            throw new RuntimeException(sprintf('Field "%s" does not exist in class "%s"', $field, $object::class));
+        }
+
+        $property = $reflectionClass->getProperty($field);
+
+        if (PHP_VERSION_ID >= 80400) {
+            return $property->getRawValue($object);
+        }
+
+        return $property->getValue($object);
+    }
+
     /**
      * Helper for sorting arrays of objects based on multiple fields + orientations.
      *
      * @return Closure
      */
-    public static function sortByField(string $name, int $orientation = 1, Closure|null $next = null)
+    public static function sortByField(string $name, int $orientation = 1, Closure|null $next = null, /* bool $accessRawFieldValues = false */)
     {
+        $accessRawFieldValues = 4 <= func_num_args() ? func_get_arg(3) : false;
+
+        if (! $accessRawFieldValues) {
+            Deprecation::trigger(
+                'doctrine/collections',
+                'https://github.com/doctrine/collections/pull/472',
+                'Not enabling raw field value access for %s is deprecated. Raw field access will be the only supported method in 3.0',
+                __METHOD__,
+            );
+        }
+
         if (! $next) {
             $next = static fn (): int => 0;
         }
 
-        return static function ($a, $b) use ($name, $next, $orientation): int {
-            $aValue = ClosureExpressionVisitor::getObjectFieldValue($a, $name);
-
-            $bValue = ClosureExpressionVisitor::getObjectFieldValue($b, $name);
+        return static function ($a, $b) use ($name, $next, $orientation, $accessRawFieldValues): int {
+            $aValue = ClosureExpressionVisitor::getObjectFieldValue($a, $name, $accessRawFieldValues);
+            $bValue = ClosureExpressionVisitor::getObjectFieldValue($b, $name, $accessRawFieldValues);
 
             if ($aValue === $bValue) {
                 return $next($a, $b);
@@ -129,25 +185,25 @@ class ClosureExpressionVisitor extends ExpressionVisitor
         $value = $comparison->getValue()->getValue();
 
         return match ($comparison->getOperator()) {
-            Comparison::EQ => static fn ($object): bool => self::getObjectFieldValue($object, $field) === $value,
-            Comparison::NEQ => static fn ($object): bool => self::getObjectFieldValue($object, $field) !== $value,
-            Comparison::LT => static fn ($object): bool => self::getObjectFieldValue($object, $field) < $value,
-            Comparison::LTE => static fn ($object): bool => self::getObjectFieldValue($object, $field) <= $value,
-            Comparison::GT => static fn ($object): bool => self::getObjectFieldValue($object, $field) > $value,
-            Comparison::GTE => static fn ($object): bool => self::getObjectFieldValue($object, $field) >= $value,
-            Comparison::IN => static function ($object) use ($field, $value): bool {
-                $fieldValue = ClosureExpressionVisitor::getObjectFieldValue($object, $field);
+            Comparison::EQ => fn ($object): bool => self::getObjectFieldValue($object, $field, $this->accessRawFieldValues) === $value,
+            Comparison::NEQ => fn ($object): bool => self::getObjectFieldValue($object, $field, $this->accessRawFieldValues) !== $value,
+            Comparison::LT => fn ($object): bool => self::getObjectFieldValue($object, $field, $this->accessRawFieldValues) < $value,
+            Comparison::LTE => fn ($object): bool => self::getObjectFieldValue($object, $field, $this->accessRawFieldValues) <= $value,
+            Comparison::GT => fn ($object): bool => self::getObjectFieldValue($object, $field, $this->accessRawFieldValues) > $value,
+            Comparison::GTE => fn ($object): bool => self::getObjectFieldValue($object, $field, $this->accessRawFieldValues) >= $value,
+            Comparison::IN => function ($object) use ($field, $value): bool {
+                $fieldValue = ClosureExpressionVisitor::getObjectFieldValue($object, $field, $this->accessRawFieldValues);
 
                 return in_array($fieldValue, $value, is_scalar($fieldValue));
             },
-            Comparison::NIN => static function ($object) use ($field, $value): bool {
-                $fieldValue = ClosureExpressionVisitor::getObjectFieldValue($object, $field);
+            Comparison::NIN => function ($object) use ($field, $value): bool {
+                $fieldValue = ClosureExpressionVisitor::getObjectFieldValue($object, $field, $this->accessRawFieldValues);
 
                 return ! in_array($fieldValue, $value, is_scalar($fieldValue));
             },
-            Comparison::CONTAINS => static fn ($object): bool => str_contains((string) self::getObjectFieldValue($object, $field), (string) $value),
-            Comparison::MEMBER_OF => static function ($object) use ($field, $value): bool {
-                $fieldValues = ClosureExpressionVisitor::getObjectFieldValue($object, $field);
+            Comparison::CONTAINS => fn ($object): bool => str_contains((string) self::getObjectFieldValue($object, $field, $this->accessRawFieldValues), (string) $value),
+            Comparison::MEMBER_OF => function ($object) use ($field, $value): bool {
+                $fieldValues = ClosureExpressionVisitor::getObjectFieldValue($object, $field, $this->accessRawFieldValues);
 
                 if (! is_array($fieldValues)) {
                     $fieldValues = iterator_to_array($fieldValues);
@@ -155,8 +211,8 @@ class ClosureExpressionVisitor extends ExpressionVisitor
 
                 return in_array($value, $fieldValues, true);
             },
-            Comparison::STARTS_WITH => static fn ($object): bool => str_starts_with((string) self::getObjectFieldValue($object, $field), (string) $value),
-            Comparison::ENDS_WITH => static fn ($object): bool => str_ends_with((string) self::getObjectFieldValue($object, $field), (string) $value),
+            Comparison::STARTS_WITH => fn ($object): bool => str_starts_with((string) self::getObjectFieldValue($object, $field, $this->accessRawFieldValues), (string) $value),
+            Comparison::ENDS_WITH => fn ($object): bool => str_ends_with((string) self::getObjectFieldValue($object, $field, $this->accessRawFieldValues), (string) $value),
             default => throw new RuntimeException('Unknown comparison operator: ' . $comparison->getOperator()),
         };
     }

--- a/tests/ArrayCollectionTestCase.php
+++ b/tests/ArrayCollectionTestCase.php
@@ -283,11 +283,8 @@ abstract class ArrayCollectionTestCase extends TestCase
 
     public function testMatchingWithSortingPreserveKeys(): void
     {
-        $object1 = new stdClass();
-        $object2 = new stdClass();
-
-        $object1->sortField = 2;
-        $object2->sortField = 1;
+        $object1 = new TestObjectPrivatePropertyOnly(2);
+        $object2 = new TestObjectPrivatePropertyOnly(1);
 
         $collection = $this->buildCollection([
             'object1' => $object1,
@@ -304,7 +301,7 @@ abstract class ArrayCollectionTestCase extends TestCase
                 'object1' => $object1,
             ],
             $collection
-                ->matching(new Criteria(null, ['sortField' => Order::Ascending]))
+                ->matching(new Criteria(null, ['fooBar' => Order::Ascending], 0, accessRawFieldValues: true))
                 ->toArray(),
         );
     }
@@ -333,7 +330,7 @@ abstract class ArrayCollectionTestCase extends TestCase
                 'object1' => $object1,
             ],
             $collection
-                ->matching(new Criteria(null, ['sortField' => Criteria::ASC]))
+                ->matching(new Criteria(null, ['sortField' => Order::Ascending]))
                 ->toArray(),
         );
     }
@@ -358,7 +355,7 @@ abstract class ArrayCollectionTestCase extends TestCase
         self::assertSame(
             $slicedArray,
             $collection
-                ->matching(new Criteria(null, null, $firstResult, $maxResult))
+                ->matching(new Criteria(null, null, $firstResult, $maxResult, accessRawFieldValues: true))
                 ->toArray(),
         );
     }
@@ -480,7 +477,7 @@ abstract class ArrayCollectionTestCase extends TestCase
         self::assertSame(
             $expected,
             $collection
-                ->matching(new Criteria(null, ['foo' => Order::Descending, 'bar' => Order::Descending]))
+                ->matching(new Criteria(null, ['foo' => Order::Descending, 'bar' => Order::Descending], 0, null, accessRawFieldValues: true))
                 ->toArray(),
         );
     }

--- a/tests/ClosureExpressionVisitorTest.php
+++ b/tests/ClosureExpressionVisitorTest.php
@@ -10,7 +10,10 @@ use Doctrine\Common\Collections\Expr\ClosureExpressionVisitor;
 use Doctrine\Common\Collections\Expr\Comparison;
 use Doctrine\Common\Collections\Expr\CompositeExpression;
 use Doctrine\Common\Collections\ExpressionBuilder;
+use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
+use PHPUnit\Framework\Attributes\RequiresPhp;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 use stdClass;
@@ -20,13 +23,15 @@ use function usort;
 #[Group('DDC-1637')]
 class ClosureExpressionVisitorTest extends TestCase
 {
+    use VerifyDeprecations;
+
     private ClosureExpressionVisitor $visitor;
 
     private ExpressionBuilder $builder;
 
     protected function setUp(): void
     {
-        $this->visitor = new ClosureExpressionVisitor();
+        $this->visitor = new ClosureExpressionVisitor(true);
         $this->builder = new ExpressionBuilder();
     }
 
@@ -37,22 +42,70 @@ class ClosureExpressionVisitorTest extends TestCase
         $this->assertFalse($closure(new TestObject(new TestObject(2))));
     }
 
+    public function testGetEmbeddedObjectFieldValueAccessingRawValue(): void
+    {
+        $object = new TestObject(new TestObjectPrivatePropertyOnly(42));
+
+        self::assertSame(42, $this->visitor->getObjectFieldValue($object, 'foo.fooBar', true));
+    }
+
+    #[RequiresPhp('>= 8.4')]
+    public function testGetObjectFieldValueAccessingRawValueBypassingPropertyHook(): void
+    {
+        $object         = new TestObjectPropertyHook();
+        $object->fooBar = 42;
+
+        self::assertSame(42, $this->visitor->getObjectFieldValue($object, 'fooBar', true));
+    }
+
+    public function testGetObjectFieldValueAccessingRawValue(): void
+    {
+        $object = new TestObjectPrivatePropertyOnly(42);
+
+        self::assertSame(42, $this->visitor->getObjectFieldValue($object, 'fooBar', true));
+    }
+
+    public function testGetObjectFieldValueFindingParentClassAccessingRawValue(): void
+    {
+        $object = new TestObjectWithPrivatePropertyInParentClass(42);
+
+        self::assertSame(42, $this->visitor->getObjectFieldValue($object, 'fooBar', true));
+    }
+
+    public function testGetObjectFieldValueNonexistentFieldAccessingRawValue(): void
+    {
+        $object = new stdClass();
+
+        $this->expectException(RuntimeException::class);
+
+        $this->visitor->getObjectFieldValue($object, 'fooBar', true);
+    }
+
+    #[IgnoreDeprecations]
     public function testGetObjectFieldValueIsAccessor(): void
     {
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/collections/pull/472');
+
         $object = new TestObject(1, 2, true);
 
         self::assertTrue($this->visitor->getObjectFieldValue($object, 'baz'));
     }
 
+    #[IgnoreDeprecations]
     public function testGetObjectFieldValueIsAccessorWithIsPrefix(): void
     {
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/collections/pull/472');
+
         $object = new TestObject(1, 2, true);
 
         self::assertTrue($this->visitor->getObjectFieldValue($object, 'isBaz'));
     }
 
+    #[IgnoreDeprecations]
     public function testGetObjectFieldValueIsAccessorCamelCase(): void
     {
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/collections/pull/472');
+
         $object = new TestObjectNotCamelCase(1);
 
         self::assertEquals(1, $this->visitor->getObjectFieldValue($object, 'foo_bar'));
@@ -60,8 +113,11 @@ class ClosureExpressionVisitorTest extends TestCase
         self::assertEquals(1, $this->visitor->getObjectFieldValue($object, 'fooBar'));
     }
 
+    #[IgnoreDeprecations]
     public function testGetObjectFieldValueIsAccessorBoth(): void
     {
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/collections/pull/472');
+
         $object = new TestObjectBothCamelCaseAndUnderscore(1, 2);
 
         self::assertEquals(2, $this->visitor->getObjectFieldValue($object, 'foo_bar'));
@@ -69,8 +125,11 @@ class ClosureExpressionVisitorTest extends TestCase
         self::assertEquals(2, $this->visitor->getObjectFieldValue($object, 'fooBar'));
     }
 
+    #[IgnoreDeprecations]
     public function testGetObjectFieldValueIsAccessorOnePublic(): void
     {
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/collections/pull/472');
+
         $object = new TestObjectPublicCamelCaseAndPrivateUnderscore(1, 2);
 
         self::assertEquals(2, $this->visitor->getObjectFieldValue($object, 'foo_bar'));
@@ -78,8 +137,11 @@ class ClosureExpressionVisitorTest extends TestCase
         self::assertEquals(2, $this->visitor->getObjectFieldValue($object, 'fooBar'));
     }
 
+    #[IgnoreDeprecations]
     public function testGetObjectFieldValueIsAccessorBothPublic(): void
     {
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/collections/pull/472');
+
         $object = new TestObjectPublicCamelCaseAndPrivateUnderscore(1, 2);
 
         self::assertEquals(2, $this->visitor->getObjectFieldValue($object, 'foo_bar'));
@@ -87,23 +149,32 @@ class ClosureExpressionVisitorTest extends TestCase
         self::assertEquals(2, $this->visitor->getObjectFieldValue($object, 'fooBar'));
     }
 
+    #[IgnoreDeprecations]
     public function testGetObjectFieldValueBlankAccessor(): void
     {
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/collections/pull/472');
+
         $object = new TestObjectBlankGetter(1);
 
         self::assertEquals(1, $this->visitor->getObjectFieldValue($object, 'foobar'));
         self::assertEquals(1, $this->visitor->getObjectFieldValue($object, 'fooBar'));
     }
 
+    #[IgnoreDeprecations]
     public function testGetObjectFieldValueMagicCallMethod(): void
     {
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/collections/pull/472');
+
         $object = new TestObject(1, 2, true, 3);
 
         self::assertEquals(3, $this->visitor->getObjectFieldValue($object, 'qux'));
     }
 
+    #[IgnoreDeprecations]
     public function testGetObjectFieldValueArrayAccess(): void
     {
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/collections/pull/472');
+
         $object = self::createMock(ArrayAccess::class);
         $object->expects(self::once())
             ->method('offsetGet')
@@ -113,8 +184,11 @@ class ClosureExpressionVisitorTest extends TestCase
         self::assertSame(33, $this->visitor->getObjectFieldValue($object, 'foo'));
     }
 
+    #[IgnoreDeprecations]
     public function testGetObjectFieldValuePublicPropertyIsNull(): void
     {
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/collections/pull/472');
+
         $object      = new stdClass();
         $object->foo = null;
 
@@ -366,7 +440,7 @@ class ClosureExpressionVisitorTest extends TestCase
     public function testSortByFieldAscending(): void
     {
         $objects = [new TestObject('b'), new TestObject('a'), new TestObject('c')];
-        $sort    = ClosureExpressionVisitor::sortByField('foo');
+        $sort    = ClosureExpressionVisitor::sortByField('foo', 1, null, true);
 
         usort($objects, $sort);
 
@@ -378,7 +452,7 @@ class ClosureExpressionVisitorTest extends TestCase
     public function testSortByFieldDescending(): void
     {
         $objects = [new TestObject('b'), new TestObject('a'), new TestObject('c')];
-        $sort    = ClosureExpressionVisitor::sortByField('foo', -1);
+        $sort    = ClosureExpressionVisitor::sortByField('foo', -1, null, true);
 
         usort($objects, $sort);
 
@@ -393,7 +467,7 @@ class ClosureExpressionVisitorTest extends TestCase
         $secondElement = new TestObject('a');
 
         $objects = [$firstElement, $secondElement];
-        $sort    = ClosureExpressionVisitor::sortByField('foo');
+        $sort    = ClosureExpressionVisitor::sortByField('foo', 0, null, true);
 
         usort($objects, $sort);
 
@@ -403,8 +477,8 @@ class ClosureExpressionVisitorTest extends TestCase
     public function testSortDelegate(): void
     {
         $objects = [new TestObject('a', 'c'), new TestObject('a', 'b'), new TestObject('a', 'a')];
-        $sort    = ClosureExpressionVisitor::sortByField('bar', 1);
-        $sort    = ClosureExpressionVisitor::sortByField('foo', 1, $sort);
+        $sort    = ClosureExpressionVisitor::sortByField('bar', 1, null, true);
+        $sort    = ClosureExpressionVisitor::sortByField('foo', 1, $sort, true);
 
         usort($objects, $sort);
 
@@ -513,4 +587,8 @@ class TestObjectBlankGetter
     {
         return $this->fooBar;
     }
+}
+
+class TestObjectWithPrivatePropertyInParentClass extends TestObjectPrivatePropertyOnly
+{
 }

--- a/tests/CollectionTest.php
+++ b/tests/CollectionTest.php
@@ -9,7 +9,9 @@ use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\Common\Collections\Expr\Value;
 use Doctrine\Common\Collections\Order;
+use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use stdClass;
 
 use function count;
@@ -17,6 +19,8 @@ use function is_string;
 
 class CollectionTest extends CollectionTestCase
 {
+    use VerifyDeprecations;
+
     protected function setUp(): void
     {
         $this->collection = new ArrayCollection();
@@ -29,11 +33,31 @@ class CollectionTest extends CollectionTestCase
     }
 
     #[Group('DDC-1637')]
-    public function testMatching(): void
+    #[IgnoreDeprecations]
+    public function testMatchingLegacy(): void
     {
-        $this->fillMatchingFixture();
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/collections/pull/472');
+
+        $std1               = new stdClass();
+        $std1->foo          = 'bar';
+        $this->collection[] = $std1;
+
+        $std2               = new stdClass();
+        $std2->foo          = 'baz';
+        $this->collection[] = $std2;
 
         $col = $this->collection->matching(new Criteria(Criteria::expr()->eq('foo', 'bar')));
+        self::assertInstanceOf(Collection::class, $col);
+        self::assertNotSame($col, $this->collection);
+        self::assertEquals(1, count($col));
+    }
+
+    public function testMatching(): void
+    {
+        $this->collection[] = new TestObjectPrivatePropertyOnly(42);
+        $this->collection[] = new TestObjectPrivatePropertyOnly(84);
+
+        $col = $this->collection->matching(new Criteria(Criteria::expr()->eq('fooBar', 42), firstResult: 0, accessRawFieldValues: true));
         self::assertInstanceOf(Collection::class, $col);
         self::assertNotSame($col, $this->collection);
         self::assertEquals(1, count($col));
@@ -47,6 +71,8 @@ class CollectionTest extends CollectionTestCase
         $col = $this->collection->matching(
             new Criteria(
                 new Value(static fn (stdClass $test): bool => $test->foo === 1),
+                firstResult: 0,
+                accessRawFieldValues: true,
             ),
         );
 
@@ -58,6 +84,25 @@ class CollectionTest extends CollectionTestCase
     #[Group('DDC-1637')]
     public function testMatchingOrdering(): void
     {
+        $this->collection['one']   = $obj1 = new TestObjectPrivatePropertyOnly(18);
+        $this->collection['two']   = $obj2 = new TestObjectPrivatePropertyOnly(10);
+        $this->collection['three'] = $obj3 = new TestObjectPrivatePropertyOnly(78);
+
+        $criteria = Criteria::create(true)->orderBy(['fooBar' => Order::Ascending]);
+
+        $col = $this->collection->matching($criteria);
+
+        self::assertInstanceOf(Collection::class, $col);
+        self::assertNotSame($col, $this->collection);
+        self::assertEquals(['two' => $obj2, 'one' => $obj1, 'three' => $obj3], $col->toArray());
+    }
+
+    #[Group('DDC-1637')]
+    #[IgnoreDeprecations]
+    public function testMatchingOrderingLegacy(): void
+    {
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/collections/pull/472');
+
         $this->fillMatchingFixture();
 
         $col = $this->collection->matching(new Criteria(null, ['foo' => Order::Descending]));
@@ -74,7 +119,7 @@ class CollectionTest extends CollectionTestCase
     {
         $this->fillMatchingFixture();
 
-        $col = $this->collection->matching(new Criteria(null, null, 1, 1));
+        $col = $this->collection->matching(new Criteria(null, null, 1, 1, accessRawFieldValues: true));
 
         self::assertInstanceOf(Collection::class, $col);
         self::assertNotSame($col, $this->collection);

--- a/tests/CollectionTestCase.php
+++ b/tests/CollectionTestCase.php
@@ -260,7 +260,7 @@ abstract class CollectionTestCase extends TestCase
             self::markTestSkipped(sprintf('Collection does not implement %s', Selectable::class));
         }
 
-        $criteria = Criteria::create();
+        $criteria = Criteria::create(true);
 
         self::assertInstanceOf(Collection::class, $this->collection->matching($criteria));
         self::assertInstanceOf(Selectable::class, $this->collection->matching($criteria));

--- a/tests/CriteriaTest.php
+++ b/tests/CriteriaTest.php
@@ -17,9 +17,19 @@ class CriteriaTest extends TestCase
 {
     use VerifyDeprecations;
 
+    #[IgnoreDeprecations]
+    public function testCreateLegacy(): void
+    {
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/collections/pull/472');
+
+        $criteria = Criteria::create();
+
+        self::assertInstanceOf(Criteria::class, $criteria);
+    }
+
     public function testCreate(): void
     {
-        $criteria = Criteria::create();
+        $criteria = Criteria::create(true);
 
         self::assertInstanceOf(Criteria::class, $criteria);
     }
@@ -27,7 +37,7 @@ class CriteriaTest extends TestCase
     public function testConstructor(): void
     {
         $expr     = new Comparison('field', '=', 'value');
-        $criteria = new Criteria($expr, ['foo' => Order::Ascending], 10, 20);
+        $criteria = new Criteria($expr, ['foo' => Order::Ascending], 10, 20, accessRawFieldValues: true);
 
         self::assertSame($expr, $criteria->getWhereExpression());
         self::assertSame(['foo' => Order::Ascending], $criteria->orderings());
@@ -49,9 +59,12 @@ class CriteriaTest extends TestCase
         self::assertSame(20, $criteria->getMaxResults());
     }
 
+    #[IgnoreDeprecations]
     public function testDefaultConstructor(): void
     {
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/collections/pull/472');
         $this->expectNoDeprecationWithIdentifier('https://github.com/doctrine/collections/pull/311');
+
         $criteria = new Criteria();
 
         self::assertNull($criteria->getWhereExpression());
@@ -63,7 +76,7 @@ class CriteriaTest extends TestCase
     public function testWhere(): void
     {
         $expr     = new Comparison('field', '=', 'value');
-        $criteria = new Criteria();
+        $criteria = Criteria::create(true);
 
         $criteria->where($expr);
 
@@ -73,7 +86,7 @@ class CriteriaTest extends TestCase
     public function testAndWhere(): void
     {
         $expr     = new Comparison('field', '=', 'value');
-        $criteria = new Criteria();
+        $criteria = Criteria::create(true);
 
         $criteria->where($expr);
         $expr = $criteria->getWhereExpression();
@@ -89,7 +102,7 @@ class CriteriaTest extends TestCase
     public function testAndWhereWithoutWhere(): void
     {
         $expr     = new Comparison('field', '=', 'value');
-        $criteria = new Criteria();
+        $criteria = Criteria::create(true);
 
         $criteria->andWhere($expr);
 
@@ -99,7 +112,7 @@ class CriteriaTest extends TestCase
     public function testOrWhere(): void
     {
         $expr     = new Comparison('field', '=', 'value');
-        $criteria = new Criteria();
+        $criteria = Criteria::create(true);
 
         $criteria->where($expr);
         $expr = $criteria->getWhereExpression();
@@ -115,7 +128,7 @@ class CriteriaTest extends TestCase
     public function testOrWhereWithoutWhere(): void
     {
         $expr     = new Comparison('field', '=', 'value');
-        $criteria = new Criteria();
+        $criteria = Criteria::create(true);
 
         $criteria->orWhere($expr);
 
@@ -124,7 +137,7 @@ class CriteriaTest extends TestCase
 
     public function testOrderings(): void
     {
-        $criteria = Criteria::create()
+        $criteria = Criteria::create(true)
             ->orderBy(['foo' => Order::Ascending]);
 
         self::assertEquals(['foo' => Order::Ascending], $criteria->orderings());
@@ -139,27 +152,27 @@ class CriteriaTest extends TestCase
     public function testPassingNonOrderEnumToOrderByIsDeprecated(): void
     {
         $this->expectDeprecationWithIdentifier('https://github.com/doctrine/collections/pull/389');
-        $criteria = Criteria::create()->orderBy(['foo' => 'ASC']);
+        $criteria = Criteria::create(true)->orderBy(['foo' => 'ASC']);
     }
 
     #[IgnoreDeprecations]
     public function testConstructingCriteriaWithNonOrderEnumIsDeprecated(): void
     {
         $this->expectDeprecationWithIdentifier('https://github.com/doctrine/collections/pull/389');
-        $criteria = new Criteria(null, ['foo' => 'ASC']);
+        $criteria = new Criteria(null, ['foo' => 'ASC'], firstResult: 0, accessRawFieldValues: true);
     }
 
     public function testUsingOrderEnumIsTheRightWay(): void
     {
         $this->expectNoDeprecationWithIdentifier('https://github.com/doctrine/collections/pull/389');
-        Criteria::create()->orderBy(['foo' => Order::Ascending]);
-        new Criteria(null, ['foo' => Order::Ascending]);
+        Criteria::create(true)->orderBy(['foo' => Order::Ascending]);
+        new Criteria(null, ['foo' => Order::Ascending], firstResult: 0, accessRawFieldValues: true);
     }
 
     #[IgnoreDeprecations]
     public function testCallingGetOrderingsIsDeprecated(): void
     {
-        $criteria = Criteria::create()->orderBy(['foo' => Order::Ascending]);
+        $criteria = Criteria::create(true)->orderBy(['foo' => Order::Ascending]);
         $this->expectDeprecationWithIdentifier('https://github.com/doctrine/collections/pull/389');
         $criteria->getOrderings();
     }

--- a/tests/DerivedCollectionTest.php
+++ b/tests/DerivedCollectionTest.php
@@ -22,6 +22,6 @@ class DerivedCollectionTest extends TestCase
         self::assertInstanceOf(DerivedArrayCollection::class, $collection->map($closure));
         self::assertInstanceOf(DerivedArrayCollection::class, $collection->filter($closure));
         self::assertContainsOnlyInstancesOf(DerivedArrayCollection::class, $collection->partition($closure));
-        self::assertInstanceOf(DerivedArrayCollection::class, $collection->matching(new Criteria()));
+        self::assertInstanceOf(DerivedArrayCollection::class, $collection->matching(Criteria::create(true)));
     }
 }

--- a/tests/TestObjectPrivatePropertyOnly.php
+++ b/tests/TestObjectPrivatePropertyOnly.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Common\Collections;
+
+class TestObjectPrivatePropertyOnly
+{
+    public function __construct(private mixed $fooBar = null)
+    {
+    }
+}

--- a/tests/TestObjectPropertyHook.php
+++ b/tests/TestObjectPropertyHook.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Common\Collections;
+
+class TestObjectPropertyHook
+{
+    public int|null $fooBar = null {
+        get {
+            return -$this->fooBar; // a different value
+        }
+    }
+}


### PR DESCRIPTION
#### Motivation

There are a few issues about differences in behaviour when using the collection filtering API (the `Selectable` interface)  against collections that are database-backed (in ORM, these are `PersistentCollections`) vs. memory-based collections using `ArrayCollection` from this package here. 

For example:

* https://github.com/doctrine/orm/pull/11160
* #170
* https://github.com/doctrine/orm/issues/3591
* Maybe https://github.com/doctrine/orm/issues/11021

Database-based matching can work on the raw field values only, as those values are persisted to the database and there is no PHP code involved when filtering at the database level.

Memory-based matching currently tries a [series of access methods on the objects](https://www.doctrine-project.org/projects/doctrine-collections/en/2.3/index.html#selectable-methods:~:text=For%20collections%20that%20contain%20objects). 

The effects of this may be surprising. For example, with the ORM, it may be fine to filter entities based on the value of `private` or `protected` fields that have no getters. This works as long as a persistent collection is uninitialized. But as soon as it gets initialized, the `ArrayCollection` will require a getter method to be available.

Another (more rare) example is a getter method that does some type of type conversion, like having a `string` field with values like `'y'|'n'` internally but returning a `bool` value from the getter; or, more generally, every type mismatch between the return value of the getter and the field value. Yet another example may be getters that cause side effects 🙈.

#### Proposed solution

I discussed with @beberlei at the Doctrine hackathon that the primary use case for this library here was supporting the ORM/ODM use cases. This can be seen in places as `ClosureExpressionVisitor::getObjectFieldValue()` that take a `$field` parameter.

So, although this library here has nothing to do with ORM/ODM mapping, I want to add a migration path here that moves the `doctrine/collection` behaviour closer to the implementation realities of ORM/ODM. This means to ultimately use direct (reflection-based) field access only. This is also what @Ocramius already suggested in [this comment](https://github.com/doctrine/collections/pull/149#issuecomment-475982285).

For reference, here is a list of discussions around which style of accessors, getters, issers, public access etc. should be used or not used – in the future, the answer would be "only direct state (raw property value) matters".

* #276 
* #263 
* #149
* #135 
* #134 
* #95 
* #62 

#### Migration path

This feature is opt-in and will be activated by passing `accessRawFieldValues: true` to the `Criteria` constructor. The `Criteria` object is what is typically constructed by users in preparation for calling the `Selectable` API, so it seems to be a good fit.

By opting in through this flag, memory-based comparisons and sorting will use direct field access only. Not activating the feature triggers a deprecation notice. In the next major version, direct field access will be the only (default) behaviour.

The `$accessRawFieldValues` can be removed in the next major version (or, possibly, go through another round of deprecations in case when it is still passed, before being eventually removed).

#### Caveat

As explained in more detail in #487 (references here after for more better visibility), accessing fields through reflection may bypass initialization of proxy objects in the ORM/ODM. See #487 for more details.

#### Remaining edge case

Given an inheritance hierarchy of classes where a multiple classes feature a `private` field of the same name, the downmost field will be picked.

This may differ from Doctrine ORM behaviour when this field is not mapped at all in the ORM and another field (higher up the class hierarchy) is used as the mapped field instead.

We cannot solve this without having access to ORM/ODM mapping metadata at hand, which is not possible from within an `ArrayCollection` that is typically created as [a newable type](https://testing.googleblog.com/2008/10/to-new-or-not-to-new.html). We rather plan to discourage or even prevent this kind of setup (entity class hierarchy with different classes having fields of the same name) at some point when loading and validating metadata.

#### TODO

- [x] Docs update
- [x] PHP 8.4 raw property access (circumvent property hooks)
- [x] After merge and/or release, maybe revisit and update documentation remarks made in https://github.com/doctrine/orm/pull/11891/