### PR TITLE
Update branch metadata

### DIFF
--- a/.doctrine-project.json
+++ b/.doctrine-project.json
@@ -11,10 +11,16 @@
             "upcoming": true
         },
         {
+            "name": "2.6",
+            "branchName": "2.6.x",
+            "slug": "2.6",
+            "current": true
+        },
+        {
             "name": "2.5",
             "branchName": "2.5.x",
             "slug": "2.5",
-            "current": true
+            "maintained": false
         },
         {
             "name": "2.4",

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Doctrine Collections
 
 [![Build Status](https://github.com/doctrine/collections/workflows/Continuous%20Integration/badge.svg)](https://github.com/doctrine/collections/actions)
-[![Code Coverage](https://codecov.io/gh/doctrine/collections/branch/2.0.x/graph/badge.svg)](https://codecov.io/gh/doctrine/collections/branch/2.0.x)
+[![Code Coverage](https://codecov.io/gh/doctrine/collections/branch/2.6.x/graph/badge.svg)](https://codecov.io/gh/doctrine/collections/branch/2.6.x)
 
 Collections Abstraction library


### PR DESCRIPTION
2.6.0 has been released. As a consequence:

- 2.6.x is the new current branch;
- 2.5.x is no longer maintained.

I did not create 2.7.x because 2.6.x is supposed to be the last 2.x branch (which 2.5.x was already supposed to be, I know :sweat: )