### PR TITLE
Deprecate Order enum

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,10 +1,25 @@
 Note about upgrading: Doctrine uses static and runtime mechanisms to raise
 awareness about deprecated code.
 
-- Use of `@deprecated` docblock that is detected by IDEs (like PHPStorm) or
+- Use of `#[Deprecated]` attribute that is detected by IDEs (like PHPStorm) or
   Static Analysis tools (like Psalm, phpstan)
 - Use of our low-overhead runtime deprecation API, details:
   https://github.com/doctrine/deprecations/
+
+# Upgrade to 3.1
+
+## Deprecated `Order` enum
+
+PHP 8.6 provides a native `\SortDirection` enum that should be used instead of
+the `Doctrine\Common\Collections\Order` enum. The `Order` enum is deprecated
+and will be removed in 4.0.
+
+`\SortDirection` is polyfilled by the `symfony/polyfill-php86` package, that we
+require.
+
+As a consequence, `Criteria::orderings()`, which returns an array of `Order`
+instances, is deprecated in favor of `Criteria::getOrderings()`, which returns
+an array of `\SortDirection` instances.
 
 # Upgrade to 3.0
 

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,8 @@
     "homepage": "https://www.doctrine-project.org/projects/collections.html",
     "require": {
         "php": "^8.4",
-        "doctrine/deprecations": "^1"
+        "doctrine/deprecations": "^1",
+        "symfony/polyfill-php86": "^1.36"
     },
     "require-dev": {
         "ext-json": "*",

--- a/src/ArrayCollection.php
+++ b/src/ArrayCollection.php
@@ -8,6 +8,7 @@ use ArrayIterator;
 use Closure;
 use Doctrine\Common\Collections\Expr\ClosureExpressionVisitor;
 use Override;
+use SortDirection;
 use Stringable;
 use Traversable;
 
@@ -394,12 +395,12 @@ class ArrayCollection implements Collection, Selectable, Stringable
             $filtered = array_filter($filtered, $filter);
         }
 
-        $orderings = $criteria->orderings();
+        $orderings = $criteria->getOrderings();
 
         if ($orderings) {
             $next = null;
             foreach (array_reverse($orderings) as $field => $ordering) {
-                $next = ClosureExpressionVisitor::sortByField($field, $ordering === Order::Descending ? -1 : 1, $next);
+                $next = ClosureExpressionVisitor::sortByField($field, $ordering === SortDirection::Descending ? -1 : 1, $next);
             }
 
             uasort($filtered, $next);

--- a/src/Criteria.php
+++ b/src/Criteria.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace Doctrine\Common\Collections;
 
+use Deprecated;
 use Doctrine\Common\Collections\Expr\CompositeExpression;
 use Doctrine\Common\Collections\Expr\Expression;
 use Doctrine\Deprecations\Deprecation;
+use SortDirection;
 
 use function func_num_args;
 
@@ -19,7 +21,7 @@ final class Criteria
 {
     private static ExpressionBuilder|null $expressionBuilder = null;
 
-    /** @var array<string, Order> */
+    /** @var array<string, Order|SortDirection> */
     private array $orderings = [];
 
     private int|null $firstResult = null;
@@ -57,7 +59,7 @@ final class Criteria
     /**
      * Construct a new Criteria.
      *
-     * @param array<string, Order>|null $orderings
+     * @param array<string, Order|SortDirection>|null $orderings
      */
     public function __construct(
         private Expression|null $expression = null,
@@ -147,22 +149,47 @@ final class Criteria
     /**
      * Gets the current orderings of this Criteria.
      *
+     * @return array<string, SortDirection>
+     */
+    public function getOrderings(): array
+    {
+        return array_map(
+            static fn (Order|SortDirection $order): SortDirection => $order instanceof Order
+                ? $order == Order::Ascending
+                    ? SortDirection::Ascending
+                    : SortDirection::Descending
+                : $order,
+            $this->orderings,
+        );
+    }
+
+    /**
+     * Gets the current orderings of this Criteria.
+     *
      * @return array<string, Order>
      */
+    #[Deprecated(message: 'Use getOrderings() instead.', since: 'doctrine/collections 3.1')]
     public function orderings(): array
     {
-        return $this->orderings;
+        return array_map(
+            static fn (Order|SortDirection $order): Order => $order instanceof SortDirection
+                ? $order == SortDirection::Ascending
+                    ? Order::Ascending
+                    : Order::Descending
+                : $order,
+            $this->orderings,
+        );
     }
 
     /**
      * Sets the ordering of the result of this Criteria.
      *
-     * Keys are field and values are the order, being a valid Order enum case.
+     * Keys are field and values are the order, being a valid SortDirection enum case.
      *
-     * @see Order::Ascending
-     * @see Order::Descending
+     * @see SortDirection::Ascending
+     * @see SortDirection::Descending
      *
-     * @param array<string, Order> $orderings
+     * @param array<string, Order|SortDirection> $orderings
      *
      * @return $this
      */

--- a/src/Order.php
+++ b/src/Order.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Common\Collections;
 
+/** @deprecated use \SortDirection instead */
 enum Order: string
 {
     case Ascending  = 'ASC';

--- a/tests/CollectionTest.php
+++ b/tests/CollectionTest.php
@@ -11,6 +11,7 @@ use Doctrine\Common\Collections\Expr\Value;
 use Doctrine\Common\Collections\Order;
 use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use PHPUnit\Framework\Attributes\Group;
+use SortDirection;
 
 use function count;
 use function is_string;
@@ -62,7 +63,7 @@ class CollectionTest extends CollectionTestCase
         $this->collection['two']   = $obj2 = new TestObjectPrivatePropertyOnly(10);
         $this->collection['three'] = $obj3 = new TestObjectPrivatePropertyOnly(78);
 
-        $criteria = Criteria::create()->orderBy(['fooBar' => Order::Ascending]);
+        $criteria = Criteria::create()->orderBy(['fooBar' => SortDirection::Ascending]);
 
         $col = $this->collection->matching($criteria);
 
@@ -76,7 +77,7 @@ class CollectionTest extends CollectionTestCase
     {
         $this->fillMatchingFixture();
 
-        $col = $this->collection->matching(new Criteria(null, ['foo' => Order::Descending]));
+        $col = $this->collection->matching(new Criteria(null, ['foo' => SortDirection::Descending]));
 
         self::assertInstanceOf(Collection::class, $col);
         self::assertNotSame($col, $this->collection);
@@ -96,5 +97,32 @@ class CollectionTest extends CollectionTestCase
         self::assertNotSame($col, $this->collection);
         self::assertEquals(1, count($col));
         self::assertEquals('baz', $col[1]->foo);
+    }
+
+    public function testMatchingOrderingMixedOrderTypes(): void
+    {
+        $this->collection[] = $obj1 = new TestObject();
+        $obj1->foo = 'c';
+        $obj1->bar = 1;
+
+        $this->collection[] = $obj2 = new TestObject();
+        $obj2->foo = 'a';
+        $obj2->bar = 2;
+
+        $this->collection[] = $obj3 = new TestObject();
+        $obj3->foo = 'b';
+        $obj3->bar = 3;
+
+        $criteria = Criteria::create()->orderBy([
+            'foo' => Order::Ascending,
+            'bar' => SortDirection::Descending,
+        ]);
+
+        $col = $this->collection->matching($criteria);
+
+        self::assertInstanceOf(Collection::class, $col);
+        self::assertCount(3, $col);
+        self::assertSame($obj2, $col->first());
+        self::assertSame($obj1, $col->last());
     }
 }

--- a/tests/CriteriaTest.php
+++ b/tests/CriteriaTest.php
@@ -12,6 +12,7 @@ use Doctrine\Common\Collections\Order;
 use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
+use SortDirection;
 
 class CriteriaTest extends TestCase
 {
@@ -42,6 +43,7 @@ class CriteriaTest extends TestCase
         self::assertInstanceOf(Criteria::class, $criteria);
     }
 
+    #[IgnoreDeprecations]
     public function testConstructor(): void
     {
         $expr     = new Comparison('field', '=', 'value');
@@ -115,10 +117,11 @@ class CriteriaTest extends TestCase
         self::assertSame($expr, $criteria->getWhereExpression());
     }
 
+    #[IgnoreDeprecations]
     public function testOrderings(): void
     {
         $criteria = Criteria::create()
-            ->orderBy(['foo' => Order::Ascending]);
+            ->orderBy(['foo' => SortDirection::Ascending]);
 
         self::assertEquals(['foo' => Order::Ascending], $criteria->orderings());
     }
@@ -126,5 +129,57 @@ class CriteriaTest extends TestCase
     public function testExpr(): void
     {
         self::assertInstanceOf(ExpressionBuilder::class, Criteria::expr());
+    }
+
+    public function testGetOrderings(): void
+    {
+        $criteria = Criteria::create()
+            ->orderBy(['foo' => SortDirection::Ascending, 'bar' => Order::Descending]);
+
+        self::assertEquals([
+            'foo' => SortDirection::Ascending,
+            'bar' => SortDirection::Descending,
+        ], $criteria->getOrderings());
+    }
+
+    #[IgnoreDeprecations]
+    public function testOrderingsWithMixedOrderTypes(): void
+    {
+        $criteria = Criteria::create()
+            ->orderBy([
+                'foo' => SortDirection::Ascending,
+                'bar' => Order::Descending,
+                'baz' => SortDirection::Descending,
+            ]);
+
+        $orderings = $criteria->orderings();
+
+        self::assertCount(3, $orderings);
+        self::assertEquals(Order::Ascending, $orderings['foo']);
+        self::assertEquals(Order::Descending, $orderings['bar']);
+        self::assertEquals(Order::Descending, $orderings['baz']);
+    }
+
+    #[IgnoreDeprecations]
+    public function testConstructorWithMixedOrderTypes(): void
+    {
+        $expr     = new Comparison('field', '=', 'value');
+        $criteria = new Criteria($expr, [
+            'foo' => Order::Ascending,
+            'bar' => SortDirection::Descending,
+        ], 5, 15);
+
+        self::assertSame($expr, $criteria->getWhereExpression());
+
+        $getOrderings = $criteria->getOrderings();
+        self::assertEquals(SortDirection::Ascending, $getOrderings['foo']);
+        self::assertEquals(SortDirection::Descending, $getOrderings['bar']);
+
+        $orderings = $criteria->orderings();
+        self::assertEquals(Order::Ascending, $orderings['foo']);
+        self::assertEquals(Order::Descending, $orderings['bar']);
+
+        self::assertSame(5, $criteria->getFirstResult());
+        self::assertSame(15, $criteria->getMaxResults());
     }
 }


### PR DESCRIPTION
PHP 8.6 provides a native `\SortDirection` enum for this exact purpose. See https://wiki.php.net/rfc/sort_direction_enum