### PR TITLE
Update branch metadata

### DIFF
--- a/.doctrine-project.json
+++ b/.doctrine-project.json
@@ -30,7 +30,6 @@
         },
         {
             "name": "2.5",
-            "branchName": "2.5.x",
             "slug": "2.5",
             "maintained": false
         },

--- a/.doctrine-project.json
+++ b/.doctrine-project.json
@@ -5,16 +5,28 @@
     "docsSlug": "doctrine-collections",
     "versions": [
         {
-            "name": "3.0",
-            "branchName": "3.0.x",
+            "name": "4.0",
+            "branchName": "4.0.x",
             "slug": "latest",
             "upcoming": true
+        },
+        {
+            "name": "3.1",
+            "branchName": "3.1.x",
+            "slug": "3.1",
+            "upcoming": true
+        },
+        {
+            "name": "3.0",
+            "branchName": "3.0.x",
+            "slug": "3.0",
+            "current": true
         },
         {
             "name": "2.6",
             "branchName": "2.6.x",
             "slug": "2.6",
-            "current": true
+            "maintained": true
         },
         {
             "name": "2.5",

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Doctrine Collections
 
 [![Build Status](https://github.com/doctrine/collections/workflows/Continuous%20Integration/badge.svg)](https://github.com/doctrine/collections/actions)
-[![Code Coverage](https://codecov.io/gh/doctrine/collections/branch/2.6.x/graph/badge.svg)](https://codecov.io/gh/doctrine/collections/branch/2.6.x)
+[![Code Coverage](https://codecov.io/gh/doctrine/collections/branch/3.0.x/graph/badge.svg)](https://codecov.io/gh/doctrine/collections/branch/3.0.x)
 
 Collections Abstraction library


### PR DESCRIPTION
3.0.0 has been released.

As a consequence:

- 3.0.x is the current branch.
- 3.1.x is the next minor branch.
- 4.0.x is the next major branch.