### PR TITLE
Update branch metadata

### DIFF
--- a/.doctrine-project.json
+++ b/.doctrine-project.json
@@ -11,16 +11,21 @@
             "upcoming": true
         },
         {
-            "name": "3.1",
-            "branchName": "3.1.x",
-            "slug": "3.1",
+            "name": "3.2",
+            "branchName": "3.2.x",
+            "slug": "3.2",
             "upcoming": true
         },
         {
-            "name": "3.0",
-            "branchName": "3.0.x",
-            "slug": "3.0",
+            "name": "3.1",
+            "branchName": "3.1.x",
+            "slug": "3.1",
             "current": true
+        },
+        {
+            "name": "3.0",
+            "slug": "3.0",
+            "maintained": false
         },
         {
             "name": "2.6",

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Doctrine Collections
 
 [![Build Status](https://github.com/doctrine/collections/workflows/Continuous%20Integration/badge.svg)](https://github.com/doctrine/collections/actions)
-[![Code Coverage](https://codecov.io/gh/doctrine/collections/branch/3.0.x/graph/badge.svg)](https://codecov.io/gh/doctrine/collections/branch/3.0.x)
+[![Code Coverage](https://codecov.io/gh/doctrine/collections/branch/3.1.x/graph/badge.svg)](https://codecov.io/gh/doctrine/collections/branch/3.1.x)
 
 Collections Abstraction library


### PR DESCRIPTION
3.1.0 has been released.

As a consequence:

- 3.2.x is the next minor branch.
- 3.1.x is the current branch.
- 3.0.x is no longer maintained.