### PR TITLE
fix: use value equality for sortByField tie detection

### DIFF
--- a/src/Expr/ClosureExpressionVisitor.php
+++ b/src/Expr/ClosureExpressionVisitor.php
@@ -170,11 +170,13 @@ class ClosureExpressionVisitor extends ExpressionVisitor
             $aValue = ClosureExpressionVisitor::getObjectFieldValue($a, $name, $accessRawFieldValues);
             $bValue = ClosureExpressionVisitor::getObjectFieldValue($b, $name, $accessRawFieldValues);
 
-            if ($aValue === $bValue) {
+            $comparison = $aValue <=> $bValue;
+
+            if ($comparison === 0) {
                 return $next($a, $b);
             }
 
-            return ($aValue > $bValue ? 1 : -1) * $orientation;
+            return $comparison * $orientation;
         };
     }
 

--- a/tests/ClosureExpressionVisitorTest.php
+++ b/tests/ClosureExpressionVisitorTest.php
@@ -6,6 +6,7 @@ namespace Doctrine\Tests\Common\Collections;
 
 use ArrayAccess;
 use ArrayIterator;
+use DateTimeImmutable;
 use Doctrine\Common\Collections\Expr\ClosureExpressionVisitor;
 use Doctrine\Common\Collections\Expr\Comparison;
 use Doctrine\Common\Collections\Expr\CompositeExpression;
@@ -485,6 +486,51 @@ class ClosureExpressionVisitorTest extends TestCase
         self::assertEquals('a', $objects[0]->getBar());
         self::assertEquals('b', $objects[1]->getBar());
         self::assertEquals('c', $objects[2]->getBar());
+    }
+
+    public function testSortDelegateWithEqualButNotIdenticalObjectPrimaryField(): void
+    {
+        // Value-equal but not identical primary values must still fall through to
+        // the secondary field.
+        $sameInstant = static fn (): DateTimeImmutable => new DateTimeImmutable('2024-12-10 16:04:11');
+
+        $objects = [
+            new TestObject($sameInstant(), 5),
+            new TestObject($sameInstant(), 6),
+        ];
+
+        self::assertNotSame($objects[0]->getFoo(), $objects[1]->getFoo());
+        self::assertEquals($objects[0]->getFoo(), $objects[1]->getFoo());
+
+        $sort = ClosureExpressionVisitor::sortByField('bar', -1, null, true);
+        $sort = ClosureExpressionVisitor::sortByField('foo', -1, $sort, true);
+
+        usort($objects, $sort);
+
+        self::assertEquals(6, $objects[0]->getBar());
+        self::assertEquals(5, $objects[1]->getBar());
+    }
+
+    public function testSortByFieldComparatorIsAntisymmetricForEqualButNotIdenticalObjects(): void
+    {
+        // Swapping the input order of two value-equal elements must not change
+        // which one sorts first.
+        $sameInstant = static fn (): DateTimeImmutable => new DateTimeImmutable('2024-12-10 16:04:11');
+
+        $element5 = new TestObject($sameInstant(), 5);
+        $element6 = new TestObject($sameInstant(), 6);
+
+        $sort = ClosureExpressionVisitor::sortByField('bar', -1, null, true);
+        $sort = ClosureExpressionVisitor::sortByField('foo', -1, $sort, true);
+
+        $orderedFromAscendingInput = [$element5, $element6];
+        usort($orderedFromAscendingInput, $sort);
+
+        $orderedFromDescendingInput = [$element6, $element5];
+        usort($orderedFromDescendingInput, $sort);
+
+        self::assertEquals(6, $orderedFromAscendingInput[0]->getBar());
+        self::assertEquals(6, $orderedFromDescendingInput[0]->getBar());
     }
 
     public function testArrayComparison(): void


### PR DESCRIPTION
Fixes #437.

## Problem

`Criteria::orderBy()` with multiple fields silently drops every field after the
first whenever the first field's value is an object (e.g. `DateTimeImmutable`,
as in the issue's repro). Two records with the same `validFrom` but different
`id` are not ordered by `id` at all — and the resulting order depends on the
input order of the array being sorted, which a comparator should never do.

`mpdude` confirmed the same root cause on the issue and linked the duplicate
#136 and an earlier unmerged attempt (#454, which added an opt-in
`treatDateTimeAsScalar()` flag scoped to `DateTimeInterface` rather than fixing
the tie-detection itself).

## Root cause

In `sortByField()` the tie check uses `===` (identity), while the ordering
decision one line below uses `>` (value comparison):

```php
if ($aValue === $bValue) {   // identity
    return $next($a, $b);
}

return ($aValue > $bValue ? 1 : -1) * $orientation;   // value comparison
```

Two distinct `DateTimeImmutable` instances for the same instant are `==` but
never `===`, so the tie branch is never taken: `$next()` — the next `orderBy()`
field — is never consulted, and the expression below degrades to an arbitrary
`1`/`-1` for values that are in fact equal, which is not antisymmetric.

## Fix

Detect the tie with the same comparison that already decides the ordering:

```php
$comparison = $aValue <=> $bValue;

if ($comparison === 0) {
    return $next($a, $b);
}

return $comparison * $orientation;
```

`<=>` is built from the same `<` / `==` / `>` semantics the previous code
already relied on, so this is behaviour-preserving for every type it handled
before, and the comparator becomes antisymmetric by construction. Scope is
`sortByField()` plus the tests below; no public API change.

## Tests

Two cases added to `ClosureExpressionVisitorTest`: one asserting the secondary
field is consulted when the primary values are equal-but-not-identical, one
sorting the same pair from both possible input orderings and asserting the
result is identical. Both fail before the change and pass after it.

Reproduced through the public API as in the issue — before the fix the two
input orderings disagree (`6` vs `5`), after it they agree (`6` and `6`).

---

Targeted at `2.6.x` because `3.1.x` requires PHP ^8.4; the same code and bug are
present on both. Happy to retarget if you'd prefer it elsewhere.
