### PR TITLE
Specify complete version requirement

### DIFF
--- a/tests/ClosureExpressionVisitorTest.php
+++ b/tests/ClosureExpressionVisitorTest.php
@@ -49,7 +49,7 @@ class ClosureExpressionVisitorTest extends TestCase
         self::assertSame(42, $this->visitor->getObjectFieldValue($object, 'foo.fooBar', true));
     }
 
-    #[RequiresPhp('>= 8.4')]
+    #[RequiresPhp('>= 8.4.0')]
     public function testGetObjectFieldValueAccessingRawValueBypassingPropertyHook(): void
     {
         $object         = new TestObjectPropertyHook();


### PR DESCRIPTION
It is mandatory:

> 1) Incomplete version requirement "8.4" used by
Doctrine\Tests\Common\Collections\ClosureExpressionVisitorTest::testGetObjectFieldValueAccessingRawValueBypassingPropertyHook()