### PR TITLE
Refine return type annotation in Selectable interface for improved type hints for IDE

### DIFF
--- a/src/Selectable.php
+++ b/src/Selectable.php
@@ -25,8 +25,7 @@ interface Selectable
      * Selects all elements from a selectable that match the expression and
      * returns a new collection containing these elements and preserved keys.
      *
-     * @return ReadableCollection<mixed>&Selectable<mixed>
-     * @phpstan-return ReadableCollection<TKey,T>&Selectable<TKey,T>
+     * @return ReadableCollection<TKey,T>
      */
     public function matching(Criteria $criteria): ReadableCollection;
 }


### PR DESCRIPTION
Hello!
This PR fixes the @return annotation of Selectable::matching() to properly propagate generic types (TKey, T) instead of falling back to mixed.

While static analysis tools like PHPStan or Psalm successfully read @phpstan-return and resolve the generics, most IDEs (including PhpStorm and editors using Intelephense) prioritize the standard @return tag.

Also ReadableCollection interface already implements Selectable #314, so no need to set it additionally