### PR TITLE
Group Doctrine workflow updates together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,7 @@ updates:
       interval: "weekly"
     labels:
       - "CI"
+    groups:
+      doctrine:
+        patterns:
+          - "doctrine/*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,7 @@ updates:
       interval: "weekly"
     labels:
       - "CI"
+    target-branch: "2.6.x"
     groups:
       doctrine:
         patterns:


### PR DESCRIPTION
We do very small releases, often touching only one workflow, which means it is unlikely to have several issues when attempting to bump several references to this repository.