### PR TITLE
Avoid triggering deprecation on named argument

### DIFF
--- a/src/Criteria.php
+++ b/src/Criteria.php
@@ -63,12 +63,13 @@ class Criteria
     /**
      * Construct a new Criteria.
      *
+     * @param int|null                         $firstResult
      * @param array<string, string|Order>|null $orderings
      */
     public function __construct(
         private Expression|null $expression = null,
         array|null $orderings = null,
-        int|null $firstResult = null,
+        int|Placeholder|null $firstResult = Placeholder::NotSpecified,
         int|null $maxResults = null,
         private bool $accessRawFieldValues = false,
     ) {
@@ -81,13 +82,17 @@ class Criteria
             );
         }
 
-        if ($firstResult === null && func_num_args() > 2) {
+        if ($firstResult === null) {
             Deprecation::trigger(
                 'doctrine/collections',
                 'https://github.com/doctrine/collections/pull/311',
                 'Passing null as $firstResult to the constructor of %s is deprecated. Pass 0 instead or omit the argument.',
                 self::class,
             );
+        }
+
+        if ($firstResult === Placeholder::NotSpecified) {
+            $firstResult = null;
         }
 
         $this->setFirstResult($firstResult);

--- a/src/Placeholder.php
+++ b/src/Placeholder.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Common\Collections;
+
+/** @internal */
+enum Placeholder
+{
+    case NotSpecified;
+}

--- a/tests/CriteriaTest.php
+++ b/tests/CriteriaTest.php
@@ -73,6 +73,12 @@ class CriteriaTest extends TestCase
         self::assertNull($criteria->getMaxResults());
     }
 
+    public function testNamedArgs(): void
+    {
+        $this->expectNoDeprecationWithIdentifier('https://github.com/doctrine/collections/pull/311');
+        new Criteria(orderings: ['startDate' => Order::Descending], accessRawFieldValues: true);
+    }
+
     public function testWhere(): void
     {
         $expr     = new Comparison('field', '=', 'value');


### PR DESCRIPTION
Our detection of whether $firstResult based on func_num_args() was unreliable with named arguments. The following prints `int(2)`:

```php
<?php
(function($a=42, $b=42) {
    var_dump(func_num_args());
})(b: 42);
```

Instead, let's change the default value for `$firstResult` to something very unlikely, and assume nobody will be passing that.

Fixes #489 