### PR TITLE
Remove the `accessRawFieldValues` parameter which is a no-op as of 3.0

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,17 @@ awareness about deprecated code.
 
 # Upgrade to 3.0
 
+## The criteria filtering API (the `Doctrine\Common\Collections\Selectable` interface) accesses fields through raw field access only
+
+When using the criteria filtering API properties will be accessed directly through reflection, also bypassing property hooks.
+
+The `$accessRawFieldValues` parameter in the following methods is now a no-op and can be removed in calling code:
+
+* `Doctrine\Common\Collections\Criteria::__construct()`
+* `Doctrine\Common\Collections\Criteria::create()`
+* `Doctrine\Common\Collections\Expr\ClosureExpressionVisitor::getObjectFieldValue()`
+* `Doctrine\Common\Collections\Expr\ClosureExpressionVisitor::sortByField()`
+
 ## Deprecated null first result
 
 Passing null as `$firstResult` to

--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -364,23 +364,6 @@ You can read more about expressions :ref:`here <expressions>`.
 .. note::
 
     For collections that contain objects, the field name given to ``Comparison`` will
-    lead to various access methods being tried in sequence. This behavior is deprecated
-    as of v2.4.0. Set the ``$accessRawFieldValues`` parameter in the ``Criteria`` constructor
-    to ``true`` to opt-in to the new behaviour of using direct (reflection-based) field access only.
-    This will be the only option in the next major version.
-
-    Unless you opt in, refer to the ``ClosureExpressionVisitor::getObjectFieldValue()`` method
-    for the exact order of accessors tried. Roughly speaking, for a field named ``field``,
-    the following things will be tried in order:
-
-    1. ``getField()``, ``isField()`` and ``field()`` as getter methods
-    2. When the object implements a ``__call`` magic method, invoke it
-       by calling ``getField()``
-    3. When the object implements ``ArrayAccess``, use that to access the
-       ``field`` offset
-    4. When the object contains a ``::$field`` public property that is not
-       ``null``, access it directly
-    5. Convert snake-case field names to camel case and retry the ``get``, ``is``
-       and prefixless accessor methods
-    6. Direct access to ``::$field``, which must be a public property, as a
-       last resort.
+    be used to read the raw value (bypassing property hooks) of the property with that name.
+    In the case of private properties, the property will be looked up by moving upwards
+    through the class inheritance tree and picking the first match.

--- a/src/ArrayCollection.php
+++ b/src/ArrayCollection.php
@@ -380,13 +380,11 @@ class ArrayCollection implements Collection, Selectable, Stringable
     /** @phpstan-return Collection<TKey, T>&Selectable<TKey,T> */
     public function matching(Criteria $criteria): Collection
     {
-        $accessRawFieldValues = $criteria->isRawFieldValueAccessEnabled();
-
         $expr     = $criteria->getWhereExpression();
         $filtered = $this->elements;
 
         if ($expr) {
-            $visitor  = new ClosureExpressionVisitor($accessRawFieldValues);
+            $visitor  = new ClosureExpressionVisitor();
             $filter   = $visitor->dispatch($expr);
             $filtered = array_filter($filtered, $filter);
         }
@@ -396,7 +394,7 @@ class ArrayCollection implements Collection, Selectable, Stringable
         if ($orderings) {
             $next = null;
             foreach (array_reverse($orderings) as $field => $ordering) {
-                $next = ClosureExpressionVisitor::sortByField($field, $ordering === Order::Descending ? -1 : 1, $next, $accessRawFieldValues);
+                $next = ClosureExpressionVisitor::sortByField($field, $ordering === Order::Descending ? -1 : 1, $next);
             }
 
             uasort($filtered, $next);

--- a/src/Criteria.php
+++ b/src/Criteria.php
@@ -8,7 +8,6 @@ use Doctrine\Common\Collections\Expr\CompositeExpression;
 use Doctrine\Common\Collections\Expr\Expression;
 use Doctrine\Deprecations\Deprecation;
 
-use function func_get_arg;
 use function func_num_args;
 
 /**
@@ -29,11 +28,18 @@ class Criteria
     /**
      * Creates an instance of the class.
      */
-    public static function create(/* bool $accessRawFieldValues = false */): static
+    public static function create(): static
     {
-        $accessRawFieldValues = 0 < func_num_args() ? func_get_arg(0) : false;
+        if (func_num_args() === 1) {
+            Deprecation::trigger(
+                'doctrine/collections',
+                'https://github.com/doctrine/collections/pull/486',
+                'The `accessRawFieldValues` parameter passed to %s is deprecated and a no-op. You can remove it.',
+                __METHOD__,
+            );
+        }
 
-        return new static(firstResult: 0, accessRawFieldValues: $accessRawFieldValues);
+        return new static();
     }
 
     /**
@@ -58,14 +64,13 @@ class Criteria
         array|null $orderings = null,
         int $firstResult = 0,
         int|null $maxResults = null,
-        private bool $accessRawFieldValues = false,
     ) {
-        if (! $accessRawFieldValues) {
+        if (func_num_args() === 5) {
             Deprecation::trigger(
                 'doctrine/collections',
-                'https://github.com/doctrine/collections/pull/472',
-                'Not enabling raw field value access for the Criteria matching API in %s is deprecated. Raw field access will be the only supported method in 3.0',
-                self::class,
+                'https://github.com/doctrine/collections/pull/486',
+                'The `accessRawFieldValues` parameter passed to %s is deprecated and a no-op. You can remove it.',
+                __METHOD__,
             );
         }
 
@@ -210,11 +215,5 @@ class Criteria
         $this->maxResults = $maxResults;
 
         return $this;
-    }
-
-    /** @internal */
-    public function isRawFieldValueAccessEnabled(): bool
-    {
-        return $this->accessRawFieldValues;
     }
 }

--- a/src/Expr/ClosureExpressionVisitor.php
+++ b/src/Expr/ClosureExpressionVisitor.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\Common\Collections\Expr;
 
-use ArrayAccess;
 use Closure;
 use Doctrine\Deprecations\Deprecation;
 use ReflectionClass;
@@ -13,20 +12,15 @@ use RuntimeException;
 use function array_all;
 use function array_any;
 use function explode;
-use function func_get_arg;
 use function func_num_args;
 use function in_array;
 use function is_array;
 use function is_scalar;
 use function iterator_to_array;
-use function method_exists;
-use function preg_match;
-use function preg_replace_callback;
 use function sprintf;
 use function str_contains;
 use function str_ends_with;
 use function str_starts_with;
-use function strtoupper;
 
 /**
  * Walks an expression graph and turns it into a PHP closure.
@@ -42,83 +36,32 @@ class ClosureExpressionVisitor extends ExpressionVisitor
     }
 
     /**
-     * Accesses the field of a given object. This field has to be public
-     * directly or indirectly (through an accessor get*, is*, or a magic
-     * method, __get, __call).
+     * Accesses the raw field value of a given object.
      *
      * @param object|mixed[] $object
      */
-    public static function getObjectFieldValue(object|array $object, string $field, /* bool $accessRawFieldValues = false */): mixed
+    public static function getObjectFieldValue(object|array $object, string $field): mixed
     {
-        $accessRawFieldValues = 3 <= func_num_args() ? func_get_arg(2) : false;
+        if (func_num_args() === 3) {
+            Deprecation::trigger(
+                'doctrine/collections',
+                'https://github.com/doctrine/collections/pull/486',
+                'The `accessRawFieldValues` parameter passed to %s is deprecated and a no-op. You can remove it.',
+                __METHOD__,
+            );
+        }
 
         if (str_contains($field, '.')) {
             [$field, $subField] = explode('.', $field, 2);
-            $object             = self::getObjectFieldValue($object, $field, $accessRawFieldValues);
+            $object             = self::getObjectFieldValue($object, $field);
 
-            return self::getObjectFieldValue($object, $subField, $accessRawFieldValues);
+            return self::getObjectFieldValue($object, $subField);
         }
 
         if (is_array($object)) {
             return $object[$field];
         }
 
-        if ($accessRawFieldValues) {
-            return self::getNearestFieldValue($object, $field);
-        }
-
-        Deprecation::trigger(
-            'doctrine/collections',
-            'https://github.com/doctrine/collections/pull/472',
-            'Not enabling raw field value access for %s is deprecated. Raw field access will be the only supported method in 3.0',
-            __METHOD__,
-        );
-
-        $accessors = ['get', 'is', ''];
-
-        foreach ($accessors as $accessor) {
-            $accessor .= $field;
-
-            if (method_exists($object, $accessor)) {
-                return $object->$accessor();
-            }
-        }
-
-        if (preg_match('/^is[A-Z]+/', $field) === 1 && method_exists($object, $field)) {
-            return $object->$field();
-        }
-
-        // __call should be triggered for get.
-        $accessor = $accessors[0] . $field;
-
-        if (method_exists($object, '__call')) {
-            return $object->$accessor();
-        }
-
-        if ($object instanceof ArrayAccess) {
-            return $object[$field];
-        }
-
-        if (isset($object->$field)) {
-            return $object->$field;
-        }
-
-        // camelcase field name to support different variable naming conventions
-        $ccField = preg_replace_callback('/_(.?)/', static fn (array $matches) => strtoupper((string) $matches[1]), $field);
-
-        foreach ($accessors as $accessor) {
-            $accessor .= $ccField;
-
-            if (method_exists($object, $accessor)) {
-                return $object->$accessor();
-            }
-        }
-
-        return $object->$field;
-    }
-
-    private static function getNearestFieldValue(object $object, string $field): mixed
-    {
         $reflectionClass = new ReflectionClass($object);
 
         while ($reflectionClass && ! $reflectionClass->hasProperty($field)) {
@@ -137,15 +80,13 @@ class ClosureExpressionVisitor extends ExpressionVisitor
     /**
      * Helper for sorting arrays of objects based on multiple fields + orientations.
      */
-    public static function sortByField(string $name, int $orientation = 1, Closure|null $next = null, /* bool $accessRawFieldValues = false */): Closure
+    public static function sortByField(string $name, int $orientation = 1, Closure|null $next = null): Closure
     {
-        $accessRawFieldValues = 4 <= func_num_args() ? func_get_arg(3) : false;
-
-        if (! $accessRawFieldValues) {
+        if (func_num_args() === 4) {
             Deprecation::trigger(
                 'doctrine/collections',
-                'https://github.com/doctrine/collections/pull/472',
-                'Not enabling raw field value access for %s is deprecated. Raw field access will be the only supported method in 3.0',
+                'https://github.com/doctrine/collections/pull/486',
+                'The `accessRawFieldValues` parameter passed to %s is deprecated and a no-op. You can remove it.',
                 __METHOD__,
             );
         }
@@ -154,9 +95,9 @@ class ClosureExpressionVisitor extends ExpressionVisitor
             $next = static fn (): int => 0;
         }
 
-        return static function (mixed $a, mixed $b) use ($name, $next, $orientation, $accessRawFieldValues): int {
-            $aValue = ClosureExpressionVisitor::getObjectFieldValue($a, $name, $accessRawFieldValues);
-            $bValue = ClosureExpressionVisitor::getObjectFieldValue($b, $name, $accessRawFieldValues);
+        return static function (mixed $a, mixed $b) use ($name, $next, $orientation): int {
+            $aValue = ClosureExpressionVisitor::getObjectFieldValue($a, $name);
+            $bValue = ClosureExpressionVisitor::getObjectFieldValue($b, $name);
 
             if ($aValue === $bValue) {
                 return $next($a, $b);
@@ -172,25 +113,25 @@ class ClosureExpressionVisitor extends ExpressionVisitor
         $value = $comparison->getValue()->getValue();
 
         return match ($comparison->getOperator()) {
-            Comparison::EQ => fn (object|array $object): bool => self::getObjectFieldValue($object, $field, $this->accessRawFieldValues) === $value,
-            Comparison::NEQ => fn (object|array $object): bool => self::getObjectFieldValue($object, $field, $this->accessRawFieldValues) !== $value,
-            Comparison::LT => fn (object|array $object): bool => self::getObjectFieldValue($object, $field, $this->accessRawFieldValues) < $value,
-            Comparison::LTE => fn (object|array $object): bool => self::getObjectFieldValue($object, $field, $this->accessRawFieldValues) <= $value,
-            Comparison::GT => fn (object|array $object): bool => self::getObjectFieldValue($object, $field, $this->accessRawFieldValues) > $value,
-            Comparison::GTE => fn (object|array $object): bool => self::getObjectFieldValue($object, $field, $this->accessRawFieldValues) >= $value,
-            Comparison::IN => function (object|array $object) use ($field, $value): bool {
-                $fieldValue = ClosureExpressionVisitor::getObjectFieldValue($object, $field, $this->accessRawFieldValues);
+            Comparison::EQ => static fn (object|array $object): bool => self::getObjectFieldValue($object, $field) === $value,
+            Comparison::NEQ => static fn (object|array $object): bool => self::getObjectFieldValue($object, $field) !== $value,
+            Comparison::LT => static fn (object|array $object): bool => self::getObjectFieldValue($object, $field) < $value,
+            Comparison::LTE => static fn (object|array $object): bool => self::getObjectFieldValue($object, $field) <= $value,
+            Comparison::GT => static fn (object|array $object): bool => self::getObjectFieldValue($object, $field) > $value,
+            Comparison::GTE => static fn (object|array $object): bool => self::getObjectFieldValue($object, $field) >= $value,
+            Comparison::IN => static function (object|array $object) use ($field, $value): bool {
+                $fieldValue = ClosureExpressionVisitor::getObjectFieldValue($object, $field);
 
                 return in_array($fieldValue, $value, is_scalar($fieldValue));
             },
-            Comparison::NIN => function (object|array $object) use ($field, $value): bool {
-                $fieldValue = ClosureExpressionVisitor::getObjectFieldValue($object, $field, $this->accessRawFieldValues);
+            Comparison::NIN => static function (object|array $object) use ($field, $value): bool {
+                $fieldValue = ClosureExpressionVisitor::getObjectFieldValue($object, $field);
 
                 return ! in_array($fieldValue, $value, is_scalar($fieldValue));
             },
-            Comparison::CONTAINS => fn (object|array $object): bool => str_contains((string) self::getObjectFieldValue($object, $field, $this->accessRawFieldValues), (string) $value),
-            Comparison::MEMBER_OF => function (object|array $object) use ($field, $value): bool {
-                $fieldValues = ClosureExpressionVisitor::getObjectFieldValue($object, $field, $this->accessRawFieldValues);
+            Comparison::CONTAINS => static fn (object|array $object): bool => str_contains((string) self::getObjectFieldValue($object, $field), (string) $value),
+            Comparison::MEMBER_OF => static function (object|array $object) use ($field, $value): bool {
+                $fieldValues = ClosureExpressionVisitor::getObjectFieldValue($object, $field);
 
                 if (! is_array($fieldValues)) {
                     $fieldValues = iterator_to_array($fieldValues);
@@ -198,8 +139,8 @@ class ClosureExpressionVisitor extends ExpressionVisitor
 
                 return in_array($value, $fieldValues, true);
             },
-            Comparison::STARTS_WITH => fn (object|array $object): bool => str_starts_with((string) self::getObjectFieldValue($object, $field, $this->accessRawFieldValues), (string) $value),
-            Comparison::ENDS_WITH => fn (object|array $object): bool => str_ends_with((string) self::getObjectFieldValue($object, $field, $this->accessRawFieldValues), (string) $value),
+            Comparison::STARTS_WITH => static fn (object|array $object): bool => str_starts_with((string) self::getObjectFieldValue($object, $field), (string) $value),
+            Comparison::ENDS_WITH => static fn (object|array $object): bool => str_ends_with((string) self::getObjectFieldValue($object, $field), (string) $value),
             default => throw new RuntimeException('Unknown comparison operator: ' . $comparison->getOperator()),
         };
     }

--- a/tests/ArrayCollectionTestCase.php
+++ b/tests/ArrayCollectionTestCase.php
@@ -11,7 +11,6 @@ use Doctrine\Common\Collections\Selectable;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
-use stdClass;
 
 use function array_keys;
 use function array_search;
@@ -301,7 +300,7 @@ abstract class ArrayCollectionTestCase extends TestCase
                 'object1' => $object1,
             ],
             $collection
-                ->matching(new Criteria(null, ['fooBar' => Order::Ascending], 0, accessRawFieldValues: true))
+                ->matching(new Criteria(null, ['fooBar' => Order::Ascending]))
                 ->toArray(),
         );
     }
@@ -309,11 +308,11 @@ abstract class ArrayCollectionTestCase extends TestCase
     #[IgnoreDeprecations]
     public function testLegacyMatchingWithSortingPreserveKeys(): void
     {
-        $object1 = new stdClass();
-        $object2 = new stdClass();
+        $object1 = new TestObject();
+        $object2 = new TestObject();
 
-        $object1->sortField = 2;
-        $object2->sortField = 1;
+        $object1->foo = 2;
+        $object2->foo = 1;
 
         $collection = $this->buildCollection([
             'object1' => $object1,
@@ -330,7 +329,7 @@ abstract class ArrayCollectionTestCase extends TestCase
                 'object1' => $object1,
             ],
             $collection
-                ->matching(new Criteria(null, ['sortField' => Order::Ascending]))
+                ->matching(new Criteria(null, ['foo' => Order::Ascending]))
                 ->toArray(),
         );
     }
@@ -355,7 +354,7 @@ abstract class ArrayCollectionTestCase extends TestCase
         self::assertSame(
             $slicedArray,
             $collection
-                ->matching(new Criteria(null, null, $firstResult, $maxResult, accessRawFieldValues: true))
+                ->matching(new Criteria(null, null, $firstResult, $maxResult))
                 ->toArray(),
         );
     }
@@ -445,7 +444,7 @@ abstract class ArrayCollectionTestCase extends TestCase
         self::assertSame(
             $expected,
             $collection
-                ->matching(new Criteria(null, ['foo' => Order::Descending, 'bar' => Order::Descending], 0, null, accessRawFieldValues: true))
+                ->matching(new Criteria(null, ['foo' => Order::Descending, 'bar' => Order::Descending], 0, null))
                 ->toArray(),
         );
     }

--- a/tests/ClosureExpressionVisitorTest.php
+++ b/tests/ClosureExpressionVisitorTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\Common\Collections;
 
-use ArrayAccess;
 use ArrayIterator;
 use Doctrine\Common\Collections\Expr\ClosureExpressionVisitor;
 use Doctrine\Common\Collections\Expr\Comparison;
@@ -13,7 +12,6 @@ use Doctrine\Common\Collections\ExpressionBuilder;
 use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\IgnoreDeprecations;
-use PHPUnit\Framework\Attributes\RequiresPhp;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 use stdClass;
@@ -42,34 +40,43 @@ class ClosureExpressionVisitorTest extends TestCase
         $this->assertFalse($closure(new TestObject(new TestObject(2))));
     }
 
+    #[IgnoreDeprecations]
+    public function testGetObjectFieldValueLegacy(): void
+    {
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/collections/pull/486');
+
+        $object = new TestObject();
+
+        $this->visitor->getObjectFieldValue($object, 'foo', true);
+    }
+
     public function testGetEmbeddedObjectFieldValueAccessingRawValue(): void
     {
         $object = new TestObject(new TestObjectPrivatePropertyOnly(42));
 
-        self::assertSame(42, $this->visitor->getObjectFieldValue($object, 'foo.fooBar', true));
+        self::assertSame(42, $this->visitor->getObjectFieldValue($object, 'foo.fooBar'));
     }
 
-    #[RequiresPhp('>= 8.4')]
     public function testGetObjectFieldValueAccessingRawValueBypassingPropertyHook(): void
     {
         $object         = new TestObjectPropertyHook();
         $object->fooBar = 42;
 
-        self::assertSame(42, $this->visitor->getObjectFieldValue($object, 'fooBar', true));
+        self::assertSame(42, $this->visitor->getObjectFieldValue($object, 'fooBar'));
     }
 
     public function testGetObjectFieldValueAccessingRawValue(): void
     {
         $object = new TestObjectPrivatePropertyOnly(42);
 
-        self::assertSame(42, $this->visitor->getObjectFieldValue($object, 'fooBar', true));
+        self::assertSame(42, $this->visitor->getObjectFieldValue($object, 'fooBar'));
     }
 
     public function testGetObjectFieldValueFindingParentClassAccessingRawValue(): void
     {
         $object = new TestObjectWithPrivatePropertyInParentClass(42);
 
-        self::assertSame(42, $this->visitor->getObjectFieldValue($object, 'fooBar', true));
+        self::assertSame(42, $this->visitor->getObjectFieldValue($object, 'fooBar'));
     }
 
     public function testGetObjectFieldValueNonexistentFieldAccessingRawValue(): void
@@ -78,121 +85,7 @@ class ClosureExpressionVisitorTest extends TestCase
 
         $this->expectException(RuntimeException::class);
 
-        $this->visitor->getObjectFieldValue($object, 'fooBar', true);
-    }
-
-    #[IgnoreDeprecations]
-    public function testGetObjectFieldValueIsAccessor(): void
-    {
-        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/collections/pull/472');
-
-        $object = new TestObject(1, 2, true);
-
-        self::assertTrue($this->visitor->getObjectFieldValue($object, 'baz'));
-    }
-
-    #[IgnoreDeprecations]
-    public function testGetObjectFieldValueIsAccessorWithIsPrefix(): void
-    {
-        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/collections/pull/472');
-
-        $object = new TestObject(1, 2, true);
-
-        self::assertTrue($this->visitor->getObjectFieldValue($object, 'isBaz'));
-    }
-
-    #[IgnoreDeprecations]
-    public function testGetObjectFieldValueIsAccessorCamelCase(): void
-    {
-        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/collections/pull/472');
-
-        $object = new TestObjectNotCamelCase(1);
-
-        self::assertEquals(1, $this->visitor->getObjectFieldValue($object, 'foo_bar'));
-        self::assertEquals(1, $this->visitor->getObjectFieldValue($object, 'foobar'));
-        self::assertEquals(1, $this->visitor->getObjectFieldValue($object, 'fooBar'));
-    }
-
-    #[IgnoreDeprecations]
-    public function testGetObjectFieldValueIsAccessorBoth(): void
-    {
-        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/collections/pull/472');
-
-        $object = new TestObjectBothCamelCaseAndUnderscore(1, 2);
-
-        self::assertEquals(2, $this->visitor->getObjectFieldValue($object, 'foo_bar'));
-        self::assertEquals(2, $this->visitor->getObjectFieldValue($object, 'foobar'));
-        self::assertEquals(2, $this->visitor->getObjectFieldValue($object, 'fooBar'));
-    }
-
-    #[IgnoreDeprecations]
-    public function testGetObjectFieldValueIsAccessorOnePublic(): void
-    {
-        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/collections/pull/472');
-
-        $object = new TestObjectPublicCamelCaseAndPrivateUnderscore(1, 2);
-
-        self::assertEquals(2, $this->visitor->getObjectFieldValue($object, 'foo_bar'));
-        self::assertEquals(2, $this->visitor->getObjectFieldValue($object, 'foobar'));
-        self::assertEquals(2, $this->visitor->getObjectFieldValue($object, 'fooBar'));
-    }
-
-    #[IgnoreDeprecations]
-    public function testGetObjectFieldValueIsAccessorBothPublic(): void
-    {
-        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/collections/pull/472');
-
-        $object = new TestObjectPublicCamelCaseAndPrivateUnderscore(1, 2);
-
-        self::assertEquals(2, $this->visitor->getObjectFieldValue($object, 'foo_bar'));
-        self::assertEquals(2, $this->visitor->getObjectFieldValue($object, 'foobar'));
-        self::assertEquals(2, $this->visitor->getObjectFieldValue($object, 'fooBar'));
-    }
-
-    #[IgnoreDeprecations]
-    public function testGetObjectFieldValueBlankAccessor(): void
-    {
-        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/collections/pull/472');
-
-        $object = new TestObjectBlankGetter(1);
-
-        self::assertEquals(1, $this->visitor->getObjectFieldValue($object, 'foobar'));
-        self::assertEquals(1, $this->visitor->getObjectFieldValue($object, 'fooBar'));
-    }
-
-    #[IgnoreDeprecations]
-    public function testGetObjectFieldValueMagicCallMethod(): void
-    {
-        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/collections/pull/472');
-
-        $object = new TestObject(1, 2, true, 3);
-
-        self::assertEquals(3, $this->visitor->getObjectFieldValue($object, 'qux'));
-    }
-
-    #[IgnoreDeprecations]
-    public function testGetObjectFieldValueArrayAccess(): void
-    {
-        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/collections/pull/472');
-
-        $object = self::createMock(ArrayAccess::class);
-        $object->expects(self::once())
-            ->method('offsetGet')
-            ->with('foo')
-            ->willReturn(33);
-
-        self::assertSame(33, $this->visitor->getObjectFieldValue($object, 'foo'));
-    }
-
-    #[IgnoreDeprecations]
-    public function testGetObjectFieldValuePublicPropertyIsNull(): void
-    {
-        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/collections/pull/472');
-
-        $object      = new stdClass();
-        $object->foo = null;
-
-        self::assertSame(null, $this->visitor->getObjectFieldValue($object, 'foo'));
+        $this->visitor->getObjectFieldValue($object, 'fooBar');
     }
 
     public function testWalkEqualsComparison(): void
@@ -437,28 +330,39 @@ class ClosureExpressionVisitorTest extends TestCase
         $closure(new TestObject());
     }
 
-    public function testSortByFieldAscending(): void
+    #[IgnoreDeprecations]
+    public function testSortByFieldLegacy(): void
     {
-        $objects = [new TestObject('b'), new TestObject('a'), new TestObject('c')];
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/collections/pull/486');
+
+        $objects = [new TestObject('b'), new TestObject('a')];
         $sort    = ClosureExpressionVisitor::sortByField('foo', 1, null, true);
 
         usort($objects, $sort);
+    }
 
-        self::assertEquals('a', $objects[0]->getFoo());
-        self::assertEquals('b', $objects[1]->getFoo());
-        self::assertEquals('c', $objects[2]->getFoo());
+    public function testSortByFieldAscending(): void
+    {
+        $objects = [new TestObject('b'), new TestObject('a'), new TestObject('c')];
+        $sort    = ClosureExpressionVisitor::sortByField('foo', 1);
+
+        usort($objects, $sort);
+
+        self::assertEquals('a', $objects[0]->foo);
+        self::assertEquals('b', $objects[1]->foo);
+        self::assertEquals('c', $objects[2]->foo);
     }
 
     public function testSortByFieldDescending(): void
     {
         $objects = [new TestObject('b'), new TestObject('a'), new TestObject('c')];
-        $sort    = ClosureExpressionVisitor::sortByField('foo', -1, null, true);
+        $sort    = ClosureExpressionVisitor::sortByField('foo', -1);
 
         usort($objects, $sort);
 
-        self::assertEquals('c', $objects[0]->getFoo());
-        self::assertEquals('b', $objects[1]->getFoo());
-        self::assertEquals('a', $objects[2]->getFoo());
+        self::assertEquals('c', $objects[0]->foo);
+        self::assertEquals('b', $objects[1]->foo);
+        self::assertEquals('a', $objects[2]->foo);
     }
 
     public function testSortByFieldKeepOrderWhenSameValue(): void
@@ -467,7 +371,7 @@ class ClosureExpressionVisitorTest extends TestCase
         $secondElement = new TestObject('a');
 
         $objects = [$firstElement, $secondElement];
-        $sort    = ClosureExpressionVisitor::sortByField('foo', 0, null, true);
+        $sort    = ClosureExpressionVisitor::sortByField('foo', 0);
 
         usort($objects, $sort);
 
@@ -477,14 +381,14 @@ class ClosureExpressionVisitorTest extends TestCase
     public function testSortDelegate(): void
     {
         $objects = [new TestObject('a', 'c'), new TestObject('a', 'b'), new TestObject('a', 'a')];
-        $sort    = ClosureExpressionVisitor::sortByField('bar', 1, null, true);
-        $sort    = ClosureExpressionVisitor::sortByField('foo', 1, $sort, true);
+        $sort    = ClosureExpressionVisitor::sortByField('bar', 1);
+        $sort    = ClosureExpressionVisitor::sortByField('foo', 1, $sort);
 
         usort($objects, $sort);
 
-        self::assertEquals('a', $objects[0]->getBar());
-        self::assertEquals('b', $objects[1]->getBar());
-        self::assertEquals('c', $objects[2]->getBar());
+        self::assertEquals('a', $objects[0]->bar);
+        self::assertEquals('b', $objects[1]->bar);
+        self::assertEquals('c', $objects[2]->bar);
     }
 
     public function testArrayComparison(): void
@@ -492,100 +396,6 @@ class ClosureExpressionVisitorTest extends TestCase
         $closure = $this->visitor->walkComparison($this->builder->eq('foo', 42));
 
         self::assertTrue($closure(['foo' => 42]));
-    }
-}
-
-class TestObject
-{
-    public function __construct(
-        private readonly mixed $foo = null,
-        private readonly mixed $bar = null,
-        private readonly mixed $baz = null,
-        private readonly mixed $qux = null,
-    ) {
-    }
-
-    /** @param array<int, mixed> $arguments */
-    public function __call(string $name, array $arguments): mixed
-    {
-        if ($name === 'getqux') {
-            return $this->qux;
-        }
-    }
-
-    public function getFoo(): mixed
-    {
-        return $this->foo;
-    }
-
-    public function getBar(): mixed
-    {
-        return $this->bar;
-    }
-
-    public function isBaz(): mixed
-    {
-        return $this->baz;
-    }
-}
-
-class TestObjectNotCamelCase
-{
-    public function __construct(private readonly int|null $foo_bar)
-    {
-    }
-
-    public function getFooBar(): int|null
-    {
-        return $this->foo_bar;
-    }
-}
-
-class TestObjectBothCamelCaseAndUnderscore
-{
-    public function __construct(private readonly int|null $foo_bar = null, private readonly int|null $fooBar = null)
-    {
-    }
-
-    public function getFooBar(): int|null
-    {
-        return $this->fooBar;
-    }
-}
-
-class TestObjectPublicCamelCaseAndPrivateUnderscore
-{
-    public function __construct(private readonly int|null $foo_bar = null, public int|null $fooBar = null)
-    {
-    }
-
-    public function getFooBar(): int|null
-    {
-        return $this->fooBar;
-    }
-}
-
-class TestObjectBothPublic
-{
-    public function __construct(public mixed $foo_bar = null, public mixed $fooBar = null)
-    {
-    }
-
-    public function getFooBar(): mixed
-    {
-        return $this->foo_bar;
-    }
-}
-
-class TestObjectBlankGetter
-{
-    public function __construct(public int|null $fooBar = null)
-    {
-    }
-
-    public function fooBar(): int|null
-    {
-        return $this->fooBar;
     }
 }
 

--- a/tests/CollectionTest.php
+++ b/tests/CollectionTest.php
@@ -11,8 +11,6 @@ use Doctrine\Common\Collections\Expr\Value;
 use Doctrine\Common\Collections\Order;
 use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\IgnoreDeprecations;
-use stdClass;
 
 use function count;
 use function is_string;
@@ -32,32 +30,12 @@ class CollectionTest extends CollectionTestCase
         self::assertTrue(is_string((string) $this->collection));
     }
 
-    #[Group('DDC-1637')]
-    #[IgnoreDeprecations]
-    public function testMatchingLegacy(): void
-    {
-        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/collections/pull/472');
-
-        $std1               = new stdClass();
-        $std1->foo          = 'bar';
-        $this->collection[] = $std1;
-
-        $std2               = new stdClass();
-        $std2->foo          = 'baz';
-        $this->collection[] = $std2;
-
-        $col = $this->collection->matching(new Criteria(Criteria::expr()->eq('foo', 'bar')));
-        self::assertInstanceOf(Collection::class, $col);
-        self::assertNotSame($col, $this->collection);
-        self::assertEquals(1, count($col));
-    }
-
     public function testMatching(): void
     {
         $this->collection[] = new TestObjectPrivatePropertyOnly(42);
         $this->collection[] = new TestObjectPrivatePropertyOnly(84);
 
-        $col = $this->collection->matching(new Criteria(Criteria::expr()->eq('fooBar', 42), firstResult: 0, accessRawFieldValues: true));
+        $col = $this->collection->matching(new Criteria(Criteria::expr()->eq('fooBar', 42)));
         self::assertInstanceOf(Collection::class, $col);
         self::assertNotSame($col, $this->collection);
         self::assertEquals(1, count($col));
@@ -69,11 +47,7 @@ class CollectionTest extends CollectionTestCase
         $this->collection[0]->foo = 1;
 
         $col = $this->collection->matching(
-            new Criteria(
-                new Value(static fn (stdClass $test): bool => $test->foo === 1),
-                firstResult: 0,
-                accessRawFieldValues: true,
-            ),
+            new Criteria(new Value(static fn (TestObject $test): bool => $test->foo === 1)),
         );
 
         self::assertInstanceOf(Collection::class, $col);
@@ -88,7 +62,7 @@ class CollectionTest extends CollectionTestCase
         $this->collection['two']   = $obj2 = new TestObjectPrivatePropertyOnly(10);
         $this->collection['three'] = $obj3 = new TestObjectPrivatePropertyOnly(78);
 
-        $criteria = Criteria::create(true)->orderBy(['fooBar' => Order::Ascending]);
+        $criteria = Criteria::create()->orderBy(['fooBar' => Order::Ascending]);
 
         $col = $this->collection->matching($criteria);
 
@@ -98,11 +72,8 @@ class CollectionTest extends CollectionTestCase
     }
 
     #[Group('DDC-1637')]
-    #[IgnoreDeprecations]
     public function testMatchingOrderingLegacy(): void
     {
-        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/collections/pull/472');
-
         $this->fillMatchingFixture();
 
         $col = $this->collection->matching(new Criteria(null, ['foo' => Order::Descending]));
@@ -119,7 +90,7 @@ class CollectionTest extends CollectionTestCase
     {
         $this->fillMatchingFixture();
 
-        $col = $this->collection->matching(new Criteria(null, null, 1, 1, accessRawFieldValues: true));
+        $col = $this->collection->matching(new Criteria(null, null, 1, 1));
 
         self::assertInstanceOf(Collection::class, $col);
         self::assertNotSame($col, $this->collection);

--- a/tests/CollectionTestCase.php
+++ b/tests/CollectionTestCase.php
@@ -8,7 +8,6 @@ use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\Common\Collections\Selectable;
 use PHPUnit\Framework\TestCase;
-use stdClass;
 
 use function count;
 use function is_array;
@@ -232,13 +231,13 @@ abstract class CollectionTestCase extends TestCase
 
     protected function fillMatchingFixture(): void
     {
-        $std1               = new stdClass();
-        $std1->foo          = 'bar';
-        $this->collection[] = $std1;
+        $obj1               = new TestObject();
+        $obj1->foo          = 'bar';
+        $this->collection[] = $obj1;
 
-        $std2               = new stdClass();
-        $std2->foo          = 'baz';
-        $this->collection[] = $std2;
+        $obj2               = new TestObject();
+        $obj2->foo          = 'baz';
+        $this->collection[] = $obj2;
     }
 
     public function testCanRemoveNullValuesByKey(): void
@@ -260,7 +259,7 @@ abstract class CollectionTestCase extends TestCase
             self::markTestSkipped(sprintf('Collection does not implement %s', Selectable::class));
         }
 
-        $criteria = Criteria::create(true);
+        $criteria = Criteria::create();
 
         self::assertInstanceOf(Collection::class, $this->collection->matching($criteria));
         self::assertInstanceOf(Selectable::class, $this->collection->matching($criteria));

--- a/tests/CriteriaTest.php
+++ b/tests/CriteriaTest.php
@@ -20,16 +20,24 @@ class CriteriaTest extends TestCase
     #[IgnoreDeprecations]
     public function testCreateLegacy(): void
     {
-        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/collections/pull/472');
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/collections/pull/486');
 
-        $criteria = Criteria::create();
+        $criteria = Criteria::create(true);
 
         self::assertInstanceOf(Criteria::class, $criteria);
     }
 
+    #[IgnoreDeprecations]
+    public function testConstructorLegacy(): void
+    {
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/collections/pull/486');
+
+        new Criteria(new Comparison('test', '=', 'test'), null, 0, null, true);
+    }
+
     public function testCreate(): void
     {
-        $criteria = Criteria::create(true);
+        $criteria = Criteria::create();
 
         self::assertInstanceOf(Criteria::class, $criteria);
     }
@@ -37,7 +45,7 @@ class CriteriaTest extends TestCase
     public function testConstructor(): void
     {
         $expr     = new Comparison('field', '=', 'value');
-        $criteria = new Criteria($expr, ['foo' => Order::Ascending], 10, 20, accessRawFieldValues: true);
+        $criteria = new Criteria($expr, ['foo' => Order::Ascending], 10, 20);
 
         self::assertSame($expr, $criteria->getWhereExpression());
         self::assertSame(['foo' => Order::Ascending], $criteria->orderings());
@@ -48,7 +56,7 @@ class CriteriaTest extends TestCase
     public function testWhere(): void
     {
         $expr     = new Comparison('field', '=', 'value');
-        $criteria = Criteria::create(true);
+        $criteria = Criteria::create();
 
         $criteria->where($expr);
 
@@ -58,7 +66,7 @@ class CriteriaTest extends TestCase
     public function testAndWhere(): void
     {
         $expr     = new Comparison('field', '=', 'value');
-        $criteria = Criteria::create(true);
+        $criteria = Criteria::create();
 
         $criteria->where($expr);
         $expr = $criteria->getWhereExpression();
@@ -74,7 +82,7 @@ class CriteriaTest extends TestCase
     public function testAndWhereWithoutWhere(): void
     {
         $expr     = new Comparison('field', '=', 'value');
-        $criteria = Criteria::create(true);
+        $criteria = Criteria::create();
 
         $criteria->andWhere($expr);
 
@@ -84,7 +92,7 @@ class CriteriaTest extends TestCase
     public function testOrWhere(): void
     {
         $expr     = new Comparison('field', '=', 'value');
-        $criteria = Criteria::create(true);
+        $criteria = Criteria::create();
 
         $criteria->where($expr);
         $expr = $criteria->getWhereExpression();
@@ -100,7 +108,7 @@ class CriteriaTest extends TestCase
     public function testOrWhereWithoutWhere(): void
     {
         $expr     = new Comparison('field', '=', 'value');
-        $criteria = Criteria::create(true);
+        $criteria = Criteria::create();
 
         $criteria->orWhere($expr);
 
@@ -109,7 +117,7 @@ class CriteriaTest extends TestCase
 
     public function testOrderings(): void
     {
-        $criteria = Criteria::create(true)
+        $criteria = Criteria::create()
             ->orderBy(['foo' => Order::Ascending]);
 
         self::assertEquals(['foo' => Order::Ascending], $criteria->orderings());

--- a/tests/DerivedCollectionTest.php
+++ b/tests/DerivedCollectionTest.php
@@ -22,6 +22,6 @@ class DerivedCollectionTest extends TestCase
         self::assertInstanceOf(DerivedArrayCollection::class, $collection->map($closure));
         self::assertInstanceOf(DerivedArrayCollection::class, $collection->filter($closure));
         self::assertContainsOnlyInstancesOf(DerivedArrayCollection::class, $collection->partition($closure));
-        self::assertInstanceOf(DerivedArrayCollection::class, $collection->matching(Criteria::create(true)));
+        self::assertInstanceOf(DerivedArrayCollection::class, $collection->matching(Criteria::create()));
     }
 }

--- a/tests/TestObject.php
+++ b/tests/TestObject.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Common\Collections;
+
+class TestObject
+{
+    public function __construct(
+        public mixed $foo = null,
+        public mixed $bar = null,
+        public mixed $baz = null,
+        public mixed $qux = null,
+    ) {
+    }
+}


### PR DESCRIPTION
This removes the `accessRawFieldValues` parameter that was added in #472 in the 3.0.0 branch. 

Since this major version, fields values are always as raw values by means of reflection, so the parameter was a no-op.