### PR TITLE
Use correct workflow name for static analysis

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -5,9 +5,21 @@ on:
   pull_request:
     branches:
       - "*.x"
+    paths:
+      - ".github/workflows/static-analysis.yml"
+      - "composer.*"
+      - "src/**"
+      - "phpstan*"
+      - "tests/**"
   push:
     branches:
       - "*.x"
+    paths:
+      - ".github/workflows/static-analysis.yml"
+      - "composer.*"
+      - "src/**"
+      - "phpstan*"
+      - "tests/**"
 
 jobs:
   static-analysis:

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -12,4 +12,4 @@ on:
 jobs:
   static-analysis:
     name: "Static Analysis"
-    uses: "doctrine/.github/.github/workflows/static-analysis.yml@13.1.0"
+    uses: "doctrine/.github/.github/workflows/phpstan.yml@13.1.0"


### PR DESCRIPTION
The static-analysis.yml workflow is referring to the wrong file name in the .github repo.

see https://github.com/doctrine/rst-parser/pull/284#issuecomment-4061729865