### PR TITLE
Benchmark reified generics

### DIFF
--- a/bench/.gitignore
+++ b/bench/.gitignore
@@ -1,0 +1,1 @@
+/perfcount

--- a/bench/collbench_baseline.php
+++ b/bench/collbench_baseline.php
@@ -1,0 +1,52 @@
+<?php
+// Baseline-branch workload: plain ArrayCollection (docblock generics, no
+// reification). Identical operations to collbench_reified.php; only the
+// `new ArrayCollection` construction line differs (bare, no type args).
+//
+//   php bench/collbench_baseline.php [ITERS] [SIZE]
+declare(strict_types=1);
+require getenv('BENCH_AUTOLOAD') ?: __DIR__ . '/../vendor/autoload.php';
+
+use Doctrine\Common\Collections\ArrayCollection;
+
+final class Item
+{
+    public function __construct(public int $v)
+    {
+    }
+}
+
+$ITERS = (int) ($argv[1] ?? 2000);
+$SIZE  = (int) ($argv[2] ?? 500);
+
+/** @var array<int, Item> $data */
+$data = [];
+for ($i = 0; $i < $SIZE; $i++) {
+    $data[$i] = new Item(($i * 7) % 101);
+}
+
+$checksum = 0;
+for ($it = 0; $it < $ITERS; $it++) {
+    $c = new ArrayCollection($data);                 // <-- only line that differs from reified
+    $c->add(new Item($it % 13));
+    $c->set(0, new Item(1));
+    $g  = $c->get(5);
+    $ck = $c->containsKey(3);
+    $ct = $c->contains($data[2]);
+    $f  = $c->filter(static fn (Item $v, int $k): bool => $v->v % 2 === 0);
+    $fr = $c->first();
+    $la = $c->last();
+    $sl = $c->slice(0, 10);
+    [$m, $n] = $c->partition(static fn (int $k, Item $v): bool => $v->v > 50);
+
+    $checksum += $c->count()
+        + ($g instanceof Item ? $g->v : 0)
+        + ($ck ? 1 : 0) + ($ct ? 1 : 0)
+        + $f->count()
+        + ($fr instanceof Item ? $fr->v : 0)
+        + ($la instanceof Item ? $la->v : 0)
+        + count($sl)
+        + $m->count() + $n->count();
+}
+
+printf("class=%s  iters=%d size=%d  (checksum=%d)\n", (new ArrayCollection())::class, $ITERS, $SIZE, $checksum);

--- a/bench/collbench_reified.php
+++ b/bench/collbench_reified.php
@@ -1,0 +1,53 @@
+<?php
+// Reified-branch workload: ArrayCollection<int, Item> — a CONCRETE monomorph so
+// the reified TKey/T checks actually fire on add/set/get/filter/etc.
+// Identical operations to collbench_baseline.php; only the `new ArrayCollection`
+// construction line differs (explicit ::<int, Item> args, no defaults).
+//
+//   php bench/collbench_reified.php [ITERS] [SIZE]
+declare(strict_types=1);
+require getenv('BENCH_AUTOLOAD') ?: __DIR__ . '/../vendor/autoload.php';
+
+use Doctrine\Common\Collections\ArrayCollection;
+
+final class Item
+{
+    public function __construct(public int $v)
+    {
+    }
+}
+
+$ITERS = (int) ($argv[1] ?? 2000);
+$SIZE  = (int) ($argv[2] ?? 500);
+
+/** @var array<int, Item> $data */
+$data = [];
+for ($i = 0; $i < $SIZE; $i++) {
+    $data[$i] = new Item(($i * 7) % 101);
+}
+
+$checksum = 0;
+for ($it = 0; $it < $ITERS; $it++) {
+    $c = new ArrayCollection::<int, Item>($data);   // <-- only line that differs from baseline
+    $c->add(new Item($it % 13));
+    $c->set(0, new Item(1));
+    $g  = $c->get(5);
+    $ck = $c->containsKey(3);
+    $ct = $c->contains($data[2]);
+    $f  = $c->filter(static fn (Item $v, int $k): bool => $v->v % 2 === 0);
+    $fr = $c->first();
+    $la = $c->last();
+    $sl = $c->slice(0, 10);
+    [$m, $n] = $c->partition(static fn (int $k, Item $v): bool => $v->v > 50);
+
+    $checksum += $c->count()
+        + ($g instanceof Item ? $g->v : 0)
+        + ($ck ? 1 : 0) + ($ct ? 1 : 0)
+        + $f->count()
+        + ($fr instanceof Item ? $fr->v : 0)
+        + ($la instanceof Item ? $la->v : 0)
+        + count($sl)
+        + $m->count() + $n->count();
+}
+
+printf("class=%s  iters=%d size=%d  (checksum=%d)\n", (new ArrayCollection::<int, Item>())::class, $ITERS, $SIZE, $checksum);

--- a/bench/perfbench.sh
+++ b/bench/perfbench.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Instruction-count comparison: bench/baseline (plain Collections) vs
+# bench/reified (native reified generics, no defaults, concrete <int,Item>
+# monomorph). Same fork binary; via perf_event_open (bench/perfcount).
+#
+# Because reified has NO defaults, construction syntax differs per branch, so
+# each branch runs its OWN workload file (identical operations, only the
+# `new ArrayCollection` line differs). Workloads are pinned to /tmp so they
+# survive `git checkout`.
+#
+#   gcc -O2 -o bench/perfcount bench/perfcount.c
+#   [PHP=...] [OPCACHE=on|off] [ITERS=] [SIZE=] [N=] bench/perfbench.sh
+set -uo pipefail
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PHP="${PHP:-/home/withinboredom/code/php-src/sapi/cli/php}"
+PC="$REPO/bench/perfcount"
+ITERS="${ITERS:-2000}"; SIZE="${SIZE:-500}"; N="${N:-5}"
+cd "$REPO" || exit 1
+[ -x "$PC" ] || { echo "build first: gcc -O2 -o bench/perfcount bench/perfcount.c" >&2; exit 1; }
+
+case "${OPCACHE:-on}" in
+  off) FLAGS=(-d opcache.enable_cli=0); OPMODE="opcache OFF" ;;
+  *)   FLAGS=(-d opcache.enable_cli=1 -d opcache.jit=disable -d opcache.jit_buffer_size=0 -d opcache.validate_timestamps=1); OPMODE="opcache ON" ;;
+esac
+
+# Pin workloads outside the repo so branch switches can't delete them.
+cp "$REPO/bench/collbench_baseline.php" /tmp/.cb_baseline.php
+cp "$REPO/bench/collbench_reified.php"  /tmp/.cb_reified.php
+export BENCH_AUTOLOAD="$REPO/vendor/autoload.php"
+
+median() { sort -n | awk '{a[NR]=$1} END{print a[int((NR+1)/2)]}'; }
+
+echo "### $OPMODE | ITERS=$ITERS SIZE=$SIZE | N=$N runs/branch" >&2
+declare -A INS CHK
+for spec in "baseline:bench/baseline:/tmp/.cb_baseline.php" "reified:bench/reified:/tmp/.cb_reified.php"; do
+  label="${spec%%:*}"; rest="${spec#*:}"; ref="${rest%%:*}"; work="${rest#*:}"
+  git checkout -q "$ref" || { echo "checkout $ref failed" >&2; exit 1; }
+  "$PHP" "${FLAGS[@]}" -r 'opcache_reset();' >/dev/null 2>&1 || true
+  "$PHP" "${FLAGS[@]}" "$work" "$ITERS" "$SIZE" >/dev/null 2>&1   # prime
+  echo "=== $label ($(git rev-parse --short HEAD)) ===" >&2
+  ins_list=()
+  for i in $(seq 1 "$N"); do
+    "$PC" "$PHP" "${FLAGS[@]}" "$work" "$ITERS" "$SIZE" >/tmp/.pcout 2>/tmp/.pcerr
+    ins="$(grep -oE 'instructions=[0-9]+' /tmp/.pcerr | cut -d= -f2)"
+    ins_list+=("$ins"); echo "  run $i: instructions=$ins" >&2
+  done
+  CHK["$label"]="$(grep -oE 'checksum=[0-9]+' /tmp/.pcout | cut -d= -f2)"
+  INS["$label"]="$(printf '%s\n' "${ins_list[@]}" | median)"
+done
+git checkout -q bench/reified
+
+echo "============================================================"
+b="${INS[baseline]}"; r="${INS[reified]}"
+echo "checksum baseline=${CHK[baseline]}  reified=${CHK[reified]}  $([ "${CHK[baseline]}" = "${CHK[reified]}" ] && echo MATCH || echo MISMATCH!!)"
+awk -v b="$b" -v r="$r" 'BEGIN{ printf "median instructions  baseline=%d  reified=%d  delta=%+.3f%%\n", b, r, (r-b)/b*100 }'
+echo "($OPMODE; restored to bench/reified)"

--- a/bench/perfcount.c
+++ b/bench/perfcount.c
@@ -1,0 +1,90 @@
+// Minimal perf_event_open wrapper: counts userspace HW events for a child process.
+// No `perf` binary and no root needed when /proc/sys/kernel/perf_event_paranoid <= 2
+// (we set exclude_kernel). Works on WSL2 when the guest exposes the PMU
+// (check: ls /sys/devices/cpu/events should list `instructions`, `cycles`, ...).
+//
+//   gcc -O2 -o bench/perfcount bench/perfcount.c
+//   bench/perfcount <cmd> [args...]
+//
+// Prints one line to stderr:
+//   PERF instructions=<n> cycles=<n> branch-misses=<n> cache-misses=<n>
+//
+// Instruction counts are frequency-independent, so they're stable on battery,
+// under load, and across machines -- far better than wall-clock for resolving
+// a sub-percent engine cost.
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+#include <errno.h>
+#include <sys/wait.h>
+#include <sys/ioctl.h>
+#include <linux/perf_event.h>
+#include <asm/unistd.h>
+
+static long perf_open(struct perf_event_attr *a, pid_t pid) {
+    return syscall(__NR_perf_event_open, a, pid, -1, -1, 0);
+}
+
+static int mkcounter(unsigned type, unsigned long long config, pid_t pid) {
+    struct perf_event_attr a;
+    memset(&a, 0, sizeof(a));
+    a.type = type;
+    a.size = sizeof(a);
+    a.config = config;
+    a.disabled = 1;            // start off...
+    a.enable_on_exec = 1;      // ...auto-enable when the child execs
+    a.exclude_kernel = 1;      // userspace only (allowed at paranoid=2)
+    a.exclude_hv = 1;
+    a.inherit = 1;             // follow into the exec'd image
+    int fd = (int) perf_open(&a, pid);
+    if (fd < 0) fprintf(stderr, "perf_open(type=%u,config=%llu) failed: %s\n", type, config, strerror(errno));
+    return fd;
+}
+
+static long long readval(int fd) {
+    long long v = -1;
+    if (fd >= 0 && read(fd, &v, sizeof(v)) != sizeof(v)) v = -1;
+    return v;
+}
+
+int main(int argc, char **argv) {
+    if (argc < 2) { fprintf(stderr, "usage: %s <cmd> [args...]\n", argv[0]); return 2; }
+
+    int pfd[2];
+    if (pipe(pfd) != 0) { perror("pipe"); return 3; }
+
+    pid_t pid = fork();
+    if (pid < 0) { perror("fork"); return 3; }
+
+    if (pid == 0) {
+        // child: wait for parent to arm counters, then exec
+        close(pfd[1]);
+        char b; if (read(pfd[0], &b, 1) < 0) _exit(126);
+        close(pfd[0]);
+        execvp(argv[1], &argv[1]);
+        perror("execvp");
+        _exit(127);
+    }
+
+    // parent: arm counters against the (still-blocked) child
+    close(pfd[0]);
+    int f_ins = mkcounter(PERF_TYPE_HARDWARE, PERF_COUNT_HW_INSTRUCTIONS,  pid);
+    int f_cyc = mkcounter(PERF_TYPE_HARDWARE, PERF_COUNT_HW_CPU_CYCLES,    pid);
+    int f_brm = mkcounter(PERF_TYPE_HARDWARE, PERF_COUNT_HW_BRANCH_MISSES, pid);
+    int f_chm = mkcounter(PERF_TYPE_HARDWARE, PERF_COUNT_HW_CACHE_MISSES,  pid);
+
+    // release the child
+    char go = 1; if (write(pfd[1], &go, 1) < 0) { /* child will EOF and exit */ }
+    close(pfd[1]);
+
+    int status = 0;
+    waitpid(pid, &status, 0);
+
+    fprintf(stderr, "PERF instructions=%lld cycles=%lld branch-misses=%lld cache-misses=%lld\n",
+            readval(f_ins), readval(f_cyc), readval(f_brm), readval(f_chm));
+
+    if (WIFEXITED(status)) return WEXITSTATUS(status);
+    return 1;
+}

--- a/src/AbstractLazyCollection.php
+++ b/src/AbstractLazyCollection.php
@@ -17,14 +17,14 @@ use Traversable;
  * @template-implements Collection<TKey,T>
  * @template-implements Selectable<TKey,T>
  */
-abstract class AbstractLazyCollection implements Collection, Selectable
+abstract class AbstractLazyCollection<TKey, T> implements Collection<TKey, T>, Selectable<TKey, T>
 {
     /**
      * The backed collection to use
      *
      * @var Collection<TKey,T>|null
      */
-    protected Collection|null $collection;
+    protected Collection<TKey, T>|null $collection;
 
     protected bool $initialized = false;
 
@@ -37,7 +37,7 @@ abstract class AbstractLazyCollection implements Collection, Selectable
     }
 
     #[Override]
-    public function add(mixed $element): void
+    public function add(T $element): void
     {
         $this->initialize();
 
@@ -68,7 +68,7 @@ abstract class AbstractLazyCollection implements Collection, Selectable
     }
 
     #[Override]
-    public function remove(string|int $key): mixed
+    public function remove(TKey $key): T|null
     {
         $this->initialize();
 
@@ -76,7 +76,7 @@ abstract class AbstractLazyCollection implements Collection, Selectable
     }
 
     #[Override]
-    public function removeElement(mixed $element): bool
+    public function removeElement(T $element): bool
     {
         $this->initialize();
 
@@ -84,7 +84,7 @@ abstract class AbstractLazyCollection implements Collection, Selectable
     }
 
     #[Override]
-    public function containsKey(string|int $key): bool
+    public function containsKey(TKey $key): bool
     {
         $this->initialize();
 
@@ -92,7 +92,7 @@ abstract class AbstractLazyCollection implements Collection, Selectable
     }
 
     #[Override]
-    public function get(string|int $key): mixed
+    public function get(TKey $key): T|null
     {
         $this->initialize();
 
@@ -116,7 +116,7 @@ abstract class AbstractLazyCollection implements Collection, Selectable
     }
 
     #[Override]
-    public function set(string|int $key, mixed $value): void
+    public function set(TKey $key, T $value): void
     {
         $this->initialize();
         $this->collection->set($key, $value);
@@ -131,7 +131,7 @@ abstract class AbstractLazyCollection implements Collection, Selectable
     }
 
     #[Override]
-    public function first(): mixed
+    public function first(): T|false
     {
         $this->initialize();
 
@@ -139,7 +139,7 @@ abstract class AbstractLazyCollection implements Collection, Selectable
     }
 
     #[Override]
-    public function last(): mixed
+    public function last(): T|false
     {
         $this->initialize();
 
@@ -147,7 +147,7 @@ abstract class AbstractLazyCollection implements Collection, Selectable
     }
 
     #[Override]
-    public function key(): string|int|null
+    public function key(): TKey|null
     {
         $this->initialize();
 
@@ -155,7 +155,7 @@ abstract class AbstractLazyCollection implements Collection, Selectable
     }
 
     #[Override]
-    public function current(): mixed
+    public function current(): T|false
     {
         $this->initialize();
 
@@ -163,7 +163,7 @@ abstract class AbstractLazyCollection implements Collection, Selectable
     }
 
     #[Override]
-    public function next(): mixed
+    public function next(): T|false
     {
         $this->initialize();
 
@@ -179,7 +179,7 @@ abstract class AbstractLazyCollection implements Collection, Selectable
     }
 
     #[Override]
-    public function findFirst(Closure $p): mixed
+    public function findFirst(Closure $p): T|null
     {
         $this->initialize();
 
@@ -187,7 +187,7 @@ abstract class AbstractLazyCollection implements Collection, Selectable
     }
 
     #[Override]
-    public function filter(Closure $p): Collection
+    public function filter(Closure $p): Collection<TKey, T>
     {
         $this->initialize();
 
@@ -203,7 +203,7 @@ abstract class AbstractLazyCollection implements Collection, Selectable
     }
 
     #[Override]
-    public function map(Closure $func): Collection
+    public function map<U>(Closure $func): Collection<TKey, U>
     {
         $this->initialize();
 
@@ -327,7 +327,7 @@ abstract class AbstractLazyCollection implements Collection, Selectable
     abstract protected function doInitialize(): void;
 
     #[Override]
-    public function matching(Criteria $criteria): ReadableCollection
+    public function matching(Criteria $criteria): ReadableCollection<TKey, T>
     {
         $this->initialize();
 

--- a/src/ArrayCollection.php
+++ b/src/ArrayCollection.php
@@ -50,7 +50,7 @@ use const ARRAY_FILTER_USE_BOTH;
  * @template-implements Selectable<TKey,T>
  * @phpstan-consistent-constructor
  */
-class ArrayCollection implements Collection, Selectable, Stringable
+class ArrayCollection<TKey, T> implements Collection<TKey, T>, Selectable<TKey, T>, Stringable
 {
     /**
      * An array containing the entries of this collection.
@@ -77,7 +77,7 @@ class ArrayCollection implements Collection, Selectable, Stringable
     }
 
     #[Override]
-    public function first(): mixed
+    public function first(): T|false
     {
         return reset($this->elements);
     }
@@ -102,31 +102,31 @@ class ArrayCollection implements Collection, Selectable, Stringable
     }
 
     #[Override]
-    public function last(): mixed
+    public function last(): T|false
     {
         return end($this->elements);
     }
 
     #[Override]
-    public function key(): int|string|null
+    public function key(): TKey|null
     {
         return key($this->elements);
     }
 
     #[Override]
-    public function next(): mixed
+    public function next(): T|false
     {
         return next($this->elements);
     }
 
     #[Override]
-    public function current(): mixed
+    public function current(): T|false
     {
         return current($this->elements);
     }
 
     #[Override]
-    public function remove(string|int $key): mixed
+    public function remove(TKey $key): T|null
     {
         if (! isset($this->elements[$key]) && ! array_key_exists($key, $this->elements)) {
             return null;
@@ -139,7 +139,7 @@ class ArrayCollection implements Collection, Selectable, Stringable
     }
 
     #[Override]
-    public function removeElement(mixed $element): bool
+    public function removeElement(T $element): bool
     {
         $key = array_search($element, $this->elements, true);
 
@@ -205,7 +205,7 @@ class ArrayCollection implements Collection, Selectable, Stringable
     }
 
     #[Override]
-    public function containsKey(string|int $key): bool
+    public function containsKey(TKey $key): bool
     {
         return isset($this->elements[$key]) || array_key_exists($key, $this->elements);
     }
@@ -239,7 +239,7 @@ class ArrayCollection implements Collection, Selectable, Stringable
     }
 
     #[Override]
-    public function get(string|int $key): mixed
+    public function get(TKey $key): T|null
     {
         return $this->elements[$key] ?? null;
     }
@@ -264,7 +264,7 @@ class ArrayCollection implements Collection, Selectable, Stringable
     }
 
     #[Override]
-    public function set(string|int $key, mixed $value): void
+    public function set(TKey $key, T $value): void
     {
         $this->elements[$key] = $value;
     }
@@ -274,7 +274,7 @@ class ArrayCollection implements Collection, Selectable, Stringable
      * be a backwards-incompatible change to remove this method
      */
     #[Override]
-    public function add(mixed $element): void
+    public function add(T $element): void
     {
         $this->elements[] = $element;
     }
@@ -304,7 +304,7 @@ class ArrayCollection implements Collection, Selectable, Stringable
      * @phpstan-template U
      */
     #[Override]
-    public function map(Closure $func): Collection
+    public function map<U>(Closure $func): Collection<TKey, U>
     {
         return $this->createFrom(array_map($func, $this->elements));
     }
@@ -322,13 +322,13 @@ class ArrayCollection implements Collection, Selectable, Stringable
      * @phpstan-return static<TKey,T>
      */
     #[Override]
-    public function filter(Closure $p): Collection
+    public function filter(Closure $p): Collection<TKey, T>
     {
         return $this->createFrom(array_filter($this->elements, $p, ARRAY_FILTER_USE_BOTH));
     }
 
     #[Override]
-    public function findFirst(Closure $p): mixed
+    public function findFirst(Closure $p): T|null
     {
         return array_find(
             $this->elements,
@@ -384,7 +384,7 @@ class ArrayCollection implements Collection, Selectable, Stringable
 
     /** @phpstan-return Collection<TKey, T>&Selectable<TKey,T> */
     #[Override]
-    public function matching(Criteria $criteria): Collection
+    public function matching(Criteria $criteria): Collection<TKey, T>
     {
         $expr     = $criteria->getWhereExpression();
         $filtered = $this->elements;

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -30,7 +30,7 @@ use Override;
  * @template-extends ReadableCollection<TKey, T>
  * @template-extends ArrayAccess<TKey, T>
  */
-interface Collection extends ReadableCollection, ArrayAccess
+interface Collection<TKey, T> extends ReadableCollection<TKey, T>, ArrayAccess
 {
     /**
      * Adds an element at the end of the collection.
@@ -38,7 +38,7 @@ interface Collection extends ReadableCollection, ArrayAccess
      * @param mixed $element The element to add.
      * @phpstan-param T $element
      */
-    public function add(mixed $element): void;
+    public function add(T $element): void;
 
     /**
      * Clears the collection, removing all elements.
@@ -54,7 +54,7 @@ interface Collection extends ReadableCollection, ArrayAccess
      * @return mixed The removed element or NULL, if the collection did not contain the element.
      * @phpstan-return T|null
      */
-    public function remove(string|int $key): mixed;
+    public function remove(TKey $key): T|null;
 
     /**
      * Removes the specified element from the collection, if it is found.
@@ -64,7 +64,7 @@ interface Collection extends ReadableCollection, ArrayAccess
      *
      * @return bool TRUE if this collection contained the specified element, FALSE otherwise.
      */
-    public function removeElement(mixed $element): bool;
+    public function removeElement(T $element): bool;
 
     /**
      * Sets an element in the collection at the specified key/index.
@@ -74,7 +74,7 @@ interface Collection extends ReadableCollection, ArrayAccess
      * @phpstan-param TKey $key
      * @phpstan-param T $value
      */
-    public function set(string|int $key, mixed $value): void;
+    public function set(TKey $key, T $value): void;
 
     /**
      * @phpstan-param Closure(T):U $func
@@ -85,7 +85,7 @@ interface Collection extends ReadableCollection, ArrayAccess
      * @phpstan-template U
      */
     #[Override]
-    public function map(Closure $func): self;
+    public function map<U>(Closure $func): self<TKey, U>;
 
     /**
      * @phpstan-param Closure(T, TKey):bool $p
@@ -94,7 +94,7 @@ interface Collection extends ReadableCollection, ArrayAccess
      * @phpstan-return Collection<TKey, T>
      */
     #[Override]
-    public function filter(Closure $p): self;
+    public function filter(Closure $p): self<TKey, T>;
 
     /**
      * @phpstan-param Closure(TKey, T):bool $p

--- a/src/ReadableCollection.php
+++ b/src/ReadableCollection.php
@@ -14,7 +14,7 @@ use IteratorAggregate;
  * @template-extends IteratorAggregate<TKey, T>
  * @template-extends Selectable<TKey, T>
  */
-interface ReadableCollection extends Countable, IteratorAggregate, Selectable
+interface ReadableCollection<TKey, T> extends Countable, IteratorAggregate, Selectable<TKey, T>
 {
     /**
      * Checks whether an element is contained in the collection.
@@ -46,7 +46,7 @@ interface ReadableCollection extends Countable, IteratorAggregate, Selectable
      * @return bool TRUE if the collection contains an element with the specified key/index,
      *              FALSE otherwise.
      */
-    public function containsKey(string|int $key): bool;
+    public function containsKey(TKey $key): bool;
 
     /**
      * Gets the element at the specified key/index.
@@ -56,7 +56,7 @@ interface ReadableCollection extends Countable, IteratorAggregate, Selectable
      *
      * @phpstan-return T|null
      */
-    public function get(string|int $key): mixed;
+    public function get(TKey $key): T|null;
 
     /**
      * Gets all keys/indices of the collection.
@@ -89,35 +89,35 @@ interface ReadableCollection extends Countable, IteratorAggregate, Selectable
      *
      * @phpstan-return T|false
      */
-    public function first(): mixed;
+    public function first(): T|false;
 
     /**
      * Sets the internal iterator to the last element in the collection and returns this element.
      *
      * @phpstan-return T|false
      */
-    public function last(): mixed;
+    public function last(): T|false;
 
     /**
      * Gets the key/index of the element at the current iterator position.
      *
      * @phpstan-return TKey|null
      */
-    public function key(): int|string|null;
+    public function key(): TKey|null;
 
     /**
      * Gets the element of the collection at the current iterator position.
      *
      * @phpstan-return T|false
      */
-    public function current(): mixed;
+    public function current(): T|false;
 
     /**
      * Moves the internal iterator position to the next element and returns this element.
      *
      * @phpstan-return T|false
      */
-    public function next(): mixed;
+    public function next(): T|false;
 
     /**
      * Extracts a slice of $length elements starting at position $offset from the Collection.
@@ -154,7 +154,7 @@ interface ReadableCollection extends Countable, IteratorAggregate, Selectable
      * @return ReadableCollection<mixed> A collection with the results of the filter operation.
      * @phpstan-return ReadableCollection<TKey, T>
      */
-    public function filter(Closure $p): self;
+    public function filter(Closure $p): self<TKey, T>;
 
     /**
      * Applies the given function to each element in the collection and returns
@@ -167,7 +167,7 @@ interface ReadableCollection extends Countable, IteratorAggregate, Selectable
      *
      * @phpstan-template U
      */
-    public function map(Closure $func): self;
+    public function map<U>(Closure $func): self<TKey, U>;
 
     /**
      * Partitions this collection in two collections according to a predicate.
@@ -218,7 +218,7 @@ interface ReadableCollection extends Countable, IteratorAggregate, Selectable
      *               null if no element respects the predicate.
      * @phpstan-return T|null
      */
-    public function findFirst(Closure $p): mixed;
+    public function findFirst(Closure $p): T|null;
 
     /**
      * Applies iteratively the given function to each element in the collection,

--- a/src/Selectable.php
+++ b/src/Selectable.php
@@ -19,7 +19,7 @@ namespace Doctrine\Common\Collections;
  * @phpstan-template TKey as array-key
  * @phpstan-template-covariant T
  */
-interface Selectable
+interface Selectable<TKey, T>
 {
     /**
      * Selects all elements from a selectable that match the expression and
@@ -28,5 +28,5 @@ interface Selectable
      * @return ReadableCollection<mixed>&Selectable<mixed>
      * @phpstan-return ReadableCollection<TKey,T>&Selectable<TKey,T>
      */
-    public function matching(Criteria $criteria): ReadableCollection;
+    public function matching(Criteria $criteria): ReadableCollection<TKey, T>;
 }

--- a/tests/AbstractLazyArrayCollectionTest.php
+++ b/tests/AbstractLazyArrayCollectionTest.php
@@ -21,7 +21,7 @@ class AbstractLazyArrayCollectionTest extends ArrayCollectionTestCase
     #[Override]
     protected function buildCollection(array $elements = []): Collection
     {
-        return new LazyArrayCollection(new ArrayCollection($elements));
+        return new LazyArrayCollection(new ArrayCollection::<int|string, int|float|string|bool|array|object|null>($elements));
     }
 
     public function testLazyCollection(): void

--- a/tests/AbstractLazyCollectionTest.php
+++ b/tests/AbstractLazyCollectionTest.php
@@ -24,13 +24,13 @@ class AbstractLazyCollectionTest extends CollectionTestCase
 {
     protected function setUp(): void
     {
-        $this->collection = new LazyArrayCollection(new ArrayCollection());
+        $this->collection = new LazyArrayCollection(new ArrayCollection::<int|string, int|float|string|bool|array|object|null>());
     }
 
     /** @phpstan-param mixed[] $elements */
     private function buildCollection(array $elements): LazyArrayCollection
     {
-        return new LazyArrayCollection(new ArrayCollection($elements));
+        return new LazyArrayCollection(new ArrayCollection::<int|string, int|float|string|bool|array|object|null>($elements));
     }
 
     public function testClearInitializes(): void

--- a/tests/ArrayCollectionTest.php
+++ b/tests/ArrayCollectionTest.php
@@ -21,7 +21,7 @@ class ArrayCollectionTest extends ArrayCollectionTestCase
     #[Override]
     protected function buildCollection(array $elements = []): Collection
     {
-        return new ArrayCollection($elements);
+        return new ArrayCollection::<int|string, int|float|string|bool|array|object|null>($elements);
     }
 
     public function testUnserializeEmptyArrayCollection(): void
@@ -40,7 +40,7 @@ class ArrayCollectionTest extends ArrayCollectionTestCase
  * @template TValue
  * @extends ArrayCollection<TKey, TValue>
  */
-class SerializableArrayCollection extends ArrayCollection
+class SerializableArrayCollection extends ArrayCollection<int|string, int|float|string|bool|array|object|null>
 {
     /** @return array<TKey, TValue> */
     public function __serialize(): array

--- a/tests/CollectionTest.php
+++ b/tests/CollectionTest.php
@@ -22,7 +22,7 @@ class CollectionTest extends CollectionTestCase
 
     protected function setUp(): void
     {
-        $this->collection = new ArrayCollection();
+        $this->collection = new ArrayCollection::<int|string, int|float|string|bool|array|object|null>();
     }
 
     public function testToString(): void

--- a/tests/DerivedArrayCollection.php
+++ b/tests/DerivedArrayCollection.php
@@ -10,7 +10,7 @@ use stdClass;
 /**
  * Simple collection implements different constructor semantics.
  */
-final class DerivedArrayCollection extends ArrayCollection
+final class DerivedArrayCollection extends ArrayCollection<int|string, int|float|string|bool|array|object|null>
 {
     /** @param mixed[] $elements */
     public function __construct(private readonly stdClass $foo, array $elements = [])

--- a/tests/LazyArrayCollection.php
+++ b/tests/LazyArrayCollection.php
@@ -10,7 +10,7 @@ use Doctrine\Common\Collections\Collection;
 /**
  * Simple lazy collection that used an ArrayCollection as backed collection.
  */
-class LazyArrayCollection extends AbstractLazyCollection
+class LazyArrayCollection extends AbstractLazyCollection<int|string, int|float|string|bool|array|object|null>
 {
     /** @param Collection<mixed> $collectionOnInitialization Apply the collection only in method doInitialize */
     public function __construct(


### PR DESCRIPTION
This is an LLM generated port for our reified generics RFC (similar to the Laravel one) for benchmarking the impact to real code in CI/CD pipelines.

Execution costs an additional +0.08% without OPcache jit and +23.6% with opcache jit -- we have not yet taught the jit how generics work.

Feel free to close this PR, but a generic review would be nice if we mis-represented the types.

PHP branch here: https://github.com/php/php-src/compare/master...bottledcode:php-src:reify