### PR TITLE
Update branch metadata

### DIFF
--- a/.doctrine-project.json
+++ b/.doctrine-project.json
@@ -14,13 +14,12 @@
             "name": "2.5",
             "branchName": "2.5.x",
             "slug": "2.5",
-            "upcoming": true
+            "current": true
         },
         {
             "name": "2.4",
-            "branchName": "2.4.x",
             "slug": "2.4",
-            "current": true
+            "maintained": false
         },
         {
             "name": "2.3",

--- a/.doctrine-project.json
+++ b/.doctrine-project.json
@@ -37,18 +37,8 @@
             "maintained": false
         },
         {
-            "name": "2.0",
-            "slug": "2.0",
-            "maintained": false
-        },
-        {
             "name": "1.8",
             "slug": "1.8",
-            "maintained": false
-        },
-        {
-            "name": "1.7",
-            "slug": "1.7",
             "maintained": false
         },
         {


### PR DESCRIPTION
2.5.0 has been released, and should be the last 2.x branch. As a result:

- 2.6.x is not created;
- 2.5.x becomes the current branch;
- 2.4.x is no longer maintained.